### PR TITLE
MODSOURCE-200-BUGFIX

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2020-10-22 v4.1.2-SNAPSHOT
+* [MODSOURCE-200](https://issues.folio.org/browse/MODSOURCE-200) Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint" [BUGFIX]
+
 ## 2020-10-14 v4.1.1
 * [MODSOURMAN-361](https://issues.folio.org/browse/MODSOURMAN-361) Add capability to remove jobs that are stuck
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/MarcUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/MarcUtil.java
@@ -21,12 +21,13 @@ import org.marc4j.marc.Record;
 public class MarcUtil {
 
   public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+  private static final String MARC_RECORD_ERROR_MESSAGE = "Unable to read marc record!";
 
   private MarcUtil() { }
 
   /**
    * Converts raw MARC to MARC json
-   * 
+   *
    * @param rawMarc raw MARC
    * @return MARC json
    * @throws IOException
@@ -38,7 +39,7 @@ public class MarcUtil {
 
   /**
    * Converts raw MARC to text formatted MARC
-   * 
+   *
    * @param rawMarc raw MARC
    * @return text formatted MARC
    * @throws IOException
@@ -50,7 +51,7 @@ public class MarcUtil {
 
   /**
    * Converts MARC json to raw MARC
-   * 
+   *
    * @param marcJson MARC json
    * @return raw MARC
    * @throws IOException
@@ -62,7 +63,7 @@ public class MarcUtil {
 
   /**
    * Converts MARC json to text formatted MARC
-   * 
+   *
    * @param marcJson MARC json
    * @return text formatted MARC
    * @throws IOException
@@ -86,7 +87,11 @@ public class MarcUtil {
     try (InputStream in = new ByteArrayInputStream(marcJson.getBytes())) {
       final MarcJsonReader reader = new MarcJsonReader(in);
       if (reader.hasNext()) {
-        return reader.next();
+        try {
+          return reader.next();
+        } catch (Exception e) {
+          throw new MarcException(MARC_RECORD_ERROR_MESSAGE);
+        }
       }
     }
     throw new MarcException(String.format("Unable to read: %s", marcJson));

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
@@ -48,6 +48,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
   private static final String SOURCE_STORAGE_BATCH_RECORDS_PATH = "/source-storage/batch/records";
   private static final String SOURCE_STORAGE_BATCH_PARSED_RECORDS_PATH = "/source-storage/batch/parsed-records";
 
+  private static final String INVALID_POST_REQUEST = "{\"records\":[{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"snapshotId\":\"7f939c0b-618c-4eab-8276-a14e0bfe5728\",\"matchedId\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"generation\":0,\"recordType\":\"MARC\",\"rawRecord\":{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"content\":\"01104cam \"},\"parsedRecord\":{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"content\":{\"leader\":\"00000cam a2200277   4500\",\"fields\":[{\"001\":\"in00000000007\"},{\"005\":\"20120817205822.0\"},{\"008\":\"690410s1965    dcu          f000 0 eng  \"},{\"010\":{\"subfields\":[{\"a\":\"65062892\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"600\":{\"subfields\":[{\"a\":\"Ross, Arthur M.\"},{\"q\":\"(Arthur Max),\"},{\"d\":\"1916-1970.\"},{\"0\":\"http://id.loc.gov/authorities/names/n50047449\"}],\"ind1\":\"1\",\"ind2\":\"0\"}}],\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"i\":\"5b38b5e6-dfa3-4f51-8b7f-858421310aa7\"}]}}},\"deleted\":false,\"order\":0,\"externalIdsHolder\":{\"instanceId\":\"5b38b5e6-dfa3-4f51-8b7f-858421310aa7\"},\"additionalInfo\":{\"suppressDiscovery\":false},\"state\":\"ACTUAL\",\"leaderRecordStatus\":\"c\"}],\"totalRecords\":1}";
   private static final String FIRST_UUID = UUID.randomUUID().toString();
   private static final String SECOND_UUID = UUID.randomUUID().toString();
   private static final String THIRD_UUID = UUID.randomUUID().toString();
@@ -77,7 +78,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
   private static ErrorRecord errorRecord = new ErrorRecord()
     .withDescription("Oops... something happened")
     .withContent("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
-  
+
   private static Record record_1 = new Record()
     .withId(FIRST_UUID)
     .withSnapshotId(snapshot_1.getJobExecutionId())
@@ -146,6 +147,22 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .body("records.size()", is(10))
       .body("errorMessages.size()", is(0))
       .body("totalRecords", is(10));
+    async.complete();
+  }
+
+  @Test
+  public void shouldPostWithoutErrorsSourceStorageBatchRecordsWithInvalidRecord(TestContext testContext) {
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(INVALID_POST_REQUEST)
+      .when()
+      .post(SOURCE_STORAGE_BATCH_RECORDS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED)
+      .body("records.size()", is(1))
+      .body("errorMessages.size()", is(0))
+      .body("totalRecords", is(1));
     async.complete();
   }
 
@@ -294,7 +311,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .body("errorMessages.size()", is(0))
       .body("totalRecords", is(10));
     async.complete();
-    
+
     async = testContext.async();
     List<Record> updated = original.stream()
       .map(record -> record.withExternalIdsHolder(record.getExternalIdsHolder().withInstanceId(UUID.randomUUID().toString())))


### PR DESCRIPTION
…lue in column \"description\" violates not-null constraint"[BUGFIX] (#250)

* MODSOURCE-200: Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint"[BUGFIX]
1. Additional error-catching added.
2. NEWS updated.
3. Test-case added.

* MODSOURCE-200: Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint"[BUGFIX]
1. Tests added.

* MODSOURCE-200: Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint"[BUGFIX]
1. Tests fixed.

* MODSOURCE-200: Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint"[BUGFIX]
1. Tests fixed.

* MODSOURCE-200: Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint"[BUGFIX]
1. NEWS updated.

(cherry picked from commit ec5997b248517ee4718ed39eb92ab08a97949f2b)