### PR TITLE
Preserve snapshots and records created and updated dates

### DIFF
--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--12-00-migrate-snapshots.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--12-00-migrate-snapshots.xml
@@ -25,9 +25,9 @@
         (jsonb->>'status')::${database.defaultSchemaName}.job_execution_status AS status,
         (jsonb->>'processingStartedDate')::timestamptz AS processing_started_date,
         (jsonb->'metadata'->>'createdByUserId')::uuid AS created_by_user_id,
-        (jsonb->'metadata'->>'createdDate')::timestamptz AS created_date,
+        coalesce((jsonb->'metadata'->>'createdDate')::timestamptz, current_timestamp) AS created_date,
         (jsonb->'metadata'->>'updatedByUserId')::uuid AS updated_by_user_id,
-        (jsonb->'metadata'->>'updatedDate')::timestamptz AS updated_date
+        coalesce((jsonb->'metadata'->>'updatedDate')::timestamptz, current_timestamp) AS updated_date
       FROM ${database.defaultSchemaName}.snapshots;
     </sql>
   </changeSet>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--12-00-migrate-snapshots.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--12-00-migrate-snapshots.xml
@@ -4,7 +4,17 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
 
-  <changeSet id="2020-06-12--12-00-migrate-snapshots" author="WilliamWelling">
+  <changeSet id="2020-06-12--12-00-disable-snapshots-triggers" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="snapshots" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.snapshots_lb DISABLE TRIGGER insert_snapshots_set_dates;
+      ALTER TABLE ${database.defaultSchemaName}.snapshots_lb DISABLE TRIGGER update_snapshots_set_dates;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--12-01-migrate-snapshots" author="WilliamWelling">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="snapshots" schemaName="${database.defaultSchemaName}"/>
     </preConditions>
@@ -22,7 +32,17 @@
     </sql>
   </changeSet>
 
-  <changeSet id="2020-06-12--13-00-create-missing-snapshots" author="WilliamWelling">
+  <changeSet id="2020-06-12--12-02-enable-snapshots-triggers" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="snapshots" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.snapshots_lb ENABLE TRIGGER insert_snapshots_set_dates;
+      ALTER TABLE ${database.defaultSchemaName}.snapshots_lb ENABLE TRIGGER update_snapshots_set_dates;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--12-03-create-missing-snapshots" author="WilliamWelling">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="snapshots" schemaName="${database.defaultSchemaName}"/>
       <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
@@ -4,7 +4,17 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
 
-  <changeSet id="2020-06-12--13-00-migrate-records" author="WilliamWelling">
+  <changeSet id="2020-06-12--13-00-disable-records-triggers" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.records_lb DISABLE TRIGGER insert_records_set_dates;
+      ALTER TABLE ${database.defaultSchemaName}.records_lb DISABLE TRIGGER update_records_set_dates;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--13-01-migrate-records" author="WilliamWelling">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
     </preConditions>
@@ -28,6 +38,16 @@
         (jsonb->'metadata'->>'updatedByUserId')::uuid AS updated_by_user_id,
         (jsonb->'metadata'->>'updatedDate')::timestamptz AS updated_date
       FROM ${database.defaultSchemaName}.records;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--13-02-enable-records-triggers" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.records_lb ENABLE TRIGGER insert_records_set_dates;
+      ALTER TABLE ${database.defaultSchemaName}.records_lb ENABLE TRIGGER update_records_set_dates;
     </sql>
   </changeSet>
 

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--13-00-migrate-records.xml
@@ -34,9 +34,9 @@
         (jsonb->>'order')::integer AS order,
         (jsonb->'additionalInfo'->>'suppressDiscovery')::boolean AS suppress_discovery,
         (jsonb->'metadata'->>'createdByUserId')::uuid AS created_by_user_id,
-        (jsonb->'metadata'->>'createdDate')::timestamptz AS created_date,
+        coalesce((jsonb->'metadata'->>'createdDate')::timestamptz, current_timestamp) AS created_date,
         (jsonb->'metadata'->>'updatedByUserId')::uuid AS updated_by_user_id,
-        (jsonb->'metadata'->>'updatedDate')::timestamptz AS updated_date
+        coalesce((jsonb->'metadata'->>'updatedDate')::timestamptz, current_timestamp) AS updated_date
       FROM ${database.defaultSchemaName}.records;
     </sql>
   </changeSet>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--15-00-migrate-marc-records.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-06-12--15-00-migrate-marc-records.xml
@@ -4,7 +4,17 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
 
-  <changeSet id="2020-06-12--15-00-migrate-marc-records" author="WilliamWelling">
+  <changeSet id="2020-06-12--15-00-disable-records-update-records-date-trigger" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
+      <tableExists tableName="marc_records" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.records_lb DISABLE TRIGGER update_records_set_dates;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--15-01-migrate-marc-records" author="WilliamWelling">
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
       <tableExists tableName="marc_records" schemaName="${database.defaultSchemaName}"/>
@@ -16,6 +26,16 @@
         mr.jsonb->'content' AS content
       FROM ${database.defaultSchemaName}.records r
       INNER JOIN ${database.defaultSchemaName}.marc_records mr ON (r.jsonb->>'parsedRecordId')::uuid = mr.id;
+    </sql>
+  </changeSet>
+
+  <changeSet id="2020-06-12--15-02-enable-records-update-records-date-trigger" author="WilliamWelling">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="records" schemaName="${database.defaultSchemaName}"/>
+      <tableExists tableName="marc_records" schemaName="${database.defaultSchemaName}"/>
+    </preConditions>
+    <sql>
+      ALTER TABLE ${database.defaultSchemaName}.records_lb ENABLE TRIGGER update_records_set_dates;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
Migration will now preserve snapshots and records created and updated dates. If not present on previous snapshot or record they will be set to current date and time of migration.