### PR TITLE
MODSOURCE-144: Delete old tables and functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 * [MODSOURCE-134](https://issues.folio.org/browse/MODSOURCE-134) New Source Record Storage API RAML and updated module descriptor
 * [MODSOURCE-143](https://issues.folio.org/browse/MODSOURCE-143) Refactor using jOOQ
 * [MODSOURCE-136](https://issues.folio.org/browse/MODSOURCE-136) New API
-* [MODSOURCE-144](https://issues.folio.org/browse/MODSOURCE-144) Remove Old API, liquibase migration scripts
+* [MODSOURCE-144](https://issues.folio.org/browse/MODSOURCE-144) Remove Old API, liquibase migration scripts, drop old tables and functions
 
 ## 2020-06-10 v3.2.0
 * [MODSOURCE-124](https://issues.folio.org/browse/MODSOURCE-124) Apply archive/unarchive eventPayload mechanism.

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -16,4 +16,12 @@
   <include file="scripts/v-4.0.0/2020-06-12--15-00-migrate-marc-records.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-4.0.0/2020-06-12--16-00-migrate-error-records.xml" relativeToChangelogFile="true"/>
 
+  <include file="scripts/v-4.0.0/2020-06-13--12-00-drop-error-records.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-4.0.0/2020-06-13--13-00-drop-marc-records.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-4.0.0/2020-06-13--14-00-drop-raw-records.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-4.0.0/2020-06-13--15-00-drop-records.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-4.0.0/2020-06-13--16-00-drop-snapshots.xml" relativeToChangelogFile="true"/>
+
+  <include file="scripts/v-4.0.0/2020-06-13--17-00-drop-functions.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--12-00-drop-error-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--12-00-drop-error-records.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--12-00-drop-error-records" author="WilliamWelling">
+    <sql>
+      DROP TABLE IF EXISTS ${database.defaultSchemaName}.error_records;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--13-00-drop-marc-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--13-00-drop-marc-records.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--13-00-drop-marc-records" author="WilliamWelling">
+    <sql>
+      DROP TABLE IF EXISTS ${database.defaultSchemaName}.marc_records;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--14-00-drop-raw-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--14-00-drop-raw-records.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--14-00-drop-raw-records" author="WilliamWelling">
+    <sql>
+      DROP TABLE IF EXISTS ${database.defaultSchemaName}.raw_records;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--15-00-drop-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--15-00-drop-records.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--15-00-drop-records" author="WilliamWelling">
+    <sql>
+      DROP TABLE IF EXISTS ${database.defaultSchemaName}.records;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--16-00-drop-snapshots.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--16-00-drop-snapshots.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--16-00-drop-snapshots" author="WilliamWelling">
+    <sql>
+      DROP TABLE IF EXISTS ${database.defaultSchemaName}.snapshots;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--17-00-drop-functions.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--17-00-drop-functions.xml
@@ -46,4 +46,76 @@
     </sql>
   </changeSet>
 
+  <changeSet runAlways="true" id="2020-06-13--17-07-drop-error_records_set_md" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.error_records_set_md();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-08-drop-marc_records_set_md" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.marc_records_set_md();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-09-drop-raw_records_set_md" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.raw_records_set_md();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-10-drop-records_set_md" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.records_set_md();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-11-drop-set_error_records_md_json" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_error_records_md_json();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-12-drop-set_id_in_jsonb" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_id_in_jsonb();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-13-drop-set_marc_records_md_json" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_marc_records_md_json();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-14-drop-set_raw_records_md_json" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_raw_records_md_json();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-15-drop-set_records_md_json" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_records_md_json();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-16-drop-set_snapshots_md_json" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_snapshots_md_json();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-17-drop-snapshots_set_md" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.snapshots_set_md();
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-18-drop-update_records_references" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.update_records_references();
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--17-00-drop-functions.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-4.0.0/2020-06-13--17-00-drop-functions.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet runAlways="true" id="2020-06-13--17-00-drop-get_record_by_external_id" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_record_by_external_id(externalId uuid, idFieldName text);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-01-drop-get_record_by_matched_id" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_record_by_matched_id(record_id uuid);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-02-drop-get_source_record_by_id" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_source_record_by_id(record_id uuid);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-03-drop-get_source_record_by_external_id" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_source_record_by_external_id(externalId uuid, idFieldName text);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-04-drop-get_records" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_records(where_clause text, order_by text, limitVal int, offsetVal int, schema_name text);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-05-drop-get_source_records" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_source_records(query_filter text, order_by text, limitVal int, offsetVal int, deleted_records text, schema_name text);
+    </sql>
+  </changeSet>
+
+  <changeSet runAlways="true" id="2020-06-13--17-06-drop-get_highest_generation" author="WilliamWelling">
+    <sql>
+      DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_highest_generation(matchedId uuid, snapshotId uuid);
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Set `changeSet` `runAlways="true"` as RMB schema will recreate tables. Removing tables in schema.json causes authentication to database to fail. Seems as if the tenant database role and credentials are not created unless a table is created.