### PR TITLE
MODSOURCE-204: Join query for get records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * [MODSOURCE-232](https://issues.folio.org/browse/MODSOURCE-232) Making Instance Records Suppress from Discovery with the Batch Import is not reflected in the SRS
 * [MODSOURCE-220](https://issues.folio.org/browse/MODSOURCE-220) Migration script between Goldenrod-hotfix-5 and Honeysuckle.
 * [MODSOURCE-216](https://issues.folio.org/browse/MODSOURCE-216) Update MARC 005 field when MARC record has changes
-* [MODSOURCE-204](https://issues.folio.org/browse/MODSOURCE-204) Join query for get records.
+* [MODSOURCE-204](https://issues.folio.org/browse/MODSOURCE-204) Join query for get records. Add records_lb index for order column.
 
 ## 2020-11-20 v4.1.3
 * [MODSOURCE-212](https://issues.folio.org/browse/MODSOURCE-212) Fix matching by 999 ff s field

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURCE-218](https://issues.folio.org/browse/MODSOURCE-218) Performance issues with SRS requests when instance ID is not found
 * [MODSOURCE-232](https://issues.folio.org/browse/MODSOURCE-232) Making Instance Records Suppress from Discovery with the Batch Import is not reflected in the SRS
 * [MODSOURCE-220](https://issues.folio.org/browse/MODSOURCE-220) Migration script between Goldenrod-hotfix-5 and Honeysuckle.
+* [MODSOURCE-204](https://issues.folio.org/browse/MODSOURCE-204) Join query for get records.
 
 ## 2020-11-20 v4.1.3
 * [MODSOURCE-212](https://issues.folio.org/browse/MODSOURCE-212) Fix matching by 999 ff s field

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -12,8 +12,8 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jackson.jaxb.version>2.9.9</jackson.jaxb.version>
-    <jooq.version>3.13.2</jooq.version>
-    <vertx-jooq.version>5.1.2</vertx-jooq.version>
+    <jooq.version>3.13.6</jooq.version>
+    <vertx-jooq.version>5.2.1</vertx-jooq.version>
     <postgres.version>42.2.16</postgres.version>
   </properties>
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -207,17 +207,6 @@ public interface RecordDao {
 
   /**
    * Creates new Record and updates status of the "old" one,
-   * no data is overwritten as a result of update
-   *
-   * @param newRecord new Record to create
-   * @param oldRecord old Record that has to be marked as "old"
-   * @param tenantId  tenant id
-   * @return future with new "updated" Record
-   */
-  Future<Record> saveUpdatedRecord(Record newRecord, Record oldRecord, String tenantId);
-
-  /**
-   * Creates new Record and updates status of the "old" one,
    * no data is overwritten as a result of update. Creates
    * new snapshot.
    *

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -197,15 +197,6 @@ public interface RecordDao {
   Future<Optional<SourceRecord>> getSourceRecordByCondition(Condition condition, String tenantId);
 
   /**
-   * Searches for {@link SourceRecord} by id (searches via "matchedId").
-   *
-   * @param id       id
-   * @param tenantId tenant id
-   * @return return future with optional {@link SourceRecord}
-   */
-  Future<Optional<SourceRecord>> getSourceRecordById(String id, String tenantId);
-
-  /**
    * Searches for {@link SourceRecord} by external entity which was created from desired record by specific type.
    *
    * @param id             id

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -119,16 +119,6 @@ public interface RecordDao {
    * Increments generation in case a record with the same matchedId exists
    * and the snapshot it is linked to is COMMITTED before the processing of the current one started
    *
-   * @param record   Record
-   * @param tenantId tenant id
-   * @return future with generation
-   */
-  Future<Integer> calculateGeneration(Record record, String tenantId);
-
-  /**
-   * Increments generation in case a record with the same matchedId exists
-   * and the snapshot it is linked to is COMMITTED before the processing of the current one started
-   *
    * @param txQE   query execution
    * @param record Record
    * @return future with generation

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -321,11 +321,6 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<Record> saveUpdatedRecord(Record newRecord, Record oldRecord, String tenantId) {
-    return getQueryExecutor(tenantId).transaction(txQE -> saveUpdatedRecord(txQE, newRecord, oldRecord));
-  }
-
-  @Override
   public Future<Record> saveUpdatedRecord(ReactiveClassicGenericQueryExecutor txQE, Record newRecord, Record oldRecord) {
     return insertOrUpdateRecord(txQE, oldRecord).compose(r -> insertOrUpdateRecord(txQE, newRecord));
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -276,11 +276,6 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<Integer> calculateGeneration(Record record, String tenantId) {
-    return getQueryExecutor(tenantId).transaction(txQE -> calculateGeneration(txQE, record));
-  }
-
-  @Override
   public Future<Integer> calculateGeneration(ReactiveClassicGenericQueryExecutor txQE, Record record) {
     return txQE.query(dsl -> dsl.select(max(RECORDS_LB.GENERATION).as(RECORDS_LB.GENERATION))
       .from(RECORDS_LB.innerJoin(SNAPSHOTS_LB).on(RECORDS_LB.SNAPSHOT_ID.eq(SNAPSHOTS_LB.ID)))

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -247,14 +247,6 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<Optional<SourceRecord>> getSourceRecordById(String id, String tenantId) {
-    Condition condition = RECORDS_LB.MATCHED_ID.eq(UUID.fromString(id))
-      .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL))
-      .and(RECORDS_LB.LEADER_RECORD_STATUS.isNotNull());
-    return getSourceRecordByCondition(condition, tenantId);
-  }
-
-  @Override
   public Future<Optional<SourceRecord>> getSourceRecordByExternalId(String externalId, ExternalIdType externalIdType, String tenantId) {
     Condition condition = RecordDaoUtil.getExternalIdCondition(externalId, externalIdType)
       .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL))

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -89,7 +89,7 @@ public class RecordDaoImpl implements RecordDao {
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
       .with(cte.as(dsl.selectCount()
         .from(RECORDS_LB)
-        .where(condition)))
+        .where(condition.and(RECORDS_LB.ID.isNotNull()))))
       .select(RECORDS_LB.ID,
               RECORDS_LB.SNAPSHOT_ID,
               RECORDS_LB.MATCHED_ID,
@@ -115,7 +115,7 @@ public class RecordDaoImpl implements RecordDao {
         .leftJoin(RAW_RECORDS_LB).on(RECORDS_LB.ID.eq(RAW_RECORDS_LB.ID))
         .leftJoin(ERROR_RECORDS_LB).on(RECORDS_LB.ID.eq(ERROR_RECORDS_LB.ID))
         .rightJoin(dsl.select().from(table(cte))).on(trueCondition())
-        .where(condition)
+        .where(condition.and(RECORDS_LB.ID.isNotNull()))
         .orderBy(orderFields)
         .offset(offset)
         .limit(limit)
@@ -221,7 +221,7 @@ public class RecordDaoImpl implements RecordDao {
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
       .with(cte.as(dsl.selectCount()
         .from(RECORDS_LB)
-        .where(condition)))
+        .where(condition.and(RECORDS_LB.ID.isNotNull()))))
       .select(RECORDS_LB.ID,
               RECORDS_LB.SNAPSHOT_ID,
               RECORDS_LB.MATCHED_ID,

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ErrorRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ErrorRecordDaoUtil.java
@@ -23,6 +23,11 @@ import io.vertx.sqlclient.RowSet;
  */
 public final class ErrorRecordDaoUtil {
 
+  private static final String ID = "id";
+  private static final String DESCRIPTION = "description";
+
+  public static final String ERROR_RECORD_CONTENT = "error_record_content";
+
   private ErrorRecordDaoUtil() { }
 
   /**
@@ -67,6 +72,23 @@ public final class ErrorRecordDaoUtil {
       .withId(pojo.getId().toString())
       .withContent(pojo.getContent())
       .withDescription(pojo.getDescription());
+  }
+
+  /**
+   * Convert database query result {@link Row} to {@link ErrorRecord}
+   * 
+   * @param row query result row
+   * @return ErrorRecord
+   */
+  public static ErrorRecord toJoinedErrorRecord(Row row) {
+    ErrorRecord errorRecord = new ErrorRecord();
+    UUID id = row.getUUID(ID);
+    if (Objects.nonNull(id)) {
+      errorRecord.withId(id.toString());
+    }
+    return errorRecord
+      .withContent(row.getString(ERROR_RECORD_CONTENT))
+      .withDescription(row.getString(DESCRIPTION));
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -1,24 +1,26 @@
 package org.folio.dao.util;
 
-import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
-import io.github.jklingsporn.vertx.jooq.shared.postgres.JSONBToJsonObjectConverter;
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
-import io.vertx.sqlclient.Row;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.table;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.ws.rs.NotFoundException;
+
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.jooq.Field;
 import org.jooq.impl.SQLDataType;
 
-import javax.ws.rs.NotFoundException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.name;
-import static org.jooq.impl.DSL.table;
+import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
+import io.github.jklingsporn.vertx.jooq.shared.postgres.JSONBToJsonObjectConverter;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
 
 /**
  * Utility class for managing {@link ParsedRecord}
@@ -28,6 +30,8 @@ public final class ParsedRecordDaoUtil {
   private static final String ID = "id";
   private static final String CONTENT = "content";
   private static final String LEADER = "leader";
+
+  public static final String PARSED_RECORD_CONTENT = "parsed_record_content";
 
   private ParsedRecordDaoUtil() {
   }
@@ -120,6 +124,25 @@ public final class ParsedRecordDaoUtil {
       parsedRecord.withId(id.toString());
     }
     Object content = row.getValue(CONTENT);
+    if (Objects.nonNull(content)) {
+      parsedRecord.withContent(normalize(content).getMap());
+    }
+    return parsedRecord;
+  }
+
+  /**
+   * Convert database query result {@link Row} to {@link ParsedRecord}
+   *
+   * @param row query result row
+   * @return ParsedRecord
+   */
+  public static ParsedRecord toJoinedParsedRecord(Row row) {
+    ParsedRecord parsedRecord = new ParsedRecord();
+    UUID id = row.getUUID(ID);
+    if (Objects.nonNull(id)) {
+      parsedRecord.withId(id.toString());
+    }
+    Object content = row.getValue(PARSED_RECORD_CONTENT);
     if (Objects.nonNull(content)) {
       parsedRecord.withContent(normalize(content).getMap());
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RawRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RawRecordDaoUtil.java
@@ -22,6 +22,10 @@ import io.vertx.sqlclient.RowSet;
  */
 public final class RawRecordDaoUtil {
 
+  private static final String ID = "id";
+
+  public static final String RAW_RECORD_CONTENT = "raw_record_content";
+
   private RawRecordDaoUtil() { }
 
   /**
@@ -65,6 +69,22 @@ public final class RawRecordDaoUtil {
     return new RawRecord()
       .withId(pojo.getId().toString())
       .withContent(pojo.getContent());
+  }
+
+  /**
+   * Convert database query result {@link Row} to {@link RawRecord}
+   * 
+   * @param row query result row
+   * @return RawRecord
+   */
+  public static RawRecord toJoinedRawRecord(Row row) {
+    RawRecord rawRecord = new RawRecord();
+    UUID id = row.getUUID(ID);
+    if (Objects.nonNull(id)) {
+      rawRecord.withId(id.toString());
+    }
+    return rawRecord
+      .withContent(row.getString(RAW_RECORD_CONTENT));
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -69,7 +69,7 @@ public final class RecordDaoUtil {
    * @param externalIdType external id type
    * @return condition
    */
-  public static Condition getExternalIdCondition(List<String> externalIds, ExternalIdType externalIdType) {
+  public static Condition getExternalIdsCondition(List<String> externalIds, ExternalIdType externalIdType) {
     return RECORDS_LB.field(LOWER_CAMEL.to(LOWER_UNDERSCORE, externalIdType.getExternalIdField()), UUID.class).in(toUUIDs(externalIds));
   }
 
@@ -490,8 +490,8 @@ public final class RecordDaoUtil {
       .map(order -> order.split(COMMA))
       .map(order -> {
         try {
-          return RECORDS_LB.field(LOWER_CAMEL.to(LOWER_UNDERSCORE, order[0])).sort(order.length > 1
-          ? SortOrder.valueOf(order[1]) : SortOrder.DEFAULT);
+          return RECORDS_LB.field(LOWER_CAMEL.to(LOWER_UNDERSCORE, order[0]))
+            .sort(order.length > 1 ? SortOrder.valueOf(order[1]) : SortOrder.DEFAULT);
         } catch (Exception e) {
           throw new BadRequestException(String.format("Invalid order by %s", String.join(",", order)));
         }

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.3/2021-01-16--08-00-create-records-order-index.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.3/2021-01-16--08-00-create-records-order-index.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet id="2021-01-16--08-00-create-records-order-index" author="WilliamWelling">
+    <createIndex
+        indexName="idx_records_order"
+        schemaName="${database.defaultSchemaName}"
+        tableName="records_lb">
+      <column name="order"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
resolves [MODSOURCE-182](https://issues.folio.org/browse/MODSOURCE-182)
resolves duplicate [MODSOURCE-204](https://issues.folio.org/browse/MODSOURCE-204)

This provides > 2x speedup of the `/source-storage/records?snapshotId=[snapshot id]&orderBy=order&limit=1000` API that is used in the data import UI. Also, has slight performance improvement on `/source-storage/source-records` API.

A downside is that both of these endpoints will require a request type parameter when introducing more parsed record tables. Previously, the n+1 lazy approach could infer the parsed record table from the record and provide a heterogeneous list of records. Additionally, the n+1 lazy approach is faster for smaller pages.