### PR TITLE
MODSOURCE-28 Renamed endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+## 2019-02-12 v1.2.0-SNAPSHOT
+* Changed project structure to contain server and client parts. Client builds as a lightweight java library.
+* Added a non-production endpoint to populate MARC records for testing purposes, which is available only in case "test.mode" environment variable is set to true.
+* Renamed entities sourceRecord -> rawRecord, result -> sourceRecord.
+* Updated sourceRecord to contain rawRecord as well as parsedRecord.
+* Renamed endpoints
+
+ | METHOD |             URL                            | DESCRIPTION                                             |
+ |--------|--------------------------------------------|---------------------------------------------------------|
+ | GET    | /source-storage/snapshots                  | Get list of snapshots                                   |
+ | POST   | /source-storage/snapshots                  | Create new snapshot                                     |
+ | UPDATE | /source-storage/snapshots/{jobExecutionId} | Update snapshot                                         |
+ | GET    | /source-storage/snapshots/{jobExecutionId} | Get snapshot by JobExecution id                         |
+ | DELETE | /source-storage/snapshots/{jobExecutionId} | Delete snapshot by JobExecution id                      |
+ | GET    | /source-storage/records                    | Get list of records                                     |
+ | POST   | /source-storage/records                    | Create new record                                       |
+ | UPDATE | /source-storage/records/{id}               | Update record                                           |
+ | GET    | /source-storage/records/{id}               | Get record by id                                        |
+ | DELETE | /source-storage/records/{id}               | Delete record by id                                     |
+ | GET    | /source-storage/sourceRecords              | Get list of source records                              |
+ | POST   | /source-storage/populate-test-marc-records | Fill db with test marc records                          |
+ 
+
 ## 2018-11-29 v1.0.0
 * Created API for managing Snapshot, Record and Result entities
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,62 +5,62 @@
   "provides": [
     {
       "id": "source-record-storage",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],
-          "pathPattern": "/source-storage/snapshot",
-          "permissionsRequired": ["source-storage.snapshot.get"]
+          "pathPattern": "/source-storage/snapshots",
+          "permissionsRequired": ["source-storage.snapshots.get"]
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/source-storage/snapshot",
-          "permissionsRequired": ["source-storage.snapshot.post"]
+          "pathPattern": "/source-storage/snapshots",
+          "permissionsRequired": ["source-storage.snapshots.post"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/source-storage/snapshot/{jobExecutionId}",
-          "permissionsRequired": ["source-storage.snapshot.get"]
+          "pathPattern": "/source-storage/snapshots/{jobExecutionId}",
+          "permissionsRequired": ["source-storage.snapshots.get"]
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/source-storage/snapshot/{jobExecutionId}",
-          "permissionsRequired": ["source-storage.snapshot.put"]
+          "pathPattern": "/source-storage/snapshots/{jobExecutionId}",
+          "permissionsRequired": ["source-storage.snapshots.put"]
         },
         {
           "methods": ["DELETE"],
-          "pathPattern": "/source-storage/snapshot/{jobExecutionId}",
-          "permissionsRequired": ["source-storage.snapshot.delete"]
+          "pathPattern": "/source-storage/snapshots/{jobExecutionId}",
+          "permissionsRequired": ["source-storage.snapshots.delete"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/source-storage/record",
-          "permissionsRequired": ["source-storage.record.get"]
+          "pathPattern": "/source-storage/records",
+          "permissionsRequired": ["source-storage.records.get"]
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/source-storage/record",
-          "permissionsRequired": ["source-storage.record.post"]
+          "pathPattern": "/source-storage/records",
+          "permissionsRequired": ["source-storage.records.post"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/source-storage/record/{id}",
-          "permissionsRequired": ["source-storage.record.get"]
+          "pathPattern": "/source-storage/records/{id}",
+          "permissionsRequired": ["source-storage.records.get"]
         },
         {
           "methods": ["PUT"],
-          "pathPattern": "/source-storage/record/{id}",
-          "permissionsRequired": ["source-storage.record.put"]
+          "pathPattern": "/source-storage/records/{id}",
+          "permissionsRequired": ["source-storage.records.put"]
         },
         {
           "methods": ["DELETE"],
-          "pathPattern": "/source-storage/record/{id}",
-          "permissionsRequired": ["source-storage.record.delete"]
+          "pathPattern": "/source-storage/records/{id}",
+          "permissionsRequired": ["source-storage.records.delete"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/source-storage/result",
-          "permissionsRequired": ["source-storage.result.get"]
+          "pathPattern": "/source-storage/sourceRecords",
+          "permissionsRequired": ["source-storage.sourceRecords.get"]
         },
         {
           "methods": ["POST"],
@@ -82,47 +82,47 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "source-storage.snapshot.get",
+      "permissionName": "source-storage.snapshots.get",
       "displayName": "Source Storage - get snapshot(s)",
       "description": "Get Snapshot(s)"
     },
     {
-      "permissionName": "source-storage.snapshot.post",
+      "permissionName": "source-storage.snapshots.post",
       "displayName": "Source Storage - create new snapshot",
       "description": "Post Snapshot"
     },
     {
-      "permissionName": "source-storage.snapshot.put",
+      "permissionName": "source-storage.snapshots.put",
       "displayName": "Source Storage - update snapshot",
       "description": "Put Snapshot"
     },
     {
-      "permissionName": "source-storage.snapshot.delete",
+      "permissionName": "source-storage.snapshots.delete",
       "displayName": "Source Storage - delete snapshot",
       "description": "Delete Snapshot"
     },
     {
-      "permissionName": "source-storage.record.get",
+      "permissionName": "source-storage.records.get",
       "displayName": "Source Storage - get record(s)",
       "description": "Get Record(s)"
     },
     {
-      "permissionName": "source-storage.record.post",
+      "permissionName": "source-storage.records.post",
       "displayName": "Source Storage - create new record",
       "description": "Post Record"
     },
     {
-      "permissionName": "source-storage.record.put",
+      "permissionName": "source-storage.records.put",
       "displayName": "Source Storage - update record",
       "description": "Put Record"
     },
     {
-      "permissionName": "source-storage.record.delete",
+      "permissionName": "source-storage.records.delete",
       "displayName": "Source Storage - delete record",
       "description": "Delete Record"
     },
     {
-      "permissionName": "source-storage.result.get",
+      "permissionName": "source-storage.sourceRecords.get",
       "displayName": "Source Storage - get results",
       "description": "Get Results"
     },
@@ -131,15 +131,15 @@
       "displayName": "Source Record Storage - all permissions",
       "description": "Entire set of permissions needed to manage snapshots and records",
       "subPermissions": [
-        "source-storage.snapshot.get",
-        "source-storage.snapshot.post",
-        "source-storage.snapshot.put",
-        "source-storage.snapshot.delete",
-        "source-storage.record.get",
-        "source-storage.record.post",
-        "source-storage.record.put",
-        "source-storage.record.delete",
-        "source-storage.result.get"
+        "source-storage.snapshots.get",
+        "source-storage.snapshots.post",
+        "source-storage.snapshots.put",
+        "source-storage.snapshots.delete",
+        "source-storage.records.get",
+        "source-storage.records.post",
+        "source-storage.records.put",
+        "source-storage.records.delete",
+        "source-storage.sourceRecords.get"
       ],
       "visible": false
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -3,8 +3,8 @@ package org.folio.dao;
 import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;
-import org.folio.rest.jaxrs.model.Result;
-import org.folio.rest.jaxrs.model.ResultCollection;
+import org.folio.rest.jaxrs.model.SourceRecord;
+import org.folio.rest.jaxrs.model.SourceRecordCollection;
 
 import java.util.Optional;
 
@@ -56,13 +56,13 @@ public interface RecordDao {
   Future<Boolean> deleteRecord(String id);
 
   /**
-   * Searches for {@link Result} in the db view
+   * Searches for {@link SourceRecord} in the db view
    *
    * @param query  query string to filter results based on matching criteria in fields
    * @param offset starting index in a list of results
    * @param limit  maximum number of results to return
-   * @return future with {@link ResultCollection}
+   * @return future with {@link SourceRecordCollection}
    */
-  Future<ResultCollection> getResults(String query, int offset, int limit);
+  Future<SourceRecordCollection> getSourceRecords(String query, int offset, int limit);
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageImpl.java
@@ -49,13 +49,13 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void getSourceStorageSnapshot(String query, int offset, int limit, String lang,
+  public void getSourceStorageSnapshots(String query, int offset, int limit, String lang,
                                        Map<String, String> okapiHeaders,
                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         snapshotService.getSnapshots(query, offset, limit)
-          .map(GetSourceStorageSnapshotResponse::respond200WithApplicationJson)
+          .map(GetSourceStorageSnapshotsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
@@ -67,13 +67,13 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void postSourceStorageSnapshot(String lang, Snapshot entity, Map<String, String> okapiHeaders,
+  public void postSourceStorageSnapshots(String lang, Snapshot entity, Map<String, String> okapiHeaders,
                                         Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         snapshotService.saveSnapshot(entity)
-          .map((Response) PostSourceStorageSnapshotResponse
-            .respond201WithApplicationJson(entity, PostSourceStorageSnapshotResponse.headersFor201()))
+          .map((Response) PostSourceStorageSnapshotsResponse
+            .respond201WithApplicationJson(entity, PostSourceStorageSnapshotsResponse.headersFor201()))
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
       } catch (Exception e) {
@@ -84,7 +84,7 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void getSourceStorageSnapshotByJobExecutionId(String jobExecutionId, Map<String, String> okapiHeaders,
+  public void getSourceStorageSnapshotsByJobExecutionId(String jobExecutionId, String lang, Map<String, String> okapiHeaders,
                                                        Handler<AsyncResult<Response>> asyncResultHandler,
                                                        Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -92,7 +92,7 @@ public class SourceStorageImpl implements SourceStorage {
         snapshotService.getSnapshotById(jobExecutionId)
           .map(optionalSnapshot -> optionalSnapshot.orElseThrow(() ->
             new NotFoundException(String.format(NOT_FOUND_MESSAGE, Snapshot.class.getSimpleName(), jobExecutionId))))
-          .map(GetSourceStorageSnapshotByJobExecutionIdResponse::respond200WithApplicationJson)
+          .map(GetSourceStorageSnapshotsByJobExecutionIdResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
@@ -104,7 +104,7 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void putSourceStorageSnapshotByJobExecutionId(String jobExecutionId, Snapshot entity,
+  public void putSourceStorageSnapshotsByJobExecutionId(String jobExecutionId, String lang, Snapshot entity,
                                                        Map<String, String> okapiHeaders,
                                                        Handler<AsyncResult<Response>> asyncResultHandler,
                                                        Context vertxContext) {
@@ -113,8 +113,8 @@ public class SourceStorageImpl implements SourceStorage {
         entity.setJobExecutionId(jobExecutionId);
         snapshotService.updateSnapshot(entity)
           .map(updated -> updated ?
-            PutSourceStorageSnapshotByJobExecutionIdResponse.respond200WithApplicationJson(entity) :
-            PutSourceStorageSnapshotByJobExecutionIdResponse.respond404WithTextPlain(
+            PutSourceStorageSnapshotsByJobExecutionIdResponse.respond200WithApplicationJson(entity) :
+            PutSourceStorageSnapshotsByJobExecutionIdResponse.respond404WithTextPlain(
               String.format(NOT_FOUND_MESSAGE, Snapshot.class.getSimpleName(), jobExecutionId))
           )
           .map(Response.class::cast)
@@ -128,16 +128,16 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void deleteSourceStorageSnapshotByJobExecutionId(String jobExecutionId, Map<String, String> okapiHeaders,
+  public void deleteSourceStorageSnapshotsByJobExecutionId(String jobExecutionId, String lang, Map<String, String> okapiHeaders,
                                                           Handler<AsyncResult<Response>> asyncResultHandler,
                                                           Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         snapshotService.deleteSnapshot(jobExecutionId)
           .map(deleted -> deleted ?
-            DeleteSourceStorageSnapshotByJobExecutionIdResponse.respond204WithTextPlain(
+            DeleteSourceStorageSnapshotsByJobExecutionIdResponse.respond204WithTextPlain(
               String.format("Snapshot with id '%s' was successfully deleted", jobExecutionId)) :
-            DeleteSourceStorageSnapshotByJobExecutionIdResponse.respond404WithTextPlain(
+            DeleteSourceStorageSnapshotsByJobExecutionIdResponse.respond404WithTextPlain(
               String.format(NOT_FOUND_MESSAGE, Snapshot.class.getSimpleName(), jobExecutionId)))
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -150,12 +150,12 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void getSourceStorageRecord(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
+  public void getSourceStorageRecords(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         recordService.getRecords(query, offset, limit)
-          .map(GetSourceStorageRecordResponse::respond200WithApplicationJson)
+          .map(GetSourceStorageRecordsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
@@ -167,13 +167,13 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void postSourceStorageRecord(String lang, Record entity, Map<String, String> okapiHeaders,
+  public void postSourceStorageRecords(String lang, Record entity, Map<String, String> okapiHeaders,
                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         recordService.saveRecord(entity)
-          .map((Response) PostSourceStorageRecordResponse
-            .respond201WithApplicationJson(entity, PostSourceStorageRecordResponse.headersFor201()))
+          .map((Response) PostSourceStorageRecordsResponse
+            .respond201WithApplicationJson(entity, PostSourceStorageRecordsResponse.headersFor201()))
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
       } catch (Exception e) {
@@ -184,14 +184,14 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void getSourceStorageRecordById(String id, Map<String, String> okapiHeaders,
+  public void getSourceStorageRecordsById(String id, String lang, Map<String, String> okapiHeaders,
                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         recordService.getRecordById(id)
           .map(optionalRecord -> optionalRecord.orElseThrow(() ->
             new NotFoundException(String.format(NOT_FOUND_MESSAGE, Record.class.getSimpleName(), id))))
-          .map(GetSourceStorageRecordByIdResponse::respond200WithApplicationJson)
+          .map(GetSourceStorageRecordsByIdResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
@@ -203,15 +203,15 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void putSourceStorageRecordById(String id, Record entity, Map<String, String> okapiHeaders,
+  public void putSourceStorageRecordsById(String id, String lang, Record entity, Map<String, String> okapiHeaders,
                                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         entity.setId(id);
         recordService.updateRecord(entity)
           .map(updated -> updated ?
-            PutSourceStorageRecordByIdResponse.respond200WithApplicationJson(entity) :
-            PutSourceStorageRecordByIdResponse.respond404WithTextPlain(
+            PutSourceStorageRecordsByIdResponse.respond200WithApplicationJson(entity) :
+            PutSourceStorageRecordsByIdResponse.respond404WithTextPlain(
               String.format(NOT_FOUND_MESSAGE, Record.class.getSimpleName(), id))
           )
           .map(Response.class::cast)
@@ -225,15 +225,15 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void deleteSourceStorageRecordById(String id, Map<String, String> okapiHeaders,
+  public void deleteSourceStorageRecordsById(String id, String lang, Map<String, String> okapiHeaders,
                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         recordService.deleteRecord(id)
           .map(deleted -> deleted ?
-            DeleteSourceStorageRecordByIdResponse.respond204WithTextPlain(
+            DeleteSourceStorageRecordsByIdResponse.respond204WithTextPlain(
               String.format("Record with id '%s' was successfully deleted", id)) :
-            DeleteSourceStorageRecordByIdResponse.respond404WithTextPlain(
+            DeleteSourceStorageRecordsByIdResponse.respond404WithTextPlain(
               String.format(NOT_FOUND_MESSAGE, Record.class.getSimpleName(), id)))
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -246,12 +246,12 @@ public class SourceStorageImpl implements SourceStorage {
   }
 
   @Override
-  public void getSourceStorageResult(String query, int offset, int limit, Map<String, String> okapiHeaders,
+  public void getSourceStorageSourceRecords(String query, int offset, int limit, Map<String, String> okapiHeaders,
                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        recordService.getResults(query, offset, limit)
-          .map(GetSourceStorageResultResponse::respond200WithApplicationJson)
+        recordService.getSourceRecords(query, offset, limit)
+          .map(GetSourceStorageSourceRecordsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
           .setHandler(asyncResultHandler);
@@ -268,15 +268,15 @@ public class SourceStorageImpl implements SourceStorage {
     vertxContext.runOnContext(v -> {
       if (Boolean.TRUE.equals(Boolean.valueOf(System.getenv(TEST_MODE)))) {
         List<Future> futures = new ArrayList<>();
-        entity.getSourceRecords().stream()
-          .map(sourceRecord -> {
+        entity.getRawRecords().stream()
+          .map(rawRecord -> {
             Record record = new Record()
-              .withId(sourceRecord.getId())
-              .withSourceRecord(sourceRecord)
+              .withId(rawRecord.getId())
+              .withRawRecord(rawRecord)
               .withSnapshotId(STUB_SNAPSHOT_ID)
               .withRecordType(Record.RecordType.MARC);
-            if (sourceRecord.getSource().startsWith("{")) {
-              record.setParsedRecord(new ParsedRecord().withContent(sourceRecord.getSource()));
+            if (rawRecord.getContent().startsWith("{")) {
+              record.setParsedRecord(new ParsedRecord().withContent(rawRecord.getContent()));
             } else {
               record = parseRecord(record);
             }
@@ -298,7 +298,7 @@ public class SourceStorageImpl implements SourceStorage {
 
   private Record parseRecord(Record record) {
     try {
-      MarcReader reader = new MarcStreamReader(new ByteArrayInputStream(record.getSourceRecord().getSource().getBytes(StandardCharsets.UTF_8)));
+      MarcReader reader = new MarcStreamReader(new ByteArrayInputStream(record.getRawRecord().getContent().getBytes(StandardCharsets.UTF_8)));
       if (reader.hasNext()) {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         MarcJsonWriter writer = new MarcJsonWriter(os);
@@ -308,7 +308,7 @@ public class SourceStorageImpl implements SourceStorage {
       }
     } catch (Exception e) {
       LOG.error("Error parsing MARC record", e);
-      record.setErrorRecord(new ErrorRecord().withContent(record.getSourceRecord().getSource()).withDescription("Error parsing marc record"));
+      record.setErrorRecord(new ErrorRecord().withContent(record.getRawRecord().getContent()).withDescription("Error parsing marc record"));
     }
     return record;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -3,7 +3,7 @@ package org.folio.services;
 import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;
-import org.folio.rest.jaxrs.model.ResultCollection;
+import org.folio.rest.jaxrs.model.SourceRecordCollection;
 
 import java.util.Optional;
 
@@ -55,12 +55,12 @@ public interface RecordService {
   Future<Boolean> deleteRecord(String id);
 
   /**
-   * Searches for results
+   * Searches for source records
    *
    * @param query  query from URL
    * @param offset starting index in a list of results
    * @param limit  limit of records for pagination
-   * @return future with {@link ResultCollection}
+   * @return future with {@link SourceRecordCollection}
    */
-  Future<ResultCollection> getResults(String query, int offset, int limit);
+  Future<SourceRecordCollection> getSourceRecords(String query, int offset, int limit);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -8,7 +8,7 @@ import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;
-import org.folio.rest.jaxrs.model.ResultCollection;
+import org.folio.rest.jaxrs.model.SourceRecordCollection;
 
 import javax.ws.rs.NotFoundException;
 import java.util.Optional;
@@ -37,7 +37,7 @@ public class RecordServiceImpl implements RecordService {
     if (record.getId() == null) {
       record.setId(UUID.randomUUID().toString());
     }
-    record.getSourceRecord().setId(UUID.randomUUID().toString());
+    record.getRawRecord().setId(UUID.randomUUID().toString());
     if (record.getParsedRecord() != null) {
       record.getParsedRecord().setId(UUID.randomUUID().toString());
     }
@@ -74,8 +74,8 @@ public class RecordServiceImpl implements RecordService {
   }
 
   @Override
-  public Future<ResultCollection> getResults(String query, int offset, int limit) {
-    return recordDao.getResults(query, offset, limit);
+  public Future<SourceRecordCollection> getSourceRecords(String query, int offset, int limit) {
+    return recordDao.getSourceRecords(query, offset, limit);
   }
 
 }

--- a/mod-source-record-storage-server/src/main/resources/templates/db_scripts/create_records_view.sql
+++ b/mod-source-record-storage-server/src/main/resources/templates/db_scripts/create_records_view.sql
@@ -10,12 +10,12 @@ CREATE OR REPLACE VIEW records_view AS
 					'generation', records.jsonb->>'generation',
 					'recordType', records.jsonb->>'recordType',
 					'metadata', records.jsonb->'metadata',
- 					'sourceRecord', source_records.jsonb,
+ 					'rawRecord', raw_records.jsonb,
  					'parsedRecord', COALESCE(marc_records.jsonb),
 					'errorRecord', error_records.jsonb)
 					AS jsonb
    FROM records
-     JOIN source_records ON records.jsonb->>'sourceRecordId' = source_records.jsonb->>'id'
+     JOIN raw_records ON records.jsonb->>'rawRecordId' = raw_records.jsonb->>'id'
      LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id'
      LEFT JOIN error_records ON records.jsonb->>'errorRecordId' = error_records.jsonb->>'id';
 
@@ -31,25 +31,27 @@ CREATE OR REPLACE VIEW records_view AS
 --					'generation', records.jsonb->>'generation',
 --					'recordType', records.jsonb->>'recordType',
 --          'metadata', records.jsonb->'metadata',
--- 					'sourceRecord', source_records.jsonb,
+-- 					'rawRecord', raw_records.jsonb,
 -- 					'parsedRecord', COALESCE(marc_records.jsonb, new_type_of_parsed_records.jsonb),
 --					'errorRecord', error_records.jsonb)
 --					AS jsonb
 --   FROM records
---     JOIN source_records ON records.jsonb->>'sourceRecordId' = source_records.jsonb->>'id'
+--     JOIN raw_records ON records.jsonb->>'rawRecordId' = raw_records.jsonb->>'id'
 --     LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id'
 --     LEFT JOIN error_records ON records.jsonb->>'errorRecordId' = error_records.jsonb->>'id'
 --     LEFT JOIN new_type_of_parsed_records ON records.jsonb->>'parsedRecordId' = new_type_of_parsed_records.jsonb->>'id';
 --
---Similarly to update results_view the following script has to be updated and copied to the appropriate scripts.snippet field of the schema.json
-CREATE OR REPLACE VIEW results_view AS
+--Similarly to update source_records_view the following script has to be updated and copied to the appropriate scripts.snippet field of the schema.json
+CREATE OR REPLACE VIEW source_records_view AS
   SELECT records._id,
   json_build_object('recordId', records.jsonb->>'id',
           'snapshotId', records.jsonb->>'snapshotId',
 					'recordType', records.jsonb->>'recordType',
 					'metadata', records.jsonb->'metadata',
+					'rawRecord', raw_records.jsonb,
  					'parsedRecord', COALESCE(marc_records.jsonb))
 					AS jsonb
    FROM records
+     JOIN raw_records ON records.jsonb->>'rawRecordId' = raw_records.jsonb->>'id'
      LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id'
      WHERE records.jsonb->>'parsedRecordId' IS NOT NULL;

--- a/mod-source-record-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-source-record-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "tableName": "source_records",
+      "tableName": "raw_records",
       "withMetadata": true,
       "pkColumnName": "_id",
       "generateId": false,
@@ -99,12 +99,12 @@
   "scripts": [
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW records_view AS SELECT records._id, json_build_object('id', records.jsonb->>'id', 'snapshotId', records.jsonb->>'snapshotId', 'matchedProfileId', records.jsonb->>'matchedProfileId','matchedId', records.jsonb->>'matchedId','generation', records.jsonb->>'generation','recordType', records.jsonb->>'recordType', 'metadata', records.jsonb->'metadata', 'sourceRecord', source_records.jsonb,'parsedRecord', COALESCE(marc_records.jsonb),'errorRecord', error_records.jsonb) AS jsonb FROM records JOIN source_records ON records.jsonb->>'sourceRecordId' = source_records.jsonb->>'id' LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id' LEFT JOIN error_records ON records.jsonb->>'errorRecordId' = error_records.jsonb->>'id';",
+      "snippet": "CREATE OR REPLACE VIEW records_view AS SELECT records._id, json_build_object('id', records.jsonb->>'id', 'snapshotId', records.jsonb->>'snapshotId', 'matchedProfileId', records.jsonb->>'matchedProfileId','matchedId', records.jsonb->>'matchedId','generation', records.jsonb->>'generation','recordType', records.jsonb->>'recordType', 'metadata', records.jsonb->'metadata', 'rawRecord', raw_records.jsonb,'parsedRecord', COALESCE(marc_records.jsonb),'errorRecord', error_records.jsonb) AS jsonb FROM records JOIN raw_records ON records.jsonb->>'rawRecordId' = raw_records.jsonb->>'id' LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id' LEFT JOIN error_records ON records.jsonb->>'errorRecordId' = error_records.jsonb->>'id';",
       "fromModuleVersion": "1.0"
     },
     {
       "run": "after",
-      "snippet": "CREATE OR REPLACE VIEW results_view AS SELECT records._id, json_build_object('recordId', records.jsonb->>'id', 'snapshotId', records.jsonb->>'snapshotId', 'recordType', records.jsonb->>'recordType', 'metadata', records.jsonb->'metadata', 'parsedRecord', COALESCE(marc_records.jsonb)) AS jsonb FROM records JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id' WHERE records.jsonb->>'parsedRecordId' IS NOT NULL;",
+      "snippet": "CREATE OR REPLACE VIEW source_records_view AS SELECT records._id, json_build_object('recordId', records.jsonb->>'id', 'snapshotId', records.jsonb->>'snapshotId', 'recordType', records.jsonb->>'recordType', 'metadata', records.jsonb->'metadata', 'rawRecord', raw_records.jsonb, 'parsedRecord', COALESCE(marc_records.jsonb)) AS jsonb FROM records JOIN raw_records ON records.jsonb->>'rawRecordId' = raw_records.jsonb->>'id' LEFT JOIN marc_records ON records.jsonb->>'parsedRecordId' = marc_records.jsonb->>'id' WHERE records.jsonb->>'parsedRecordId' IS NOT NULL;",
       "fromModuleVersion": "1.0"
     }
   ]

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
@@ -8,6 +8,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -26,47 +27,47 @@ import static org.hamcrest.Matchers.notNullValue;
 @RunWith(VertxUnitRunner.class)
 public class RecordApiTest extends AbstractRestVerticleTest {
 
-  private static final String SOURCE_STORAGE_RECORD_PATH = "/source-storage/record";
-  private static final String SOURCE_STORAGE_RESULT_PATH = "/source-storage/result";
+  private static final String SOURCE_STORAGE_RECORDS_PATH = "/source-storage/records";
+  private static final String SOURCE_STORAGE_SOURCE_RECORDS_PATH = "/source-storage/sourceRecords";
   private static final String RECORDS_TABLE_NAME = "records";
-  private static final String SOURCE_RECORDS_TABLE_NAME = "source_records";
+  private static final String RAW_RECORDS_TABLE_NAME = "raw_records";
   private static final String ERROR_RECORDS_TABLE_NAME = "error_records";
   private static final String MARC_RECORDS_TABLE_NAME = "marc_records";
 
-  private static JsonObject sourceRecord_1 =  new JsonObject()
-    .put("source", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.");
-  private static JsonObject sourceRecord_2 = new JsonObject()
-    .put("source", "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
-  private static JsonObject marcRecord = new JsonObject()
-    .put("content", "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.");
-  private static JsonObject errorRecord = new JsonObject()
-    .put("description", "Oops... something happened")
-    .put("content", "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
-  private static JsonObject record_1 = new JsonObject()
-    .put("snapshotId", "11dfac11-1caf-4470-9ad1-d533f6360bdd")
-    .put("recordType", "MARC")
-    .put("sourceRecord", sourceRecord_1);
-  private static JsonObject record_2 = new JsonObject()
-    .put("snapshotId", "22dfac11-1caf-4470-9ad1-d533f6360bdd")
-    .put("recordType", "MARC")
-    .put("sourceRecord", sourceRecord_2)
-    .put("parsedRecord", marcRecord);
-  private static JsonObject record_3 = new JsonObject()
-    .put("snapshotId", "22dfac11-1caf-4470-9ad1-d533f6360bdd")
-    .put("recordType", "MARC")
-    .put("sourceRecord", sourceRecord_1)
-    .put("errorRecord", errorRecord);
-  private static JsonObject record_4 = new JsonObject()
-    .put("snapshotId", "11dfac11-1caf-4470-9ad1-d533f6360bdd")
-    .put("recordType", "MARC")
-    .put("sourceRecord", sourceRecord_1)
-    .put("parsedRecord", marcRecord);
+  private static RawRecord rawRecord_1 =  new RawRecord()
+    .withContent("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.");
+  private static RawRecord rawRecord_2 = new RawRecord()
+    .withContent("Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+  private static ParsedRecord marcRecord = new ParsedRecord()
+    .withContent("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.");
+  private static ErrorRecord errorRecord = new ErrorRecord()
+    .withDescription("Oops... something happened")
+    .withContent("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
+  private static Record record_1 = new Record()
+    .withSnapshotId("11dfac11-1caf-4470-9ad1-d533f6360bdd")
+    .withRecordType(Record.RecordType.MARC)
+    .withRawRecord(rawRecord_1);
+  private static Record record_2 = new Record()
+    .withSnapshotId("22dfac11-1caf-4470-9ad1-d533f6360bdd")
+    .withRecordType(Record.RecordType.MARC)
+    .withRawRecord(rawRecord_2)
+    .withParsedRecord(marcRecord);
+  private static Record record_3 = new Record()
+    .withSnapshotId("22dfac11-1caf-4470-9ad1-d533f6360bdd")
+    .withRecordType(Record.RecordType.MARC)
+    .withRawRecord(rawRecord_1)
+    .withErrorRecord(errorRecord);
+  private static Record record_4 = new Record()
+    .withSnapshotId("11dfac11-1caf-4470-9ad1-d533f6360bdd")
+    .withRecordType(Record.RecordType.MARC)
+    .withRawRecord(rawRecord_1)
+    .withParsedRecord(marcRecord);
 
   @Override
   public void clearTables(TestContext context) {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, TENANT_ID);
     pgClient.delete(RECORDS_TABLE_NAME, new Criterion(), event -> {
-      pgClient.delete(SOURCE_RECORDS_TABLE_NAME, new Criterion(), event1 -> {
+      pgClient.delete(RAW_RECORDS_TABLE_NAME, new Criterion(), event1 -> {
         pgClient.delete(ERROR_RECORDS_TABLE_NAME, new Criterion(), event2 -> {
           pgClient.delete(MARC_RECORDS_TABLE_NAME, new Criterion(), event3 -> {
             if (event3.failed()) {
@@ -83,7 +84,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH)
+      .get(SOURCE_STORAGE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(0))
@@ -92,13 +93,13 @@ public class RecordApiTest extends AbstractRestVerticleTest {
 
   @Test
   public void shouldReturnAllRecordsOnGetWhenNoQueryIsSpecified() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -106,7 +107,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH)
+      .get(SOURCE_STORAGE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(recordsToPost.size()));
@@ -114,13 +115,13 @@ public class RecordApiTest extends AbstractRestVerticleTest {
 
   @Test
   public void shouldReturnRecordsOnGetBySpecifiedSnapshotId() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -128,22 +129,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "?query=snapshotId=" + record_2.getString("snapshotId"))
+      .get(SOURCE_STORAGE_RECORDS_PATH + "?query=snapshotId=" + record_2.getSnapshotId())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(2))
-      .body("records*.snapshotId", everyItem(is(record_2.getString("snapshotId"))));
+      .body("records*.snapshotId", everyItem(is(record_2.getSnapshotId())));
   }
 
   @Test
   public void shouldReturnLimitedCollectionOnGetWithLimit() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -151,7 +152,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "?limit=2")
+      .get(SOURCE_STORAGE_RECORDS_PATH + "?limit=2")
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("records.size()", is(2))
@@ -164,7 +165,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
       .spec(spec)
       .body(new JsonObject().toString())
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH)
+      .post(SOURCE_STORAGE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
   }
@@ -173,29 +174,29 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldCreateRecordOnPost() {
     RestAssured.given()
       .spec(spec)
-      .body(record_1.toString())
+      .body(record_1)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH)
+      .post(SOURCE_STORAGE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_CREATED)
-      .body("snapshotId", is(record_1.getString("snapshotId")))
-      .body("recordType", is(record_1.getString("recordType")))
-      .body("sourceRecord.source", is(sourceRecord_1.getString("source")));
+      .body("snapshotId", is(record_1.getSnapshotId()))
+      .body("recordType", is(record_1.getRecordType().name()))
+      .body("rawRecord.content", is(rawRecord_1.getContent()));
   }
 
   @Test
   public void shouldCreateErrorRecordOnPost() {
     RestAssured.given()
       .spec(spec)
-      .body(record_3.toString())
+      .body(record_3)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH)
+      .post(SOURCE_STORAGE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_CREATED)
-      .body("snapshotId", is(record_3.getString("snapshotId")))
-      .body("recordType", is(record_3.getString("recordType")))
-      .body("sourceRecord.source", is(sourceRecord_1.getString("source")))
-      .body("errorRecord.content", is(errorRecord.getString("content")));
+      .body("snapshotId", is(record_3.getSnapshotId()))
+      .body("recordType", is(record_3.getRecordType().name()))
+      .body("rawRecord.content", is(rawRecord_1.getContent()))
+      .body("errorRecord.content", is(errorRecord.getContent()));
   }
 
   @Test
@@ -204,7 +205,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
       .spec(spec)
       .body(new JsonObject().toString())
       .when()
-      .put(SOURCE_STORAGE_RECORD_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
+      .put(SOURCE_STORAGE_RECORDS_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
   }
@@ -213,9 +214,9 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldReturnNotFoundOnPutWhenRecordDoesNotExist() {
     RestAssured.given()
       .spec(spec)
-      .body(record_1.toString())
+      .body(record_1)
       .when()
-      .put(SOURCE_STORAGE_RECORD_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
+      .put(SOURCE_STORAGE_RECORDS_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
       .then()
       .statusCode(HttpStatus.SC_NOT_FOUND);
   }
@@ -224,22 +225,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldUpdateExistingRecordOnPut() {
     Response createResponse = RestAssured.given()
       .spec(spec)
-      .body(record_1.toString())
+      .body(record_1)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH);
+      .post(SOURCE_STORAGE_RECORDS_PATH);
     Assert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
     Record createdRecord = createResponse.body().as(Record.class);
 
-    createdRecord.setParsedRecord(marcRecord.mapTo(ParsedRecord.class));
+    createdRecord.setParsedRecord(marcRecord);
     RestAssured.given()
       .spec(spec)
       .body(createdRecord)
       .when()
-      .put(SOURCE_STORAGE_RECORD_PATH + "/" + createdRecord.getId())
+      .put(SOURCE_STORAGE_RECORDS_PATH + "/" + createdRecord.getId())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("id", is(createdRecord.getId()))
-      .body("sourceRecord.source", is(createdRecord.getSourceRecord().getSource()))
+      .body("rawRecord.content", is(createdRecord.getRawRecord().getContent()))
       .body("parsedRecord.content", is(createdRecord.getParsedRecord().getContent()));
   }
 
@@ -247,22 +248,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldUpdateErrorRecordOnPut() {
     Response createResponse = RestAssured.given()
       .spec(spec)
-      .body(record_1.toString())
+      .body(record_1)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH);
+      .post(SOURCE_STORAGE_RECORDS_PATH);
     Assert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
     Record createdRecord = createResponse.body().as(Record.class);
 
-    createdRecord.setErrorRecord(errorRecord.mapTo(ErrorRecord.class));
+    createdRecord.setErrorRecord(errorRecord);
     RestAssured.given()
       .spec(spec)
       .body(createdRecord)
       .when()
-      .put(SOURCE_STORAGE_RECORD_PATH + "/" + createdRecord.getId())
+      .put(SOURCE_STORAGE_RECORDS_PATH + "/" + createdRecord.getId())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("id", is(createdRecord.getId()))
-      .body("sourceRecord.source", is(createdRecord.getSourceRecord().getSource()))
+      .body("rawRecord.content", is(createdRecord.getRawRecord().getContent()))
       .body("errorRecord.content", is(createdRecord.getErrorRecord().getContent()));
   }
 
@@ -271,7 +272,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
+      .get(SOURCE_STORAGE_RECORDS_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
       .then()
       .statusCode(HttpStatus.SC_NOT_FOUND);
   }
@@ -280,21 +281,21 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldReturnExistingRecordOnGetById() {
     Response createResponse = RestAssured.given()
       .spec(spec)
-      .body(record_2.toString())
+      .body(record_2)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH);
+      .post(SOURCE_STORAGE_RECORDS_PATH);
     Assert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
     Record createdRecord = createResponse.body().as(Record.class);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "/" + createdRecord.getId())
+      .get(SOURCE_STORAGE_RECORDS_PATH + "/" + createdRecord.getId())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("id", is(createdRecord.getId()))
-      .body("sourceRecord.source", is(sourceRecord_2.getString("source")))
-      .body("parsedRecord.content", is(marcRecord.getString("content")));
+      .body("rawRecord.content", is(rawRecord_2.getContent()))
+      .body("parsedRecord.content", is(marcRecord.getContent()));
   }
 
   @Test
@@ -302,7 +303,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .delete(SOURCE_STORAGE_RECORD_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
+      .delete(SOURCE_STORAGE_RECORDS_PATH + "/11dfac11-1caf-4470-9ad1-d533f6360bdd")
       .then()
       .statusCode(HttpStatus.SC_NOT_FOUND);
   }
@@ -311,16 +312,16 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   public void shouldDeleteExistingRecordOnDelete() {
     Response createResponse = RestAssured.given()
       .spec(spec)
-      .body(record_1.toString())
+      .body(record_1)
       .when()
-      .post(SOURCE_STORAGE_RECORD_PATH);
+      .post(SOURCE_STORAGE_RECORDS_PATH);
     Assert.assertThat(createResponse.statusCode(), is(HttpStatus.SC_CREATED));
     Record createdRecord = createResponse.body().as(Record.class);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .delete(SOURCE_STORAGE_RECORD_PATH + "/" + createdRecord.getId())
+      .delete(SOURCE_STORAGE_RECORDS_PATH + "/" + createdRecord.getId())
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
   }
@@ -330,22 +331,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH)
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(0))
-      .body("results", empty());
+      .body("sourceRecords", empty());
   }
 
   @Test
   public void shouldReturnAllParsedResultsOnGetWhenNoQueryIsSpecified() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -353,22 +354,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH)
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH)
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(2))
-      .body("results*.parsedRecord", notNullValue());
+      .body("sourceRecords*.parsedRecord", notNullValue());
   }
 
   @Test
   public void shouldReturnResultsOnGetBySpecifiedSnapshotId() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -376,22 +377,22 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH + "?query=snapshotId=" + record_2.getString("snapshotId"))
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?query=snapshotId=" + record_2.getSnapshotId())
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(1))
-      .body("results*.snapshotId", everyItem(is(record_2.getString("snapshotId"))));
+      .body("sourceRecords*.snapshotId", everyItem(is(record_2.getSnapshotId())));
   }
 
   @Test
   public void shouldReturnLimitedResultCollectionOnGetWithLimit() {
-    List<JsonObject> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
-    for (JsonObject record : recordsToPost) {
+    List<Record> recordsToPost = Arrays.asList(record_1, record_2, record_3, record_4);
+    for (Record record : recordsToPost) {
       RestAssured.given()
         .spec(spec)
-        .body(record.toString())
+        .body(record)
         .when()
-        .post(SOURCE_STORAGE_RECORD_PATH)
+        .post(SOURCE_STORAGE_RECORDS_PATH)
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
@@ -399,10 +400,10 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH + "?limit=1")
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?limit=1")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("results.size()", is(1))
+      .body("sourceRecords.size()", is(1))
       .body("totalRecords", is(2));
   }
 
@@ -411,42 +412,42 @@ public class RecordApiTest extends AbstractRestVerticleTest {
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH + "?query=error!")
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?query=error!")
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH + "?query=select * from table")
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?query=select * from table")
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RESULT_PATH + "?limit=select * from table")
+      .get(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?limit=select * from table")
       .then()
       .statusCode(HttpStatus.SC_BAD_REQUEST);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "?query=error!")
+      .get(SOURCE_STORAGE_RECORDS_PATH + "?query=error!")
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "?query=select * from table")
+      .get(SOURCE_STORAGE_RECORDS_PATH + "?query=select * from table")
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
 
     RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_RECORD_PATH + "?limit=select * from table")
+      .get(SOURCE_STORAGE_RECORDS_PATH + "?limit=select * from table")
       .then()
       .statusCode(HttpStatus.SC_BAD_REQUEST);
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/TestMarcRecordsApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/TestMarcRecordsApiTest.java
@@ -1,13 +1,11 @@
 package org.folio.rest.impl;
 
 import io.restassured.RestAssured;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
-import org.folio.rest.jaxrs.model.SourceRecord;
+import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.TestMarcRecordsCollection;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -16,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,24 +24,24 @@ public class TestMarcRecordsApiTest extends AbstractRestVerticleTest {
 
   private static final String POPULATE_TEST_MARK_RECORDS_PATH = "/source-storage/populate-test-marc-records";
   private static final String RECORDS_TABLE_NAME = "records";
-  private static final String SOURCE_RECORDS_TABLE_NAME = "source_records";
+  private static final String RAW_RECORDS_TABLE_NAME = "raw_records";
   private static final String ERROR_RECORDS_TABLE_NAME = "error_records";
   private static final String MARC_RECORDS_TABLE_NAME = "marc_records";
 
-  private static JsonObject sourceRecord_1 = new JsonObject()
-    .put("id", "9b0ae8c4-2e0c-11e9-b210-d663bd873d93")
-    .put("source", "01240cas a2200397   4500001000700000005001700007008004100024010001700065022001400082035002600096035002200122035001100144035001900155040004400174050001500218082001100233222004200244245004300286260004700329265003800376300001500414310002200429321002500451362002300476570002900499650003300528650004500561655004200606700004500648853001800693863002300711902001600734905002100750948003700771950003400808\u001E366832\u001E20141106221425.0\u001E750907c19509999enkqr p       0   a0eng d\u001E  \u001Fa   58020553 \u001E  \u001Fa0022-0469\u001E  \u001Fa(CStRLIN)NYCX1604275S\u001E  \u001Fa(NIC)notisABP6388\u001E  \u001Fa366832\u001E  \u001Fa(OCoLC)1604275\u001E  \u001FdCtY\u001FdMBTI\u001FdCtY\u001FdMBTI\u001FdNIC\u001FdCStRLIN\u001FdNIC\u001E0 \u001FaBR140\u001Fb.J6\u001E  \u001Fa270.05\u001E04\u001FaThe Journal of ecclesiastical history\u001E04\u001FaThe Journal of ecclesiastical history.\u001E  \u001FaLondon,\u001FbCambridge University Press [etc.]\u001E  \u001Fa32 East 57th St., New York, 10022\u001E  \u001Fav.\u001Fb25 cm.\u001E  \u001FaQuarterly,\u001Fb1970-\u001E  \u001FaSemiannual,\u001Fb1950-69\u001E0 \u001Fav. 1-   Apr. 1950-\u001E  \u001FaEditor:   C. W. Dugmore.\u001E 0\u001FaChurch history\u001FxPeriodicals.\u001E 7\u001FaChurch history\u001F2fast\u001F0(OCoLC)fst00860740\u001E 7\u001FaPeriodicals\u001F2fast\u001F0(OCoLC)fst01411641\u001E1 \u001FaDugmore, C. W.\u001Fq(Clifford William),\u001Feed.\u001E03\u001F81\u001Fav.\u001Fi(year)\u001E40\u001F81\u001Fa1-49\u001Fi1950-1998\u001E  \u001Fapfnd\u001FbLintz\u001E  \u001Fa19890510120000.0\u001E2 \u001Fa20141106\u001Fbm\u001Fdbatch\u001Felts\u001Fxaddfast\u001E  \u001FlOLIN\u001FaBR140\u001Fb.J86\u001Fh01/01/01 N\u001E\u001D01542ccm a2200361   ");
-  private static JsonObject sourceRecord_2 = new JsonObject()
-    .put("id", "9b0aec8e-2e0c-11e9-b210-d663bd873d93")
-    .put("source", "{ \\\"leader\\\": \\\"00508cjm a22001813 4500\\\", \\\"fields\\\": [ { \\\"001\\\": \\\"10062588\\\" }, { \\\"005\\\": \\\"20171013073237.0\\\" }, { \\\"007\\\": \\\"sd fsngnnmmneu\\\" }, { \\\"008\\\": \\\"170825s2017 xx nn n zxx d\\\" }, { \\\"024\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"00190295755553\\\" }, { \\\"2\\\": \\\"gtin-14\\\" } ], \\\"ind1\\\": \\\"7\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"024\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"190295755553\\\" } ], \\\"ind1\\\": \\\"1\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"035\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"(OCoLC)1002130878\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"035\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"10062588\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"040\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"BTCTA\\\" }, { \\\"b\\\": \\\"eng\\\" }, { \\\"c\\\": \\\"BTCTA\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"100\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"Rossi, Daniele\\\" } ], \\\"ind1\\\": \\\"1\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"245\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"Saint-Saens: Organ Symphony and Carnival of The Animals\\\" } ], \\\"ind1\\\": \\\"0\\\", \\\"ind2\\\": \\\"0\\\" } }, { \\\"260\\\": { \\\"subfields\\\": [ { \\\"b\\\": \\\"Wea Corp\\\" }, { \\\"c\\\": \\\"2017.\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"948\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"20171013\\\" }, { \\\"b\\\": \\\"m\\\" }, { \\\"d\\\": \\\"batch\\\" }, { \\\"e\\\": \\\"lts\\\" }, { \\\"x\\\": \\\"deloclcprefix\\\" } ], \\\"ind1\\\": \\\"2\\\", \\\"ind2\\\": \\\" \\\" } } ] }");
-  private static JsonObject recordCollection = new JsonObject()
-    .put("sourceRecords", new JsonArray().add(sourceRecord_1).add(sourceRecord_2));
+  private static RawRecord rawRecord_1 = new RawRecord()
+    .withId("9b0ae8c4-2e0c-11e9-b210-d663bd873d93")
+    .withContent("01240cas a2200397   4500001000700000005001700007008004100024010001700065022001400082035002600096035002200122035001100144035001900155040004400174050001500218082001100233222004200244245004300286260004700329265003800376300001500414310002200429321002500451362002300476570002900499650003300528650004500561655004200606700004500648853001800693863002300711902001600734905002100750948003700771950003400808\u001E366832\u001E20141106221425.0\u001E750907c19509999enkqr p       0   a0eng d\u001E  \u001Fa   58020553 \u001E  \u001Fa0022-0469\u001E  \u001Fa(CStRLIN)NYCX1604275S\u001E  \u001Fa(NIC)notisABP6388\u001E  \u001Fa366832\u001E  \u001Fa(OCoLC)1604275\u001E  \u001FdCtY\u001FdMBTI\u001FdCtY\u001FdMBTI\u001FdNIC\u001FdCStRLIN\u001FdNIC\u001E0 \u001FaBR140\u001Fb.J6\u001E  \u001Fa270.05\u001E04\u001FaThe Journal of ecclesiastical history\u001E04\u001FaThe Journal of ecclesiastical history.\u001E  \u001FaLondon,\u001FbCambridge University Press [etc.]\u001E  \u001Fa32 East 57th St., New York, 10022\u001E  \u001Fav.\u001Fb25 cm.\u001E  \u001FaQuarterly,\u001Fb1970-\u001E  \u001FaSemiannual,\u001Fb1950-69\u001E0 \u001Fav. 1-   Apr. 1950-\u001E  \u001FaEditor:   C. W. Dugmore.\u001E 0\u001FaChurch history\u001FxPeriodicals.\u001E 7\u001FaChurch history\u001F2fast\u001F0(OCoLC)fst00860740\u001E 7\u001FaPeriodicals\u001F2fast\u001F0(OCoLC)fst01411641\u001E1 \u001FaDugmore, C. W.\u001Fq(Clifford William),\u001Feed.\u001E03\u001F81\u001Fav.\u001Fi(year)\u001E40\u001F81\u001Fa1-49\u001Fi1950-1998\u001E  \u001Fapfnd\u001FbLintz\u001E  \u001Fa19890510120000.0\u001E2 \u001Fa20141106\u001Fbm\u001Fdbatch\u001Felts\u001Fxaddfast\u001E  \u001FlOLIN\u001FaBR140\u001Fb.J86\u001Fh01/01/01 N\u001E\u001D01542ccm a2200361   ");
+  private static RawRecord rawRecord_2 = new RawRecord()
+    .withId("9b0aec8e-2e0c-11e9-b210-d663bd873d93")
+    .withContent("{ \\\"leader\\\": \\\"00508cjm a22001813 4500\\\", \\\"fields\\\": [ { \\\"001\\\": \\\"10062588\\\" }, { \\\"005\\\": \\\"20171013073237.0\\\" }, { \\\"007\\\": \\\"sd fsngnnmmneu\\\" }, { \\\"008\\\": \\\"170825s2017 xx nn n zxx d\\\" }, { \\\"024\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"00190295755553\\\" }, { \\\"2\\\": \\\"gtin-14\\\" } ], \\\"ind1\\\": \\\"7\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"024\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"190295755553\\\" } ], \\\"ind1\\\": \\\"1\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"035\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"(OCoLC)1002130878\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"035\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"10062588\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"040\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"BTCTA\\\" }, { \\\"b\\\": \\\"eng\\\" }, { \\\"c\\\": \\\"BTCTA\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"100\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"Rossi, Daniele\\\" } ], \\\"ind1\\\": \\\"1\\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"245\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"Saint-Saens: Organ Symphony and Carnival of The Animals\\\" } ], \\\"ind1\\\": \\\"0\\\", \\\"ind2\\\": \\\"0\\\" } }, { \\\"260\\\": { \\\"subfields\\\": [ { \\\"b\\\": \\\"Wea Corp\\\" }, { \\\"c\\\": \\\"2017.\\\" } ], \\\"ind1\\\": \\\" \\\", \\\"ind2\\\": \\\" \\\" } }, { \\\"948\\\": { \\\"subfields\\\": [ { \\\"a\\\": \\\"20171013\\\" }, { \\\"b\\\": \\\"m\\\" }, { \\\"d\\\": \\\"batch\\\" }, { \\\"e\\\": \\\"lts\\\" }, { \\\"x\\\": \\\"deloclcprefix\\\" } ], \\\"ind1\\\": \\\"2\\\", \\\"ind2\\\": \\\" \\\" } } ] }");
+  private static TestMarcRecordsCollection recordCollection = new TestMarcRecordsCollection()
+    .withRawRecords(Arrays.asList(rawRecord_1, rawRecord_2));
 
   @Override
   public void clearTables(TestContext context) {
     PostgresClient pgClient = PostgresClient.getInstance(vertx, TENANT_ID);
     pgClient.delete(RECORDS_TABLE_NAME, new Criterion(), event -> {
-      pgClient.delete(SOURCE_RECORDS_TABLE_NAME, new Criterion(), event1 -> {
+      pgClient.delete(RAW_RECORDS_TABLE_NAME, new Criterion(), event1 -> {
         pgClient.delete(ERROR_RECORDS_TABLE_NAME, new Criterion(), event2 -> {
           pgClient.delete(MARC_RECORDS_TABLE_NAME, new Criterion(), event3 -> {
             if (event3.failed()) {
@@ -93,7 +92,7 @@ public class TestMarcRecordsApiTest extends AbstractRestVerticleTest {
     Async async = testContext.async();
     RestAssured.given()
       .spec(spec)
-      .body(recordCollection.encode())
+      .body(recordCollection)
       .when()
       .post(POPULATE_TEST_MARK_RECORDS_PATH)
       .then()
@@ -103,8 +102,8 @@ public class TestMarcRecordsApiTest extends AbstractRestVerticleTest {
 
   @Test
   public void shouldReturnUnprocessableEntityOnPostWhenNoRecordCollectionPassedInBody() {
-    TestMarcRecordsCollection testMarcRecordsCollection = new TestMarcRecordsCollection();
-    testMarcRecordsCollection.setSourceRecords(Collections.singletonList(new SourceRecord()));
+    TestMarcRecordsCollection testMarcRecordsCollection = new TestMarcRecordsCollection()
+      .withRawRecords(Collections.singletonList(new RawRecord()));
 
     RestAssured.given()
       .spec(spec)

--- a/ramls/source-record-storage.raml
+++ b/ramls/source-record-storage.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Module
-version: v1.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -14,8 +14,8 @@ types:
   snapshotCollection: !include raml-storage/schemas/mod-source-record-storage/snapshotCollection.json
   record: !include raml-storage/schemas/dto/record.json
   recordCollection: !include raml-storage/schemas/dto/recordCollection.json
-  result: !include raml-storage/schemas/dto/result.json
-  resultCollection: !include raml-storage/schemas/dto/resultCollection.json
+  sourceRecord: !include raml-storage/schemas/dto/sourceRecord.json
+  sourceRecordCollection: !include raml-storage/schemas/dto/sourceRecordCollection.json
   errors: !include raml-storage/raml-util/schemas/errors.schema
   recordModel: !include raml-storage/schemas/mod-source-record-storage/recordModel.json
   testMarcRecordsCollection: !include raml-storage/schemas/mod-source-record-storage/testMarcRecordsCollection.json
@@ -31,8 +31,8 @@ resourceTypes:
   collection-item: !include raml-storage/raml-util/rtypes/item-collection.raml
 
 /source-storage:
-  /snapshot:
-    displayName: Snapshot
+  /snapshots:
+    displayName: Snapshots
     description: API for managing Snapshots
     type:
       collection:
@@ -40,8 +40,9 @@ resourceTypes:
         schemaItem: snapshot
         exampleCollection: !include raml-storage/examples/mod-source-record-storage/snapshotCollection.sample
         exampleItem: !include raml-storage/examples/mod-source-record-storage/snapshot.sample
+    post:
+      is: [validate]
     get:
-      description: Get a list of snapshots
       is: [
         searchable: {
           description:
@@ -52,113 +53,27 @@ resourceTypes:
         pageable,
         validate
       ]
-      responses:
-        200:
-          body:
-            application/json:
-              type: snapshotCollection
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
-    post:
-      description: "Create new snapshot"
-      is: [validate]
-      body:
-        application/json:
-          type: snapshot
-      responses:
-        201:
-          body:
-            application/json:
-              type: snapshot
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        422:
-          description: "Unprocessable Entity"
-          body:
-            application/json:
-              type: errors
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
     /{jobExecutionId}:
-      get:
-        description: Get snapshot by id
-        responses:
-          200:
-            body:
-              application/json:
-                type: snapshot
-          404:
-            description: "Not found"
-            body:
-              text/plain:
-                example: "Not found"
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
+      displayName: Snapshot
+      description: Get, Delete or Update a specific Snapshot
+      type:
+        collection-item:
+          schema: snapshot
+          exampleItem: !include raml-storage/examples/mod-source-record-storage/snapshot.sample
       put:
-        description: Update snapshot
-        body:
-          application/json:
-            type: snapshot
+        is: [validate]
         responses:
           200:
             body:
               application/json:
                 type: snapshot
-          400:
-            description: "Bad request"
-            body:
-              text/plain:
-                example: "Bad request"
-          404:
-            description: "Not found"
-            body:
-              text/plain:
-                example: "Not found"
-          422:
-            description: "Unprocessable Entity"
-            body:
-              application/json:
-                type: errors
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
       delete:
-        description: Delete snapshot by id
         responses:
           204:
             body:
               text/plain: !!null
-          404:
-            description: "File not found"
-            body:
-              text/plain:
-                example: "File not found"
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
-  /record:
-    displayName: Record
+  /records:
+    displayName: Records
     description: API for managing Records
     type:
       collection:
@@ -166,8 +81,9 @@ resourceTypes:
         schemaItem: record
         exampleCollection: !include raml-storage/examples/mod-source-record-storage/recordCollection.sample
         exampleItem: !include raml-storage/examples/mod-source-record-storage/record.sample
+    post:
+      is: [validate]
     get:
-      description: Get a list of records
       is: [
         searchable: {
           description:
@@ -178,116 +94,30 @@ resourceTypes:
         pageable,
         validate
       ]
-      responses:
-        200:
-          body:
-            application/json:
-              type: recordCollection
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
-    post:
-      description: "Create new record"
-      is: [validate]
-      body:
-        application/json:
-          type: record
-      responses:
-        201:
-          body:
-            application/json:
-              type: record
-        400:
-          description: "Bad request"
-          body:
-            text/plain:
-              example: "Bad request"
-        422:
-          description: "Unprocessable Entity"
-          body:
-            application/json:
-              type: errors
-        500:
-          description: "Internal server error"
-          body:
-            text/plain:
-              example: "Internal server error"
     /{id}:
-      get:
-        description: Get record by id
-        responses:
-          200:
-            body:
-              application/json:
-                type: record
-          404:
-            description: "Not found"
-            body:
-              text/plain:
-                example: "Not found"
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
+      displayName: Record
+      description: Get, Delete or Update a specific Record
+      type:
+        collection-item:
+          schema: record
+          exampleItem: !include raml-storage/examples/mod-source-record-storage/record.sample
       put:
-        description: Update record
-        body:
-          application/json:
-            type: record
+        is: [validate]
         responses:
           200:
             body:
               application/json:
                 type: record
-          400:
-            description: "Bad request"
-            body:
-              text/plain:
-                example: "Bad request"
-          404:
-            description: "Not found"
-            body:
-              text/plain:
-                example: "Not found"
-          422:
-            description: "Unprocessable Entity"
-            body:
-              application/json:
-                type: errors
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
       delete:
-        description: Delete record by id
         responses:
           204:
             body:
               text/plain: !!null
-          404:
-            description: "File not found"
-            body:
-              text/plain:
-                example: "File not found"
-          500:
-            description: "Internal server error"
-            body:
-              text/plain:
-                example: "Internal server error"
-  /result:
-    displayName: Result
-    description: API for getting Results
+  /sourceRecords:
+    displayName: Source Records
+    description: API for getting Source Records
     get:
-      description: Get a list of results
+      description: Get a list of Source Records
       is: [
         searchable: {
           description:
@@ -302,7 +132,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              type: resultCollection
+              type: sourceRecordCollection
         400:
           description: "Bad request"
           body:


### PR DESCRIPTION
* Renamed endpoints /snapshot -> /snapshots, /record -> /records, /result -> /sourceRecords
* Renamed entities sourceRecord -> rawRecord, result -> sourceRecord
* Updated SourceRecord to contain rawRecord
* Simplified raml file, removed response overriding
* Updated tests to use entities instead of JsonObjects
* Updated NEWS