### PR TITLE
MODSOURCE-174: Disable CQL2PgJSON & CQLWrapper extra logging in mod-source-record-storage.

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -3,7 +3,7 @@ stages:
   steps:
   - runScriptConfig:
       image: grizzlysoftware/maven-non-root:3.6.2-11.0.4-jdk-stretch
-      shellScript: mvn package -DskipTests
+      shellScript: mvn package -DskipTests -Djava.util.logging.config.file=vertx-default-jul-logging.properties
 - name: Build Docker with DIND
   steps:
   - publishImageConfig:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2020-10-22 v4.1.2-SNAPSHOT
 * [MODSOURCE-200](https://issues.folio.org/browse/MODSOURCE-200) Post to /source-storage/batch/records returns "null value in column \"description\" violates not-null constraint" [BUGFIX]
+* [MODSOURCE-174](https://issues.folio.org/browse/MODSOURCE-174) Disable CQL2PgJSON & CQLWrapper extra logging in mod-source-record-storage.
 
 ## 2020-10-09 v4.1.1
 * [MODSOURMAN-361](https://issues.folio.org/browse/MODSOURMAN-361) Add capability to remove jobs that are stuck

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -346,7 +346,7 @@
     "env": [
       {
         "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=66.0 -Djava.util.logging.config.file=vertx-default-jul-logging.properties"
       },
       {
         "name": "DB_HOST",

--- a/mod-source-record-storage-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-storage-server/src/main/resources/log4j2.properties
@@ -13,3 +13,6 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId
 
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.cql2pgjson.name = org.folio.rest.persist.cql
+logger.cql2pgjson.level = OFF

--- a/mod-source-record-storage-server/src/main/resources/vertx-default-jul-logging.properties
+++ b/mod-source-record-storage-server/src/main/resources/vertx-default-jul-logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level = ALL
+
+logger.cql2pgjson.level = ERROR
+logger.cql2pgjson.name = org.folio.cql2pgjson.CQL2PgJSON


### PR DESCRIPTION
1. New config file "vertx-default-jul-logging" for overriding vertx-jul added with disabling(except ERROR log-level) CQL2PgJSON.
2. Disabling CQLWrapper to log4j2.properties added.
3. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" added for ModuleDescriptor.
4. "-Djava.util.logging.config.file=vertx-default-jul-logging.properties" to the .rancher-config-file.
5. NEWS updated.