### PR TITLE
MODSOURSE-250: Make tenant API asynchronous.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * [MODSOURCE-225](https://issues.folio.org/browse/MODSOURCE-225) Add personal data disclosure.
 * [MODSOURCE-225](https://issues.folio.org/browse/MODSOURCE-225) Add personal data disclosure.
 * [MODSOURCE-239](https://issues.folio.org/browse/MODSOURCE-239) Upgrade to RAML Module Builder 32.x.
+* [MODSOURCE-250](https://issues.folio.org/browse/MODSOURCE-250) Make tenant API asynchronous.
 
 
 ### Stream Records API

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -696,6 +696,11 @@
             <LC_CTYPE>en_US.UTF-8</LC_CTYPE>
             <LANG>en_US</LANG>
           </environmentVariables>
+          <argLine>
+            --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
+            --illegal-access=warn
+          </argLine>
         </configuration>
       </plugin>
 

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -255,6 +255,12 @@
       <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-testng</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -243,6 +243,18 @@
       <artifactId>postgresql</artifactId>
       <version>42.2.18</version>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -51,12 +51,6 @@ public class ModTenantAPI extends TenantAPI {
     this.tenantId = TenantTool.calculateTenantId(tenantId);
   }
 
-  @Validate
-  @Override
-  public void postTenant(TenantAttributes tenantAttributes, Map<String, String> headers, Handler<AsyncResult<Response>> handler, Context context) {
-    super.postTenantSync(tenantAttributes, headers, handler, context);
-  }
-
   @Override
   Future<Integer> loadData(TenantAttributes attributes, String tenantId,
                            Map<String, String> headers, Context context) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -5,6 +5,7 @@ import static org.folio.rest.impl.ModTenantAPI.LOAD_SAMPLE_PARAMETER;
 
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -24,11 +25,19 @@ import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.util.OkapiConnectionParams;
+import org.folio.util.pubsub.PubSubClientUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.restassured.RestAssured;
@@ -43,6 +52,9 @@ import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
 import io.vertx.reactivex.core.Vertx;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PubSubClientUtils.class)
+@PowerMockIgnore({"org.mockito.*"})
 public abstract class AbstractRestVerticleTest {
 
   private static PostgreSQLContainer<?> postgresSQLContainer;
@@ -130,6 +142,11 @@ public abstract class AbstractRestVerticleTest {
     TenantClient tenantClient = new TenantClient(okapiUrl, "diku", "dummy-token");
     DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", okapiPort));
+
+    PowerMockito.mockStatic(PubSubClientUtils.class);
+    PowerMockito.when(PubSubClientUtils.registerModule(Mockito.any(OkapiConnectionParams.class)))
+      .thenReturn(CompletableFuture.completedFuture(true));
+
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, res -> {
       try {
         tenantClient.postTenant(new TenantAttributes()

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -38,6 +38,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.restassured.RestAssured;
@@ -55,7 +56,7 @@ import io.vertx.reactivex.core.Vertx;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(PubSubClientUtils.class)
 @PowerMockIgnore({"org.mockito.*"})
-public abstract class AbstractRestVerticleTest {
+public abstract class AbstractRestVerticleTest extends PowerMockTestCase {
 
   private static PostgreSQLContainer<?> postgresSQLContainer;
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -11,8 +11,16 @@ import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.util.OkapiConnectionParams;
+import org.folio.util.pubsub.PubSubClientUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.core.DeploymentOptions;
@@ -25,6 +33,11 @@ import org.junit.ClassRule;
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
 
+import java.util.concurrent.CompletableFuture;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PubSubClientUtils.class)
+@PowerMockIgnore({"org.mockito.*"})
 public abstract class AbstractLBServiceTest {
 
   private static final String KAFKA_HOST = "KAFKA_HOST";
@@ -81,6 +94,11 @@ public abstract class AbstractLBServiceTest {
     TenantClient tenantClient = new TenantClient(okapiUrl, "diku", "dummy-token");
     DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", port));
+
+    PowerMockito.mockStatic(PubSubClientUtils.class);
+    PowerMockito.when(PubSubClientUtils.registerModule(Mockito.any(OkapiConnectionParams.class)))
+      .thenReturn(CompletableFuture.completedFuture(true));
+
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, deployResponse -> {
       try {
         tenantClient.postTenant(new TenantAttributes().withModuleTo("3.2.0"), res2 -> {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -7,6 +7,7 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -82,8 +83,22 @@ public abstract class AbstractLBServiceTest {
       .setConfig(new JsonObject().put("http.port", port));
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, deployResponse -> {
       try {
-        tenantClient.postTenant(new TenantAttributes().withModuleTo("3.2.0"), postTenantResponse -> {
+        tenantClient.postTenant(new TenantAttributes().withModuleTo("3.2.0"), res2 -> {
           postgresClientFactory = new PostgresClientFactory(vertx);
+          if (res2.result().statusCode() == 204) {
+            return;
+          }
+          if (res2.result().statusCode() == 201) {
+            tenantClient.getTenantByOperationId(res2.result().bodyAsJson(TenantJob.class).getId(), 60000, context.asyncAssertSuccess(res3 -> {
+              context.assertTrue(res3.bodyAsJson(TenantJob.class).getComplete());
+              String error = res3.bodyAsJson(TenantJob.class).getError();
+              if (error != null) {
+                context.assertEquals("Failed to make post tenant. Received status code 400", error);
+              }
+            }));
+          } else {
+            context.assertEquals("Failed to make post tenant. Received status code 400", res2.result().bodyAsString());
+          }
           async.complete();
         });
       } catch (Exception e) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -21,6 +21,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.core.DeploymentOptions;
@@ -38,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(PubSubClientUtils.class)
 @PowerMockIgnore({"org.mockito.*"})
-public abstract class AbstractLBServiceTest {
+public abstract class AbstractLBServiceTest extends PowerMockTestCase {
 
   private static final String KAFKA_HOST = "KAFKA_HOST";
   private static final String KAFKA_PORT = "KAFKA_PORT";

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
         <version>2.22.2</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <argLine>
+            --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
+            --illegal-access=warn
+          </argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Purpose
Avoid calling postTenantSync and update the tests to reflect it.

## Approach
Remove overriding postTenant(), leave only loadData(). Some tests added.

## Learning
More info: https://issues.folio.org/browse/MODSOURCE-250
