### PR TITLE
Require pubsub.events.post

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -236,7 +236,7 @@
           ],
           "pathPattern": "/source-storage/handlers/data-import",
           "permissionsRequired": [
-            "source-storage.events.post"
+            "pubsub.events.post"
           ],
           "modulePermissions": [
             "pubsub.publish.post"
@@ -248,7 +248,7 @@
           ],
           "pathPattern": "/source-storage/handlers/updated-record",
           "permissionsRequired": [
-            "source-storage.events.post"
+            "pubsub.events.post"
           ],
           "modulePermissions": [
             "pubsub.publish.post"


### PR DESCRIPTION
This permission is renamed - defined in mod-pubsub. See https://issues.folio.org/browse/MODPUBSUB-145
