### PR TITLE
MODSOURCE-249: Receive event with parsed EDIFACT records

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -18,7 +18,7 @@ import org.folio.services.handlers.MarcBibliographicMatchEventHandler;
 import org.folio.services.handlers.actions.ModifyRecordEventHandler;
 import org.folio.spring.SpringContextUtil;
 import org.folio.verticle.consumers.DataImportConsumersVerticle;
-import org.folio.verticle.consumers.ParsedMarcChunkConsumersVerticle;
+import org.folio.verticle.consumers.ParsedRecordChunkConsumersVerticle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -70,13 +70,13 @@ public class InitAPIImpl implements InitAPI {
 
   private Future<?> deployConsumerVerticles(Vertx vertx) {
     //TODO: get rid of this workaround with global spring context
-    ParsedMarcChunkConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
+    ParsedRecordChunkConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
     DataImportConsumersVerticle.setSpringGlobalContext(vertx.getOrCreateContext().get("springContext"));
 
     Promise<String> deployConsumer1 = Promise.promise();
     Promise<String> deployConsumer2 = Promise.promise();
 
-    vertx.deployVerticle("org.folio.verticle.consumers.ParsedMarcChunkConsumersVerticle",
+    vertx.deployVerticle("org.folio.verticle.consumers.ParsedRecordChunkConsumersVerticle",
       new DeploymentOptions().setWorker(true).setInstances(parsedMarcChunkConsumerInstancesNumber), deployConsumer1);
 
     vertx.deployVerticle("org.folio.verticle.consumers.DataImportConsumersVerticle",

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedMarcChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedMarcChunksKafkaHandler.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
 
 @Component
 @Qualifier("ParsedMarcChunksKafkaHandler")
@@ -90,7 +90,7 @@ public class ParsedMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
     try {
       event = new Event()
         .withId(UUID.randomUUID().toString())
-        .withEventType(DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value())
+        .withEventType(DI_PARSED_RECORDS_CHUNK_SAVED.value())
         .withEventPayload(ZIPArchiver.zip(Json.encode(normalize(recordsBatchResponse))))
         .withEventMetadata(new EventMetadata()
           .withTenantId(tenantId)
@@ -104,7 +104,7 @@ public class ParsedMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
     String key = String.valueOf(indexer.incrementAndGet() % maxDistributionNum);
 
     String topicName = KafkaTopicNameHelper.formatTopicName(kafkaConfig.getEnvId(), KafkaTopicNameHelper.getDefaultNameSpace(),
-      tenantId, DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED.value());
+      tenantId, DI_PARSED_RECORDS_CHUNK_SAVED.value());
 
     KafkaProducerRecord<String, String> record =
       KafkaProducerRecord.create(topicName, key, Json.encode(event));
@@ -113,7 +113,7 @@ public class ParsedMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
 
     Promise<String> writePromise = Promise.promise();
 
-    String producerName = DI_PARSED_MARC_BIB_RECORDS_CHUNK_SAVED + "_Producer";
+    String producerName = DI_PARSED_RECORDS_CHUNK_SAVED + "_Producer";
     KafkaProducer<String, String> producer =
       KafkaProducer.createShared(Vertx.currentContext().owner(), producerName, kafkaConfig.getProducerProps());
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedRecordChunksKafkaHandler.java
@@ -37,8 +37,8 @@ import java.util.stream.Collectors;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
 
 @Component
-@Qualifier("ParsedMarcChunksKafkaHandler")
-public class ParsedMarcChunksKafkaHandler implements AsyncRecordHandler<String, String> {
+@Qualifier("ParsedRecordChunksKafkaHandler")
+public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String, String> {
   private static final Logger LOGGER = LogManager.getLogger();
 
   private static final AtomicInteger chunkCounter = new AtomicInteger();
@@ -48,12 +48,13 @@ public class ParsedMarcChunksKafkaHandler implements AsyncRecordHandler<String, 
   private Vertx vertx;
   private KafkaConfig kafkaConfig;
 
-  @Value("${srs.kafka.ParsedMarcChunksKafkaHandler.maxDistributionNum:100}")
+  // TODO: refactor srs.kafka.ParsedRecordChunksKafkaHandler
+  @Value("${srs.kafka.ParsedRecordChunksKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
 
-  public ParsedMarcChunksKafkaHandler(@Autowired RecordService recordService,
-                                      @Autowired Vertx vertx,
-                                      @Autowired KafkaConfig kafkaConfig) {
+  public ParsedRecordChunksKafkaHandler(@Autowired RecordService recordService,
+                                        @Autowired Vertx vertx,
+                                        @Autowired KafkaConfig kafkaConfig) {
     this.recordService = recordService;
     this.vertx = vertx;
     this.kafkaConfig = kafkaConfig;

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedMarcChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedMarcChunkConsumersVerticle.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.support.AbstractApplicationContext;
 
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_MARC_BIB_RECORDS_CHUNK_PARSED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 
 public class ParsedMarcChunkConsumersVerticle extends AbstractVerticle {
   //TODO: get rid of this workaround with global spring context
@@ -42,7 +42,7 @@ public class ParsedMarcChunkConsumersVerticle extends AbstractVerticle {
     SpringContextUtil.autowireDependencies(this, context);
 
     SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition(kafkaConfig.getEnvId(),
-      KafkaTopicNameHelper.getDefaultNameSpace(), DI_RAW_MARC_BIB_RECORDS_CHUNK_PARSED.value());
+      KafkaTopicNameHelper.getDefaultNameSpace(), DI_RAW_RECORDS_CHUNK_PARSED.value());
 
     consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
       .context(context)

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticle.java
@@ -17,15 +17,15 @@ import org.springframework.context.support.AbstractApplicationContext;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_RAW_RECORDS_CHUNK_PARSED;
 
-public class ParsedMarcChunkConsumersVerticle extends AbstractVerticle {
+public class ParsedRecordChunkConsumersVerticle extends AbstractVerticle {
   //TODO: get rid of this workaround with global spring context
   private static AbstractApplicationContext springGlobalContext;
 
   private static final GlobalLoadSensor globalLoadSensor = new GlobalLoadSensor();
 
   @Autowired
-  @Qualifier("ParsedMarcChunksKafkaHandler")
-  private AsyncRecordHandler<String, String> parsedMarcChunksKafkaHandler;
+  @Qualifier("ParsedRecordChunksKafkaHandler")
+  private AsyncRecordHandler<String, String> parsedRecordChunksKafkaHandler;
 
   @Autowired
   private KafkaConfig kafkaConfig;
@@ -53,7 +53,7 @@ public class ParsedMarcChunkConsumersVerticle extends AbstractVerticle {
       .subscriptionDefinition(subscriptionDefinition)
       .build();
 
-    consumerWrapper.start(parsedMarcChunksKafkaHandler, PomReader.INSTANCE.getModuleName()).onComplete(sar -> {
+    consumerWrapper.start(parsedRecordChunksKafkaHandler, PomReader.INSTANCE.getModuleName()).onComplete(sar -> {
       if (sar.succeeded()) {
         startPromise.complete();
       } else {
@@ -69,7 +69,7 @@ public class ParsedMarcChunkConsumersVerticle extends AbstractVerticle {
 
   @Deprecated
   public static void setSpringGlobalContext(AbstractApplicationContext springGlobalContext) {
-    ParsedMarcChunkConsumersVerticle.springGlobalContext = springGlobalContext;
+    ParsedRecordChunkConsumersVerticle.springGlobalContext = springGlobalContext;
   }
 
 }


### PR DESCRIPTION
Resolves [MODSOURCE-249](https://issues.folio.org/browse/MODSOURCE-249)

Requires https://github.com/folio-org/data-import-raml-storage/pull/207

- [x] update ParsedMarcChunkConsumersVerticle to create kafka consumer for DI_RAW_RECORDS_CHUNK_PARSED event and save records of any types (MARC/EDIFACT)
- [ ] add tests