### PR TITLE
MODSOURCE-238: docker-maven-plugin to support build with newer versions of postgres

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODSOURCE-203](https://issues.folio.org/browse/MODSOURCE-203) Ensure queries with offset include order. Add records_lb order index to liquibase change log.
 * [MODSOURCE-202](https://issues.folio.org/browse/MODSOURCE-202) Records stream API using reactivex.
 * [MODSOURCE-201](https://issues.folio.org/browse/MODSOURCE-201) Source Records stream API using reactivex.
+* [MODSOURCE-238](https://issues.folio.org/browse/MODSOURCE-238) Use docker-maven-plugin to support build with newer versions of postgres.
 
 ### Stream Records API
  | METHOD |             URL                                      | DESCRIPTION                                                               |

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -14,7 +14,7 @@
     <jackson.jaxb.version>2.9.9</jackson.jaxb.version>
     <jooq.version>3.13.6</jooq.version>
     <vertx-jooq.version>5.2.1</vertx-jooq.version>
-    <postgres.version>42.2.16</postgres.version>
+    <postgres.version>42.2.18</postgres.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records</generate_routing_context>
   </properties>
 
@@ -294,21 +294,22 @@
           <images>
             <image>
               <alias>db</alias>
-              <name>postgres:10</name>
+              <name>postgres:12-alpine</name>
               <run>
+                <privileged>true</privileged>
+                <containerNamePattern>%n-%t</containerNamePattern>
                 <env>
+                  <POSTGRES_DB>postgres</POSTGRES_DB>
                   <POSTGRES_USER>postgres</POSTGRES_USER>
                   <POSTGRES_PASSWORD>postgres</POSTGRES_PASSWORD>
                 </env>
                 <ports>
                   <port>${db.port}:5432</port>
-                  <port>127.0.0.1:${db.port}:5432</port>
-                  <port>localhost:${db.port}:5432</port>
                   <port>+docker.host.address:${db.port}:5432</port>
                 </ports>
                 <wait>
-                  <log>database system is ready to accept connections</log>
-                  <time>20000</time>
+                  <log>(?s)ready to accept connections.*ready to accept connections</log>
+                  <time>90000</time>
                 </wait>
               </run>
             </image>
@@ -336,11 +337,11 @@
       <plugin>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-maven-plugin</artifactId>
-        <version>4.0.0</version>
+        <version>4.2.2</version>
         <configuration>
           <changeLogFile>src/main/resources/liquibase/tenant/changelog.xml</changeLogFile>
           <driver>org.postgresql.Driver</driver>
-          <url>jdbc:postgresql://${docker.host.address}:${db.port}/postgres</url>
+          <url>jdbc:postgresql://${docker.host.address}:${db.port},${docker.container.db.ip}:5432/postgres</url>
           <username>postgres</username>
           <password>postgres</password>
           <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
@@ -396,7 +397,7 @@
         <configuration>
           <jdbc>
             <driver>org.postgresql.Driver</driver>
-            <url>jdbc:postgresql://${docker.host.address}:${db.port}/postgres</url>
+            <url>jdbc:postgresql://${docker.host.address}:${db.port},${docker.container.db.ip}:5432/postgres</url>
             <user>postgres</user>
             <password>postgres</password>
           </jdbc>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java2</artifactId>
-     </dependency>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
@@ -267,14 +267,52 @@
       </plugin>
 
       <plugin>
-        <groupId>com.gitlab.janecekpetr</groupId>
-        <artifactId>embedded-postgresql-maven-plugin</artifactId>
-        <version>0.1.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.10</version>
+        <executions>
+          <execution>
+            <id>reserve-db-port</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>db.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.34.1</version>
         <configuration>
-          <pgServerPort>15432</pgServerPort>
-          <dbName>postgres</dbName>
-          <userName>postgres</userName>
-          <password>postgres</password>
+          <images>
+            <image>
+              <alias>db</alias>
+              <name>postgres:10</name>
+              <run>
+                <env>
+                  <POSTGRES_USER>postgres</POSTGRES_USER>
+                  <POSTGRES_PASSWORD>postgres</POSTGRES_PASSWORD>
+                </env>
+                <ports>
+                  <port>${db.port}:5432</port>
+                  <port>127.0.0.1:${db.port}:5432</port>
+                  <port>localhost:${db.port}:5432</port>
+                  <port>+docker.host.address:${db.port}:5432</port>
+                </ports>
+                <wait>
+                  <log>database system is ready to accept connections</log>
+                  <time>20000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
         </configuration>
         <executions>
           <execution>
@@ -289,6 +327,7 @@
             <phase>compile</phase>
             <goals>
               <goal>stop</goal>
+              <goal>remove</goal>
             </goals>
           </execution>
         </executions>
@@ -301,9 +340,10 @@
         <configuration>
           <changeLogFile>src/main/resources/liquibase/tenant/changelog.xml</changeLogFile>
           <driver>org.postgresql.Driver</driver>
-          <url>jdbc:postgresql://localhost:15432/postgres</url>
+          <url>jdbc:postgresql://${docker.host.address}:${db.port}/postgres</url>
           <username>postgres</username>
           <password>postgres</password>
+          <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
         </configuration>
         <dependencies>
           <dependency>
@@ -356,7 +396,7 @@
         <configuration>
           <jdbc>
             <driver>org.postgresql.Driver</driver>
-            <url>jdbc:postgresql://localhost:15432/postgres</url>
+            <url>jdbc:postgresql://${docker.host.address}:${db.port}/postgres</url>
             <user>postgres</user>
             <password>postgres</password>
           </jdbc>


### PR DESCRIPTION
## Purpose
This pull request is to resolve the issue with using Liquibase scripts that utilize later versions of PostgreSQL.

[MODSOURCE-238](https://issues.folio.org/browse/MODSOURCE-238)

## Approach
Switched outdated embedded postgres plugin with docker maven plugin.

## Learning
Learned that in order to connect from build process to docker container running in Jenkins CI you have to use container IP and default service ports. Also, that postgres connection URL allows for fallback. This was needed to allow for the build to work locally and in Jenkins.
