### PR TITLE
MODDICORE-43 SRS MARC Bib: Fix formatting of 035 field 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2020-04-10 v3.2.0-SNAPSHOT
 * Added State "field" to records table. (MODSOURCE-114)
+* [MODDICORE-43](https://issues.folio.org/browse/MODDICORE-43) SRS MARC Bib: Fix formatting of 035 field constructed from incoming 001
 
 ## 2020-04-07 v3.1.4-SNAPSHOT
 * [MODOAIPMH-119](https://issues.folio.org/browse/MODOAIPMH-119) Extended sourceRecord schema with externalIdsHolder field.


### PR DESCRIPTION
1. The 035 field should indicators 1 and 2 of [blank] (currently no JSON for indicators in the screenshot where 035 looks like a fixed field)
2. The contents of the former 001 field should be in subfield a of the 035 field (currently no subfield)
3. If there are existing 035 fields, the newly-created 035 should be a completely new 035 (since 035 is a repeatable field)
4. If the newly-created 035 matches an existing 035 exactly, then do not add that new 035 field.
5. If possible, put the newly-created 035 fields in numeric order within the 0XX fields (but DO NOT resequence the entire MARC record into numeric order)