### PR TITLE
Modinv 144

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 ## 2019-08-02 v2.6.0-SNAPSHOT 
 * Fixed security vulnerability with jackson databind
 * Changed response status on partial success of batch save/update - return 201/200 if at least one of the records was saved/updated, 500 if none of the records was saved/updated
+* Added suppress from discovery endpoint for change records value
+
+| METHOD |             URL                                       | DESCRIPTION                                      |
+|--------|-------------------------------------------------------|--------------------------------------------------|
+| POST   | /source-storage/record/suppressFromDiscovery         | Change suppress from discovery flag for record   |
 
 ## 2019-07-23 v2.5.0
 * Added endpoint for updating parsed records

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 
 | METHOD |             URL                                       | DESCRIPTION                                      |
 |--------|-------------------------------------------------------|--------------------------------------------------|
-| POST   | /source-storage/record/suppressFromDiscovery         | Change suppress from discovery flag for record   |
+| PUT    | /source-storage/record/suppressFromDiscovery         | Change suppress from discovery flag for record   |
 
 ## 2019-07-23 v2.5.0
 * Added endpoint for updating parsed records

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -70,6 +70,11 @@
           "methods": ["GET"],
           "pathPattern": "/source-storage/formattedRecords/{id}",
           "permissionsRequired": ["source-storage.records.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/source-storage/record/suppressFromDiscovery",
+          "permissionsRequired": ["source-storage.record.update"]
         }
       ]
     },
@@ -144,6 +149,11 @@
       "permissionName": "source-storage.records.put",
       "displayName": "Source Storage - update record",
       "description": "Put Record"
+    },
+    {
+      "permissionName": "source-storage.record.update",
+      "displayName": "Source Storage - update record",
+      "description": "Update Record's fields"
     },
     {
       "permissionName": "source-storage.records.delete",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,7 +178,8 @@
         "source-storage.records.post",
         "source-storage.records.put",
         "source-storage.records.delete",
-        "source-storage.sourceRecords.get"
+        "source-storage.sourceRecords.get",
+        "source-storage.record.update"
       ],
       "visible": false
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -7,6 +7,7 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.folio.rest.jaxrs.model.SourceRecordCollection;
+import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 
 import java.util.Optional;
 
@@ -18,9 +19,9 @@ public interface RecordDao {
   /**
    * Searches for {@link Record} in the db view
    *
-   * @param query  query string to filter records based on matching criteria in fields
-   * @param offset starting index in a list of results
-   * @param limit  maximum number of results to return
+   * @param query    query string to filter records based on matching criteria in fields
+   * @param offset   starting index in a list of results
+   * @param limit    maximum number of results to return
    * @param tenantId tenant id
    * @return future with {@link RecordCollection}
    */
@@ -29,7 +30,7 @@ public interface RecordDao {
   /**
    * Searches for {@link Record} by id
    *
-   * @param id Record id
+   * @param id       Record id
    * @param tenantId tenant id
    * @return future with optional {@link Record}
    */
@@ -38,7 +39,7 @@ public interface RecordDao {
   /**
    * Saves {@link Record} to the db
    *
-   * @param record {@link Record} to save
+   * @param record   {@link Record} to save
    * @param tenantId tenant id
    * @return future with true if succeeded
    */
@@ -47,7 +48,7 @@ public interface RecordDao {
   /**
    * Updates {{@link Record} in the db
    *
-   * @param record {@link Record} to update
+   * @param record   {@link Record} to update
    * @param tenantId tenant id
    * @return future with true if succeeded
    */
@@ -56,11 +57,11 @@ public interface RecordDao {
   /**
    * Searches for {@link SourceRecord} in the db view
    *
-   * @param query  query string to filter results based on matching criteria in fields
-   * @param offset starting index in a list of results
-   * @param limit  maximum number of results to return
+   * @param query          query string to filter results based on matching criteria in fields
+   * @param offset         starting index in a list of results
+   * @param limit          maximum number of results to return
    * @param deletedRecords indicates to return records marked as deleted or not
-   * @param tenantId tenant id
+   * @param tenantId       tenant id
    * @return future with {@link SourceRecordCollection}
    */
   Future<SourceRecordCollection> getSourceRecords(String query, int offset, int limit, boolean deletedRecords, String tenantId);
@@ -79,8 +80,8 @@ public interface RecordDao {
    * Updates {@link ParsedRecord} in the db
    *
    * @param parsedRecord {@link ParsedRecord} to update
-   * @param recordType type of ParsedRecord
-   * @param tenantId tenant id
+   * @param recordType   type of ParsedRecord
+   * @param tenantId     tenant id
    * @return future with true if succeeded
    */
   Future<Boolean> updateParsedRecord(ParsedRecord parsedRecord, ParsedRecordCollection.RecordType recordType, String tenantId);
@@ -89,9 +90,18 @@ public interface RecordDao {
    * Searches for {@link Record} by instance id
    *
    * @param instanceId Instance id
-   * @param tenantId tenant id
+   * @param tenantId   tenant id
    * @return future with optional {@link Record}
    */
   Future<Optional<Record>> getRecordByInstanceId(String instanceId, String tenantId);
+
+  /**
+   * Change suppress from discovery flag for record by external relation id
+   *
+   * @param suppressFromDiscoveryDto - dto that contains new value and id
+   * @param tenantId                 - tenant id
+   * @return - future with true if succeeded
+   */
+  Future<Boolean> updateSuppressFromDiscoveryForRecord(SuppressFromDiscoveryDto suppressFromDiscoveryDto, String tenantId);
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -180,9 +180,9 @@ public class RecordDaoImpl implements RecordDao {
     Future<Boolean> future = Future.future();
     String rollBackMessage = format("Record with %s id: %s was not found", suppressFromDiscoveryDto.getIncomingIdType().name(), suppressFromDiscoveryDto.getId());
     try {
-      String queryforRecordSearchByExternalId;
+      String queryForRecordSearchByExternalId;
       if (suppressFromDiscoveryDto.getIncomingIdType().equals(SuppressFromDiscoveryDto.IncomingIdType.INSTANCE)) {
-        queryforRecordSearchByExternalId = format(GET_RECORD_BY_INSTANCE_ID_QUERY, suppressFromDiscoveryDto.getId());
+        queryForRecordSearchByExternalId = format(GET_RECORD_BY_INSTANCE_ID_QUERY, suppressFromDiscoveryDto.getId());
       } else {
         throw new BadRequestException("Selected IncomingIdType doesn't supported");
       }
@@ -193,7 +193,7 @@ public class RecordDaoImpl implements RecordDao {
           return tx;
         }).compose(v -> {
         Future<ResultSet> resultSetFuture = Future.future();
-        pgClientFactory.createInstance(tenantId).select(tx, queryforRecordSearchByExternalId, resultSetFuture);
+        pgClientFactory.createInstance(tenantId).select(tx, queryForRecordSearchByExternalId, resultSetFuture);
         return resultSetFuture;
       }).compose(resultSet -> {
         if (resultSet.getResults() == null

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -18,6 +18,7 @@ import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordModel;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.folio.rest.jaxrs.model.SourceRecordCollection;
+import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -25,11 +26,14 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.z3950.zing.cql.cql2pgjson.FieldException;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.Optional;
 import java.util.UUID;
 
+import static java.lang.String.format;
 import static org.folio.dataimport.util.DaoUtil.constructCriteria;
 import static org.folio.dataimport.util.DaoUtil.getCQLWrapper;
 import static org.folio.rest.persist.PostgresClient.pojo2json;
@@ -114,7 +118,7 @@ public class RecordDaoImpl implements RecordDao {
   public Future<Integer> calculateGeneration(Record record, String tenantId) {
     Future<ResultSet> future = Future.future();
     try {
-      String getHighestGeneration = String.format(GET_HIGHEST_GENERATION_QUERY, record.getMatchedId(), record.getSnapshotId());
+      String getHighestGeneration = format(GET_HIGHEST_GENERATION_QUERY, record.getMatchedId(), record.getSnapshotId());
       pgClientFactory.createInstance(tenantId).select(getHighestGeneration, future.completer());
     } catch (Exception e) {
       LOG.error("Error while searching for records highest generation", e);
@@ -140,7 +144,7 @@ public class RecordDaoImpl implements RecordDao {
             LOG.error("Could not update ParsedRecord with id {}", updateResult.cause(), parsedRecord.getId());
             future.fail(updateResult.cause());
           } else if (updateResult.result().getUpdated() != 1) {
-            String errorMessage = String.format("ParsedRecord with id '%s' was not found", parsedRecord.getId());
+            String errorMessage = format("ParsedRecord with id '%s' was not found", parsedRecord.getId());
             LOG.error(errorMessage);
             future.fail(new NotFoundException(errorMessage));
           } else {
@@ -158,7 +162,7 @@ public class RecordDaoImpl implements RecordDao {
   public Future<Optional<Record>> getRecordByInstanceId(String instanceId, String tenantId) {
     Future<ResultSet> future = Future.future();
     try {
-      String query = String.format(GET_RECORD_BY_INSTANCE_ID_QUERY, instanceId);
+      String query = format(GET_RECORD_BY_INSTANCE_ID_QUERY, instanceId);
       pgClientFactory.createInstance(tenantId).select(query, future.completer());
     } catch (Exception e) {
       LOG.error("Error while searching for Record by instance id {}", e, instanceId);
@@ -168,6 +172,75 @@ public class RecordDaoImpl implements RecordDao {
       String record = resultSet.getResults().get(0).getString(0);
       return Optional.ofNullable(record).map(it -> new JsonObject(it).mapTo(Record.class));
     });
+  }
+
+  @Override
+  public Future<Boolean> updateSuppressFromDiscoveryForRecord(SuppressFromDiscoveryDto suppressFromDiscoveryDto,
+                                                              String tenantId) {
+    Future<Boolean> future = Future.future();
+    String rollBackMessage = format("Record with %s id: %s was not found", suppressFromDiscoveryDto.getIncomingIdType().name(), suppressFromDiscoveryDto.getId());
+    try {
+      String queryforRecordSearchByExternalId;
+      if (suppressFromDiscoveryDto.getIncomingIdType().equals(SuppressFromDiscoveryDto.IncomingIdType.INSTANCE)) {
+        queryforRecordSearchByExternalId = format(GET_RECORD_BY_INSTANCE_ID_QUERY, suppressFromDiscoveryDto.getId());
+      } else {
+        throw new BadRequestException("Selected IncomingIdType doesn't supported");
+      }
+      Future<SQLConnection> tx = Future.future(); //NOSONAR
+      Future.succeededFuture()
+        .compose(v -> {
+          pgClientFactory.createInstance(tenantId).startTx(tx.completer());
+          return tx;
+        }).compose(v -> {
+        Future<ResultSet> resultSetFuture = Future.future();
+        pgClientFactory.createInstance(tenantId).select(tx, queryforRecordSearchByExternalId, resultSetFuture);
+        return resultSetFuture;
+      }).compose(resultSet -> {
+        if (resultSet.getResults() == null
+          || resultSet.getResults().isEmpty()
+          || resultSet.getResults().get(0) == null
+          || resultSet.getResults().get(0).getString(0) == null
+        ) {
+          throw new NotFoundException(rollBackMessage);
+        }
+        Record record = new JsonObject(resultSet.getResults().get(0).getString(0)).mapTo(Record.class);
+        Future<Results<RecordModel>> resultSetFuture = Future.future();
+        Criteria idCrit = constructCriteria(ID_FIELD, record.getId());
+        pgClientFactory.createInstance(tenantId).get(tx, RECORDS_TABLE, RecordModel.class, new Criterion(idCrit), true, true, resultSetFuture);
+        return resultSetFuture.map(recordModelResults -> recordModelResults.getResults().get(0));
+      }).compose(recordModel -> {
+        recordModel.getAdditionalInfo().setSuppressDiscovery(suppressFromDiscoveryDto.getSuppressFromDiscovery());
+        CQLWrapper filter; //NOSONAR
+        try {
+          filter = getCQLWrapper(RECORDS_TABLE, "id==" + recordModel.getId());
+        } catch (FieldException e) {
+          throw new RuntimeException(e);
+        }
+        Future<UpdateResult> updateHandler = Future.future();
+        pgClientFactory.createInstance(tenantId).update(tx, RECORDS_TABLE, recordModel, filter, true, updateHandler);
+        return updateHandler;
+      }).compose(updateHandler -> {
+        if (updateHandler.getUpdated() != 1) {
+          throw new NotFoundException(rollBackMessage);
+        }
+        Future<Void> endTxFuture = Future.future(); //NOSONAR
+        pgClientFactory.createInstance(tenantId).endTx(tx, endTxFuture);
+        return endTxFuture;
+      }).setHandler(v -> {
+        if (v.failed()) {
+          pgClientFactory.createInstance(tenantId).rollbackTx(tx, rollback -> future.fail(v.cause()));
+          return;
+        }
+        future.complete(true);
+      });
+      return future;
+    } catch (
+      Exception e) {
+      LOG.error("Error updating Record's suppress from discovery flag by {} id {}",
+        e, suppressFromDiscoveryDto.getIncomingIdType(), suppressFromDiscoveryDto.getId());
+      future.fail(e);
+    }
+    return future;
   }
 
   private Future<Boolean> insertOrUpdateRecord(Record record, String tenantId) {
@@ -222,7 +295,7 @@ public class RecordDaoImpl implements RecordDao {
     Future<UpdateResult> future = Future.future();
     try {
       JsonArray params = new JsonArray().add(id).add(pojo2json(rawRecord)).add(pojo2json(rawRecord));
-      String query = String.format(UPSERT_QUERY, PostgresClient.convertToPsqlStandard(tenantId), tableName);
+      String query = format(UPSERT_QUERY, PostgresClient.convertToPsqlStandard(tenantId), tableName);
       pgClientFactory.createInstance(tenantId).execute(tx, query, params, future.completer());
       return future.map(result -> result.getUpdated() == 1);
     } catch (Exception e) {
@@ -238,7 +311,7 @@ public class RecordDaoImpl implements RecordDao {
       JsonObject jsonData = convertParsedRecordToJsonObject(parsedRecord);
       JsonArray params = new JsonArray().add(
         parsedRecord.getId()).add(pojo2json(jsonData)).add(pojo2json(jsonData));
-      String query = String.format(UPSERT_QUERY, PostgresClient.convertToPsqlStandard(tenantId), RecordType.valueOf(record.getRecordType().value()).getTableName());
+      String query = format(UPSERT_QUERY, PostgresClient.convertToPsqlStandard(tenantId), RecordType.valueOf(record.getRecordType().value()).getTableName());
       record.setParsedRecord(jsonData.mapTo(ParsedRecord.class));
       pgClientFactory.createInstance(tenantId).execute(tx, query, params, future.completer());
       return future.map(result -> result.getUpdated() == 1);

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageImpl.java
@@ -1,17 +1,5 @@
 package org.folio.rest.impl;
 
-import static org.folio.rest.impl.ModTenantAPI.LOAD_SAMPLE_PARAMETER;
-
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
@@ -26,6 +14,7 @@ import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceStorageFormattedRecordsIdGetIdentifier;
+import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 import org.folio.rest.jaxrs.model.TestMarcRecordsCollection;
 import org.folio.rest.jaxrs.resource.SourceStorage;
 import org.folio.rest.tools.utils.TenantTool;
@@ -36,6 +25,17 @@ import org.marc4j.MarcJsonWriter;
 import org.marc4j.MarcReader;
 import org.marc4j.MarcStreamReader;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.folio.rest.impl.ModTenantAPI.LOAD_SAMPLE_PARAMETER;
 
 public class SourceStorageImpl implements SourceStorage {
 
@@ -204,6 +204,25 @@ public class SourceStorageImpl implements SourceStorage {
           .setHandler(asyncResultHandler);
       } catch (Exception e) {
         LOG.error("Failed to get record by id", e);
+        asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
+      }
+    });
+  }
+
+  @Override
+  public void putSourceStorageRecordSuppressFromDiscovery(SuppressFromDiscoveryDto entity,
+                                                          Map<String, String> okapiHeaders,
+                                                          Handler<AsyncResult<Response>> asyncResultHandler,
+                                                          Context vertxContext) {
+    vertxContext.runOnContext(v -> {
+      try {
+        recordService.updateSuppressFromDiscoveryForRecord(entity, tenantId)
+          .map(PutSourceStorageRecordSuppressFromDiscoveryResponse::respond200WithTextPlain)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .setHandler(asyncResultHandler);
+      } catch (Exception e) {
+        LOG.error("Failed to update record's SuppressFromDiscovery flag", e);
         asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
       }
     });

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -8,6 +8,7 @@ import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.rest.jaxrs.model.SourceRecordCollection;
 import org.folio.rest.jaxrs.model.SourceStorageFormattedRecordsIdGetIdentifier;
+import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 
 import java.util.Optional;
 
@@ -93,5 +94,14 @@ public interface RecordService {
    * @return future with {@link Record}
    */
   Future<Record> getFormattedRecord(SourceStorageFormattedRecordsIdGetIdentifier identifier, String id, String tenantId);
+
+  /**
+   * Change suppress from discovery flag for record by external relation id
+   *
+   * @param suppressFromDiscoveryDto - dto that contains new value and id
+   * @param tenantId                 - tenant id
+   * @return - future with true if succeeded
+   */
+  Future<Boolean> updateSuppressFromDiscoveryForRecord(SuppressFromDiscoveryDto suppressFromDiscoveryDto, String tenantId);
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -18,6 +18,7 @@ import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.rest.jaxrs.model.SourceRecordCollection;
 import org.folio.rest.jaxrs.model.SourceStorageFormattedRecordsIdGetIdentifier;
+import org.folio.rest.jaxrs.model.SuppressFromDiscoveryDto;
 import org.marc4j.MarcJsonReader;
 import org.marc4j.MarcReader;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -94,7 +95,7 @@ public class RecordServiceImpl implements RecordService {
     Future<RecordsBatchResponse> result = Future.future();
 
     CompositeFuture.join(new ArrayList<>(savedRecords.values())).setHandler(ar -> {
-      RecordsBatchResponse response = new RecordsBatchResponse();
+        RecordsBatchResponse response = new RecordsBatchResponse();
         savedRecords.forEach((record, future) -> {
           if (future.failed()) {
             response.getErrorMessages().add(future.cause().getMessage());
@@ -145,7 +146,7 @@ public class RecordServiceImpl implements RecordService {
     Future<ParsedRecordsBatchResponse> result = Future.future();
 
     CompositeFuture.join(new ArrayList<>(updatedRecords.values())).setHandler(ar -> {
-      ParsedRecordsBatchResponse response = new ParsedRecordsBatchResponse();
+        ParsedRecordsBatchResponse response = new ParsedRecordsBatchResponse();
         updatedRecords.forEach((record, future) -> {
           if (future.failed()) {
             response.getErrorMessages().add(future.cause().getMessage());
@@ -170,6 +171,11 @@ public class RecordServiceImpl implements RecordService {
     }
     return future.map(optionalRecord -> formatMarcRecord(optionalRecord.orElseThrow(() -> new NotFoundException(
       String.format("Couldn't find Record with %s id %s", identifier, id)))));
+  }
+
+  @Override
+  public Future<Boolean> updateSuppressFromDiscoveryForRecord(SuppressFromDiscoveryDto suppressFromDiscoveryDto, String tenantId) {
+    return recordDao.updateSuppressFromDiscoveryForRecord(suppressFromDiscoveryDto, tenantId);
   }
 
   private Record formatMarcRecord(Record record) {

--- a/ramls/source-record-storage.raml
+++ b/ramls/source-record-storage.raml
@@ -19,6 +19,7 @@ types:
   errors: !include raml-storage/raml-util/schemas/errors.schema
   recordModel: !include raml-storage/schemas/mod-source-record-storage/recordModel.json
   testMarcRecordsCollection: !include raml-storage/schemas/mod-source-record-storage/testMarcRecordsCollection.json
+  suppressFromDiscoveryDto: !include raml-storage/schemas/mod-source-record-storage/suppressFromDiscoveryDto.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
@@ -208,3 +209,31 @@ resourceTypes:
           body:
             text/plain:
               example: "Internal server error"
+  /record:
+    displayName: Records
+    description: API for managing Records
+    /suppressFromDiscovery:
+          put:
+            description: Change suppress from discovery flag for record
+            body:
+              application/json:
+                type: suppressFromDiscoveryDto
+            responses:
+              200:
+                body:
+                  text/plain: !!null
+              400:
+                description: "Bad request"
+                body:
+                  text/plain:
+                    example: "Bad request"
+              422:
+                description: "Unprocessable Entity"
+                body:
+                  application/json:
+                    type: errors
+              500:
+                description: "Internal server error"
+                body:
+                  text/plain:
+                    example: "Internal server error"


### PR DESCRIPTION
Overview: Libraries sometimes want to suppress records from discovery by their patrons. Much of the discovery work involves harvesting SRS MARC Bib records via OAI-PMH. When a user updates this flag in the FOLIO instance, the corresponding change should be made to the related SRS MARC Bib record, which then in turn updates the flag in the MARCcat MARC Bib record