### PR TITLE
Update interface versions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -228,7 +228,7 @@
     },
     {
       "id": "source-storage-event-handlers",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [

--- a/ramls/source-record-storage-handlers.raml
+++ b/ramls/source-record-storage-handlers.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Event Handlers API
-version: v0.1
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/source-record-storage-records.raml
+++ b/ramls/source-record-storage-records.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Record API
-version: v3.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/source-record-storage-snapshots.raml
+++ b/ramls/source-record-storage-snapshots.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Snapshot API
-version: v3.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/source-record-storage-source-records.raml
+++ b/ramls/source-record-storage-source-records.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Source Record API
-version: v3.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/source-record-storage-test-records.raml
+++ b/ramls/source-record-storage-test-records.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Source Record Storage Test Record API
-version: v3.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 


### PR DESCRIPTION
## Purpose
* source-storage-event-handlers API version needs to be bumped as /source-storage/handlers/data-import endpoint was removed 
* versions declared in the ModuleDescriptor should match versions in raml
