### PR TITLE
MODSOURCE-155: Add MARC leader record status to records and ability to filter by

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURCE-136](https://issues.folio.org/browse/MODSOURCE-136) New API
 * [MODSOURCE-144](https://issues.folio.org/browse/MODSOURCE-144) Remove Old API, liquibase migration scripts, drop old tables and functions
 * [MODSOURCE-139](https://issues.folio.org/browse/MODSOURCE-139) Upgrade RMB to 30.0.3
+* [MODSOURCE-155](https://issues.folio.org/browse/MODSOURCE-155) MARC leader 05 status on record and query parameter to filter by
 
 ## 2020-06-10 v3.2.0
 * [MODSOURCE-124](https://issues.folio.org/browse/MODSOURCE-124) Apply archive/unarchive eventPayload mechanism.

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -25,6 +25,8 @@ import io.vertx.sqlclient.Row;
  */
 public final class ParsedRecordDaoUtil {
 
+  private static final String LEADER_PROPERTY = "leader";
+
   private static final String CONTENT_COLUMN = "content";
 
   public static final String ID_COLUMN = "id";
@@ -138,6 +140,28 @@ public final class ParsedRecordDaoUtil {
       content = JsonObject.mapFrom(parsedRecord.getContent()).encode();
     }
     return parsedRecord.withContent(content);
+  }
+
+  /**
+   * Extract MARC Leader status 05 from {@link ParsedRecord} content.
+   * 
+   * @param parsedRecord parsed record
+   * @return MARC Leader status 05
+   */
+  public static String getLeaderStatus(ParsedRecord parsedRecord) {
+    if (Objects.nonNull(parsedRecord)) {
+      JsonObject content;
+      if (parsedRecord.getContent() instanceof String) {
+        content = new JsonObject((String) parsedRecord.getContent());
+      } else {
+        content = JsonObject.mapFrom(parsedRecord.getContent());
+      }
+      String leader = content.getString(LEADER_PROPERTY);
+      if (Objects.nonNull(leader) && leader.length() > 5) {
+        return String.valueOf(leader.charAt(5));
+      }
+    } 
+    return null;
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -310,12 +310,9 @@ public final class RecordDaoUtil {
    * @param recordType            record type to equal
    * @param suppressFromDiscovery suppress from discovery to equal
    * @param deleted               deleted to equal
-   * @param updatedAfter          updated after to be greater than or equal
-   * @param updatedBefore         updated before to be less than or equal
    * @return condition
    */
-  public static Condition filterRecordBy(String recordId, String recordType, Boolean suppressFromDiscovery, Boolean deleted,
-      Date updatedAfter, Date updatedBefore) {
+  public static Condition filterRecordBy(String recordId, String recordType, Boolean suppressFromDiscovery, Boolean deleted) {
     Condition condition = DSL.trueCondition();
     if (StringUtils.isNotEmpty(recordId)) {
       condition = condition.and(RECORDS_LB.ID.eq(toUUID(recordId)));
@@ -331,6 +328,18 @@ public final class RecordDaoUtil {
         ? RECORDS_LB.STATE.eq(RecordState.DELETED)
         : RECORDS_LB.STATE.eq(RecordState.ACTUAL));
     }
+    return condition;
+  }
+
+  /**
+   * Get {@link Condition} to filter by range of updated date
+   * 
+   * @param updatedAfter  updated after to be greater than or equal
+   * @param updatedBefore updated before to be less than or equal
+   * @return condition
+   */
+  public static Condition filterRecordByUpdatedDate(Date updatedAfter, Date updatedBefore) {
+    Condition condition = DSL.trueCondition();
     if (Objects.nonNull(updatedAfter)) {
       condition = condition.and(RECORDS_LB.UPDATED_DATE.greaterOrEqual(updatedAfter.toInstant().atOffset(ZoneOffset.UTC)));
     }
@@ -338,6 +347,19 @@ public final class RecordDaoUtil {
       condition = condition.and(RECORDS_LB.UPDATED_DATE.lessOrEqual(updatedBefore.toInstant().atOffset(ZoneOffset.UTC)));
     }
     return condition;
+  }
+
+  /**
+   * Get {@link Condition} to filter by leader record status
+   * 
+   * @param leaderRecordState leader record status to equal
+   * @return condition
+   */
+  public static Condition filterRecordByLeaderRecordState(String leaderRecordState) {
+    if (StringUtils.isNotEmpty(leaderRecordState)) {
+      return RECORDS_LB.LEADER_RECORD_STATUS.eq(leaderRecordState);
+    }
+    return DSL.trueCondition();
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -176,6 +176,7 @@ public final class RecordDaoUtil {
       sourceRecord.withRecordType(org.folio.rest.jaxrs.model.SourceRecord.RecordType.valueOf(record.getRecordType().toString()));
     }
     if (Objects.nonNull(record.getState())) {
+      // TODO: should leader record status be checked for deleted here as well?
       sourceRecord.withDeleted(record.getState().equals(State.DELETED));
     }
     return sourceRecord
@@ -214,7 +215,8 @@ public final class RecordDaoUtil {
     }
     record
       .withOrder(pojo.getOrder())
-      .withGeneration(pojo.getGeneration());
+      .withGeneration(pojo.getGeneration())
+      .withLeaderRecordStatus(pojo.getLeaderRecordStatus());
     AdditionalInfo additionalInfo = new AdditionalInfo();
     if (Objects.nonNull(pojo.getSuppressDiscovery())) {
       additionalInfo.withSuppressDiscovery(pojo.getSuppressDiscovery());
@@ -277,6 +279,7 @@ public final class RecordDaoUtil {
     }
     dbRecord.setOrder(record.getOrder());
     dbRecord.setGeneration(record.getGeneration());
+    dbRecord.setLeaderRecordStatus(record.getLeaderRecordStatus());
     if (Objects.nonNull(record.getAdditionalInfo())) {
       dbRecord.setSuppressDiscovery(record.getAdditionalInfo().getSuppressDiscovery());
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
@@ -2,7 +2,9 @@ package org.folio.rest.impl;
 
 import static org.folio.dao.util.RecordDaoUtil.filterRecordBy;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByInstanceId;
+import static org.folio.dao.util.RecordDaoUtil.filterRecordByLeaderRecordState;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordBySnapshotId;
+import static org.folio.dao.util.RecordDaoUtil.filterRecordByUpdatedDate;
 import static org.folio.dao.util.RecordDaoUtil.toRecordOrderFields;
 
 import java.util.Date;
@@ -48,13 +50,16 @@ public class SourceStorageSourceRecordsImpl implements SourceStorageSourceRecord
 
   @Override
   public void getSourceStorageSourceRecords(String recordId, String snapshotId, String instanceId, String recordType,
-      Boolean suppressFromDiscovery, Boolean deleted, Date updatedAfter, Date updatedBefore, List<String> orderBy, int offset, int limit,
-      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      Boolean suppressFromDiscovery, Boolean deleted, String leaderRecordStatus, Date updatedAfter, Date updatedBefore,
+      List<String> orderBy, int offset, int limit, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     // NOTE: if and when a new record type is introduced and a parsed record table is added,
     // will need to add a record type query parameter
     vertxContext.runOnContext(v -> {
       try {
-        Condition condition = filterRecordBy(recordId, recordType, suppressFromDiscovery, deleted, updatedAfter, updatedBefore)
+        Condition condition = filterRecordBy(recordId, recordType, suppressFromDiscovery, deleted)
+          .and(filterRecordByUpdatedDate(updatedAfter, updatedBefore))
+          .and(filterRecordByLeaderRecordState(leaderRecordStatus))
           .and(filterRecordBySnapshotId(snapshotId))
           .and(filterRecordByInstanceId(instanceId));
         List<OrderField<?>> orderFields = toRecordOrderFields(orderBy);

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--13-00-create-records-table.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--13-00-create-records-table.xml
@@ -44,6 +44,7 @@
       <column name="state" type="${database.defaultSchemaName}.record_state">
         <constraints nullable="false"/>
       </column>
+      <column name="leader_record_status" type="char(1)"></column>
       <column name="order" type="integer"></column>
       <column name="suppress_discovery" type="boolean"></column>
       <column name="created_by_user_id" type="uuid"></column>
@@ -70,7 +71,7 @@
 
   <changeSet id="2020-06-11--13-04-set-records-suppressdiscovery-default" author="WilliamWelling">
     <addDefaultValue
-        columnDataType="integer"
+        columnDataType="boolean"
         columnName="suppress_discovery"
         defaultValueBoolean="false"
         schemaName="${database.defaultSchemaName}"

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--15-00-create-marc-records-table.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--15-00-create-marc-records-table.xml
@@ -9,7 +9,7 @@
       <column name="id" type="uuid">
         <constraints primaryKey="true" nullable="false"/>
       </column>
-      <column name="content" type="text">
+      <column name="content" type="jsonb">
         <constraints nullable="false"/>
       </column>
     </createTable>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--15-00-create-marc-records-table.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-11--15-00-create-marc-records-table.xml
@@ -30,4 +30,33 @@
         referencedTableSchemaName="${database.defaultSchemaName}"/>
   </changeSet>
 
+  <changeSet id="2020-06-11--15-02-create-update-records-set-leader-record-status-function" author="WilliamWelling">
+    <createProcedure>
+      create function ${database.defaultSchemaName}.update_records_set_leader_record_status() returns trigger
+          language plpgsql
+      as
+      $$
+      BEGIN
+          IF (TG_OP = 'DELETE') THEN
+            UPDATE ${database.defaultSchemaName}.records_lb SET leader_record_status = NULL WHERE id = OLD.id;
+            RETURN OLD;
+          ELSE
+            UPDATE ${database.defaultSchemaName}.records_lb SET leader_record_status = substring(NEW.content->>'leader' from 6 for 1)::char(1) WHERE id = NEW.id;
+            RETURN NEW;
+          END IF;
+      END;
+      $$;
+    </createProcedure>
+  </changeSet>
+
+  <changeSet id="2020-06-11--15-03-create-update-records-set-leader-record-status-trigger" author="WilliamWelling">
+    <sql>
+      create trigger update_records_set_leader_record_status
+          after insert or update or delete
+          on ${database.defaultSchemaName}.marc_records_lb
+          for each row
+      execute procedure ${database.defaultSchemaName}.update_records_set_leader_record_status();
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
@@ -20,6 +20,7 @@
         CASE (jsonb->>'deleted')::boolean WHEN true THEN ('DELETED')::${database.defaultSchemaName}.record_state
         ELSE coalesce(jsonb->>'state', 'ACTUAL')::${database.defaultSchemaName}.record_state
         END AS state,
+        NULL as leader_record_status,
         (jsonb->>'order')::integer AS order,
         (jsonb->'additionalInfo'->>'suppressDiscovery')::boolean AS suppress_discovery,
         (jsonb->'metadata'->>'createdByUserId')::uuid AS created_by_user_id,

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--15-00-migrate-marc-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--15-00-migrate-marc-records.xml
@@ -13,7 +13,7 @@
       INSERT INTO ${database.defaultSchemaName}.marc_records_lb
       SELECT
         r.id AS id,
-        mr.jsonb->>'content' AS content
+        mr.jsonb->'content' AS content
       FROM ${database.defaultSchemaName}.records r
       INNER JOIN ${database.defaultSchemaName}.marc_records mr ON (r.jsonb->>'parsedRecordId')::uuid = mr.id;
     </sql>

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -546,6 +546,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
     context.assertEquals(expected.getMatchedId(), actual.getMatchedId());
     context.assertEquals(expected.getRecordType(), actual.getRecordType());
     context.assertEquals(expected.getState(), actual.getState());
+    context.assertEquals(expected.getLeaderRecordStatus(), actual.getLeaderRecordStatus());
     context.assertEquals(expected.getOrder(), actual.getOrder());
     context.assertEquals(expected.getGeneration(), actual.getGeneration());
     if (Objects.nonNull(expected.getRawRecord())) {

--- a/mod-source-record-storage-server/src/test/resources/mock/records/0f0fe962-d502-4a4f-9e74-7732bec94ee8.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/0f0fe962-d502-4a4f-9e74-7732bec94ee8.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 1,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/4c0ff739-3f4d-4670-a693-84dd48e31c53.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/4c0ff739-3f4d-4670-a693-84dd48e31c53.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 2,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/7293f287-bb51-41f5-805d-00ff18a1f791.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/7293f287-bb51-41f5-805d-00ff18a1f791.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 1,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/8452daf9-c130-4955-99ce-1c397a218900.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/8452daf9-c130-4955-99ce-1c397a218900.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 1,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/8f462542-387c-4f06-a01b-50829c7c7b13.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/8f462542-387c-4f06-a01b-50829c7c7b13.json
@@ -4,6 +4,7 @@
   "matchedId": "8f462542-387c-4f06-a01b-50829c7c7b13",
   "generation": 0,
   "recordType": "MARC",
+  "leaderRecordStatus": "n",
   "deleted": false,
   "order": 1,
   "state": "ACTUAL"

--- a/mod-source-record-storage-server/src/test/resources/mock/records/8fb19e31-0920-49d7-9438-b573c292b1a6.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/8fb19e31-0920-49d7-9438-b573c292b1a6.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 2,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/be1b25ae-4a9d-4077-93e6-7f8e59efd609.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/be1b25ae-4a9d-4077-93e6-7f8e59efd609.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 2,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/d3cd3e1e-a18c-4f7c-b053-9aa50343394e.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/d3cd3e1e-a18c-4f7c-b053-9aa50343394e.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 3,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/e567b8e2-a45b-45f1-a85a-6b6312bdf4d8.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/e567b8e2-a45b-45f1-a85a-6b6312bdf4d8.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 1,
   "state": "ACTUAL"
 }

--- a/mod-source-record-storage-server/src/test/resources/mock/records/ec53a386-9616-428b-92a9-e1f07756ea1f.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/ec53a386-9616-428b-92a9-e1f07756ea1f.json
@@ -5,6 +5,7 @@
   "generation": 0,
   "recordType": "MARC",
   "deleted": false,
+  "leaderRecordStatus": "n",
   "order": 2,
   "state": "ACTUAL"
 }

--- a/ramls/source-record-storage-source-records.raml
+++ b/ramls/source-record-storage-source-records.raml
@@ -73,6 +73,12 @@ resourceTypes:
         example: true
         required: false
         default: false
+      leaderRecordStatus:
+        description: Filter by MARC leader 05 status
+        type: string
+        example: "n"
+        required: false
+        "pattern": "^[a|c|d|n|p|o|s|x]{1}$"
       updatedAfter:
         description: Start date to filter after, inclusive
         type: datetime


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURCE-155

Requires https://github.com/folio-org/data-import-raml-storage/pull/175

This PR also addresses a performance issue with get source records. The column leader_record_status is used to condition not null in order to perform join with marc records after offset and limit.