### PR TITLE
Bug fix MODSOURCE-36 UUID in Sample Data should not be generated

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 public class ModTenantAPI extends TenantAPI {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -122,11 +122,12 @@ public class ModTenantAPI extends TenantAPI {
         Files.walk(sampleDir.toPath()).forEach(file -> { //NOSONAR
           if (file.toFile().getName().endsWith(JSON_EXTENSION)) {
             Record record = new Record();
-            record.setId(file.toFile().getName().split(JSON_EXTENSION)[0]);
+            String recordUUID = file.toFile().getName().split(JSON_EXTENSION)[0];
+            record.setId(recordUUID);
             try {
               String content = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-              record.setParsedRecord(new ParsedRecord().withId(UUID.randomUUID().toString()).withContent(content));
-              record.setRawRecord(new RawRecord().withId(UUID.randomUUID().toString()).withContent(content));
+              record.setParsedRecord(new ParsedRecord().withId(recordUUID).withContent(content));
+              record.setRawRecord(new RawRecord().withId(recordUUID).withContent(content));
               record.setRecordType(Record.RecordType.MARC);
               record.setSnapshotId("00000000-0000-0000-0000-000000000000");
               record.setGeneration("0");


### PR DESCRIPTION
UUID for sample data must be the same as names of the files MARC records are contained in.