### PR TITLE
MODSOURCE-242: Testcontainers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [MODSOURCE-202](https://issues.folio.org/browse/MODSOURCE-202) Records stream API using reactivex.
 * [MODSOURCE-201](https://issues.folio.org/browse/MODSOURCE-201) Source Records stream API using reactivex.
 * [MODSOURCE-238](https://issues.folio.org/browse/MODSOURCE-238) Use docker-maven-plugin to support build with newer versions of postgres.
+* [MODSOURCE-242](https://issues.folio.org/browse/MODSOURCE-242) Use Testcontainers for tests.
 
 ### Stream Records API
  | METHOD |             URL                                      | DESCRIPTION                                                               |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Provides PostgreSQL based storage to complement the data import module. Written 
 
 ## Compiling
 
+> [Docker](https://www.docker.com/) is now required to build mod-source-record-storage. [docker-maven-plugin](https://dmp.fabric8.io/) is used to create a Postgres Container
+for running [Liquibase](https://www.liquibase.org/) scripts and generating [jOOQ](https://www.jooq.org/) schema DAOs for type safe SQL query building.
+
 ```
    mvn install
 ```

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -15,6 +15,7 @@
     <jooq.version>3.13.6</jooq.version>
     <vertx-jooq.version>5.2.1</vertx-jooq.version>
     <postgres.version>42.2.18</postgres.version>
+    <postgres.image>postgres:12-alpine</postgres.image>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records</generate_routing_context>
   </properties>
 
@@ -39,6 +40,12 @@
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>1.15.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -181,6 +188,18 @@
               </sources>
             </configuration>
           </execution>
+          <execution>
+            <id>reserve-db-port</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>db.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -267,26 +286,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.10</version>
-        <executions>
-          <execution>
-            <id>reserve-db-port</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <configuration>
-              <portNames>
-                <portName>db.port</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>0.34.1</version>
@@ -294,7 +293,7 @@
           <images>
             <image>
               <alias>db</alias>
-              <name>postgres:12-alpine</name>
+              <name>${postgres.image}</name>
               <run>
                 <privileged>true</privileged>
                 <containerNamePattern>%n-%t</containerNamePattern>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -455,12 +455,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.6</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.6</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-utils</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -48,10 +48,8 @@ public class PostgresClientFactory {
 
   private static final Map<String, PgPool> POOL_CACHE = new HashMap<>();
 
-  
   private static JsonObject postgresConfig;
 
-  
   private static String postgresConfigFilePath;
 
   private final Vertx vertx;

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
@@ -32,6 +32,7 @@ public class PostgresClientFactoryTest {
     PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
     assertEquals("/postgres-conf.json", PostgresClientFactory.getConfigFilePath());
     postgresClientFactory.close();
+    PostgresClientFactory.setConfigFilePath(null);
   }
 
   @Test
@@ -46,10 +47,8 @@ public class PostgresClientFactoryTest {
     assertEquals("test.password", config.getString("password"));
     assertEquals("test.database", config.getString("database"));
     postgresClientFactory.close();
-    // reset env
     Envs.setEnv(new HashMap<>());
-    // set back to default
-    PostgresClientFactory.setConfigFilePath(PostgresClient.getConfigFilePath());
+    PostgresClientFactory.setConfigFilePath(null);
   }
 
   @Test
@@ -63,16 +62,15 @@ public class PostgresClientFactoryTest {
     assertEquals("password", config.getString("password"));
     assertEquals("database", config.getString("database"));
     postgresClientFactory.close();
-    // reset env
     Envs.setEnv(new HashMap<>());
+    PostgresClientFactory.setConfigFilePath(null);
   }
 
   @Test
   public void shouldSetConfigFilePath() {
     PostgresClientFactory.setConfigFilePath("/postgres-conf-local.json");
     assertEquals("/postgres-conf-local.json", PostgresClientFactory.getConfigFilePath());
-    // set back to default
-    PostgresClientFactory.setConfigFilePath(PostgresClient.getConfigFilePath());
+    PostgresClientFactory.setConfigFilePath(null);
   }
 
   @AfterClass

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
@@ -1,0 +1,18 @@
+package org.folio.dao;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class PostgresClientFactoryTest {
+
+  @Test
+  public void shouldSetConfigFilePath() {
+    PostgresClientFactory.setConfigFilePath("/postgres-conf-local.json");
+    assertEquals("/postgres-conf-local.json", PostgresClientFactory.getConfigFilePath());
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
@@ -2,17 +2,85 @@ package org.folio.dao;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.Envs;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
 
-@RunWith(BlockJUnit4ClassRunner.class)
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
 public class PostgresClientFactoryTest {
+
+  static Vertx vertx;
+
+  @BeforeClass
+  public static void setUpClass(TestContext context) throws Exception {
+    vertx = Vertx.vertx();
+  }
+
+  @Test
+  public void shouldCreateFactoryWithDefaultConfigFilePath(TestContext context) {
+    PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+    assertEquals("/postgres-conf.json", PostgresClientFactory.getConfigFilePath());
+    postgresClientFactory.close();
+  }
+
+  @Test
+  public void shouldCreateFactoryWithTestConfig(TestContext context) {
+    PostgresClientFactory.setConfigFilePath("/postgres-conf-test.json");
+    assertEquals("/postgres-conf-test.json", PostgresClientFactory.getConfigFilePath());
+    PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+    JsonObject config = PostgresClientFactory.getConfig();
+    assertEquals("test.host", config.getString("host"));
+    assertEquals(Integer.valueOf(25432), config.getInteger("port"));
+    assertEquals("test.username", config.getString("username"));
+    assertEquals("test.password", config.getString("password"));
+    assertEquals("test.database", config.getString("database"));
+    postgresClientFactory.close();
+    // reset env
+    Envs.setEnv(new HashMap<>());
+    // set back to default
+    PostgresClientFactory.setConfigFilePath(PostgresClient.getConfigFilePath());
+  }
+
+  @Test
+  public void shouldCreateFactoryWithConfigFromSpecifiedEnvironment(TestContext context) {
+    Envs.setEnv("host", 15432, "username", "password", "database");
+    PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+    JsonObject config = PostgresClientFactory.getConfig();
+    assertEquals("host", config.getString("host"));
+    assertEquals(Integer.valueOf(15432), config.getInteger("port"));
+    assertEquals("username", config.getString("username"));
+    assertEquals("password", config.getString("password"));
+    assertEquals("database", config.getString("database"));
+    postgresClientFactory.close();
+    // reset env
+    Envs.setEnv(new HashMap<>());
+  }
 
   @Test
   public void shouldSetConfigFilePath() {
     PostgresClientFactory.setConfigFilePath("/postgres-conf-local.json");
     assertEquals("/postgres-conf-local.json", PostgresClientFactory.getConfigFilePath());
+    // set back to default
+    PostgresClientFactory.setConfigFilePath(PostgresClient.getConfigFilePath());
+  }
+
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      async.complete();
+    }));
   }
 
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/util/MarcUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/util/MarcUtilTest.java
@@ -15,11 +15,10 @@ import org.folio.rest.jaxrs.model.SourceRecord;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.marc4j.MarcException;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-
-@RunWith(VertxUnitRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class MarcUtilTest {
 
   private static final String SOURCE_RECORD_PATH = "src/test/resources/mock/sourceRecords/d3cd3e1e-a18c-4f7c-b053-9aa50343394e.json";

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -15,12 +15,14 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -32,6 +34,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.reactivex.core.Vertx;
 
 public abstract class AbstractRestVerticleTest {
+
+  private static PostgreSQLContainer<?> postgresSQLContainer;
 
   static final String TENANT_ID = "diku";
 
@@ -62,6 +66,7 @@ public abstract class AbstractRestVerticleTest {
     vertx = Vertx.vertx();
     okapiPort = NetworkUtils.nextFreePort();
     String okapiUrl = "http://localhost:" + okapiPort;
+
     useExternalDatabase = System.getProperty(
       "org.folio.source.storage.test.database",
       "embedded");
@@ -74,11 +79,20 @@ public abstract class AbstractRestVerticleTest {
         String postgresConfigPath = System.getProperty(
           "org.folio.source.storage.test.config",
           "/postgres-conf-local.json");
-        PostgresClient.setConfigFilePath(postgresConfigPath);
+        PostgresClientFactory.setConfigFilePath(postgresConfigPath);
         break;
       case "embedded":
-        PostgresClient.setIsEmbedded(true);
-        PostgresClient.getInstance(vertx.getDelegate()).startEmbeddedPostgres();
+        String postgresImage = PomReader.INSTANCE.getProps().getProperty("postgres.image");
+        postgresSQLContainer = new PostgreSQLContainer<>(postgresImage);
+        postgresSQLContainer.start();
+    
+        Envs.setEnv(
+          postgresSQLContainer.getHost(),
+          postgresSQLContainer.getFirstMappedPort(),
+          postgresSQLContainer.getUsername(),
+          postgresSQLContainer.getPassword(),
+          postgresSQLContainer.getDatabaseName()
+        );
         break;
       default:
         String message = "No understood database choice made." +
@@ -130,7 +144,7 @@ public abstract class AbstractRestVerticleTest {
     PostgresClientFactory.closeAll();
     vertx.close(context.asyncAssertSuccess(res -> {
       if (useExternalDatabase.equals("embedded")) {
-        PostgresClient.stopEmbeddedPostgres();
+        postgresSQLContainer.stop();
       }
       async.complete();
     }));

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -5,10 +5,12 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.PomReader;
+import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -17,6 +19,8 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 
 public abstract class AbstractLBServiceTest {
+
+  private static PostgreSQLContainer<?> postgresSQLContainer;
 
   static final String TENANT_ID = "diku";
 
@@ -29,11 +33,17 @@ public abstract class AbstractLBServiceTest {
     Async async = context.async();
     vertx = Vertx.vertx();
 
-    PostgresClient.setIsEmbedded(true);
+    String postgresImage = PomReader.INSTANCE.getProps().getProperty("postgres.image");
+    postgresSQLContainer = new PostgreSQLContainer<>(postgresImage);
+    postgresSQLContainer.start();
 
-    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-
-    postgresClientFactory = new PostgresClientFactory(vertx);
+    Envs.setEnv(
+      postgresSQLContainer.getHost(),
+      postgresSQLContainer.getFirstMappedPort(),
+      postgresSQLContainer.getUsername(),
+      postgresSQLContainer.getPassword(),
+      postgresSQLContainer.getDatabaseName()
+    );
 
     int port = NetworkUtils.nextFreePort();
     String okapiUrl = "http://localhost:" + port;
@@ -43,6 +53,7 @@ public abstract class AbstractLBServiceTest {
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, deployResponse -> {
       try {
         tenantClient.postTenant(new TenantAttributes().withModuleTo("3.2.0"), postTenantResponse -> {
+          postgresClientFactory = new PostgresClientFactory(vertx);
           async.complete();
         });
       } catch (Exception e) {
@@ -56,7 +67,7 @@ public abstract class AbstractLBServiceTest {
     Async async = context.async();
     PostgresClientFactory.closeAll();
     vertx.close(context.asyncAssertSuccess(res -> {
-      PostgresClient.stopEmbeddedPostgres();
+      postgresSQLContainer.stop();
       async.complete();
     }));
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -7,6 +7,7 @@ import org.folio.TestUtil;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.util.AdditionalFieldsUtil;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -214,7 +215,7 @@ public class AdditionalFieldsUtilTest {
         existsNewField = true;
         String currentTag = fields.getJsonObject(i).stream().map(Map.Entry::getKey).findFirst().get();
         String nextTag = fields.getJsonObject(i + 1).stream().map(Map.Entry::getKey).findFirst().get();
-        Assert.assertThat(currentTag, lessThanOrEqualTo(nextTag));
+        MatcherAssert.assertThat(currentTag, lessThanOrEqualTo(nextTag));
       }
     }
     Assert.assertTrue(existsNewField);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibliographicMatchEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibliographicMatchEventHandlerTest.java
@@ -13,7 +13,6 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATC
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.mockito.ArgumentMatchers.any;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -83,7 +82,6 @@ public class MarcBibliographicMatchEventHandlerTest extends AbstractLBServiceTes
   private MarcBibliographicMatchEventHandler marcBibliographicMatchEventHandler;
 
   private static RawRecord rawRecord;
-  private static ParsedRecord parsedRecord;
 
   private static String recordId = "acf4f6e2-115c-4509-9d4c-536c758ef917";
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.folio.TestMocks;

--- a/mod-source-record-storage-server/src/test/resources/postgres-conf-test.json
+++ b/mod-source-record-storage-server/src/test/resources/postgres-conf-test.json
@@ -1,0 +1,8 @@
+
+{
+  "host" : "test.host",
+  "port" : 25432,
+  "database" : "test.database",
+  "username" : "test.username",
+  "password" : "test.password"
+}


### PR DESCRIPTION
## Purpose
Switch from embedded postgres to testcontainers for tests.

[MODSOURCE-242](https://issues.folio.org/browse/MODSOURCE-242)

## Approach
Loosen dependency on RMB postgres client and resolve postgres configuration. During tests bring up postgres testcontainer instead of starting embedded postgres.
