### PR TITLE
Fix Unit test: Not equals : MARC != EDIFACT MODSOURCE-251

### DIFF
--- a/mod-source-record-storage-server/src/test/java/org/folio/TestMocks.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/TestMocks.java
@@ -70,12 +70,20 @@ public class TestMocks {
     return clone(records.get(index));
   }
 
-  public static Record getEdifactRecord() {
+  public static Record getRecords(RecordType type) {
     return records.stream()
-      .filter(s -> s.getRecordType().equals(RecordType.EDIFACT))
+      .filter(s -> s.getRecordType().equals(type))
       .map(TestMocks::clone)
       .findFirst()
       .get();
+  }
+
+  public static Record getMarcRecord() {
+    return getRecords(RecordType.MARC);
+  }
+
+  public static Record getEdifactRecord() {
+    return getRecords(RecordType.EDIFACT);
   }
 
   public static List<ErrorRecord> getErrorRecords() {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -256,7 +256,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldSaveMarcRecord(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordService.saveRecord(expected, TENANT_ID).onComplete(save -> {
       if (save.failed()) {
         context.fail(save.cause());

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -220,7 +220,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetRecordById(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordDao.saveRecord(expected, TENANT_ID).onComplete(save -> {
       if (save.failed()) {
         context.fail(save.cause());
@@ -727,7 +727,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetSourceRecordById(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordDao.saveRecord(expected, TENANT_ID).onComplete(save -> {
       if (save.failed()) {
         context.fail(save.cause());
@@ -750,7 +750,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldNotGetSourceRecordById(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordService.getSourceRecordById(expected.getExternalIdsHolder().getInstanceId(), ExternalIdType.INSTANCE, TENANT_ID).onComplete(get -> {
       if (get.failed()) {
         context.fail(get.cause());
@@ -808,7 +808,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetFormattedMarcRecord(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordDao.saveRecord(expected, TENANT_ID).onComplete(save -> {
       if (save.failed()) {
         context.fail(save.cause());
@@ -846,7 +846,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldUpdateSuppressFromDiscoveryForRecord(TestContext context) {
     Async async = context.async();
-    Record expected = TestMocks.getRecord(0);
+    Record expected = TestMocks.getMarcRecord();
     recordDao.saveRecord(expected, TENANT_ID).onComplete(save -> {
       if (save.failed()) {
         context.fail(save.cause());


### PR DESCRIPTION
See https://issues.folio.org/browse/MODSOURCE-251 . Only a PR which changes tests a bit.

Problem with existing test was that it assumes all records in there were MARC. Well. They were,.. but one.
