### PR TITLE
MODSOURCE-248: Incoming MARC Bib with 003, but no 001 should not create an 035 [BUGFIX].

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * [MODSOURCE-225](https://issues.folio.org/browse/MODSOURCE-225) Add personal data disclosure.
 * [MODSOURCE-239](https://issues.folio.org/browse/MODSOURCE-239) Upgrade to RAML Module Builder 32.x.
 * [MODSOURCE-250](https://issues.folio.org/browse/MODSOURCE-250) Make tenant API asynchronous.
+* [MODSOURCE-248](https://issues.folio.org/browse/MODSOURCE-248) Incoming MARC Bib with 003, but no 001 should not create an 035[BUGFIX].
 
 
 ### Stream Records API

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -302,6 +302,7 @@ public final class AdditionalFieldsUtil {
    */
   public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair) {
     String hrId = recordInstancePair.getValue().getString(HR_ID_FIELD);
+    String valueFrom001 = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrId = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrIdPrefix = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
     originalHrId = mergeFieldsFor035(originalHrIdPrefix, originalHrId);
@@ -309,7 +310,7 @@ public final class AdditionalFieldsUtil {
       removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
       removeField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
       addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
-      if (!isFieldExist(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_SUB, originalHrId)) {
+      if (valueFrom001 != null && !isFieldExist(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_SUB, originalHrId)) {
         addDataFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, originalHrId);
       }
     } else if (StringUtils.isNotEmpty(hrId)) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -7,7 +7,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.TestUtil;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.util.AdditionalFieldsUtil;
@@ -17,6 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -236,6 +239,22 @@ public class AdditionalFieldsUtilTest {
     boolean added = AdditionalFieldsUtil.addDataFieldToMarcRecord(record, "999", 'f', 'f', 'i', instanceId);
     // then
     Assert.assertTrue(added);
+    Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
+  }
+
+  @Test
+  public void shouldNotAdd035AndAdd001FieldsIf001And003FieldsNotExists() {
+    // given
+    String parsedContent = "{\"leader\":\"00115nam  22000731a 4500\",\"fields\":[{\"003\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00086nam  22000611a 4500\",\"fields\":[{\"001\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    ParsedRecord parsedRecord = new ParsedRecord();
+    parsedRecord.setContent(parsedContent);
+    Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord).withGeneration(0).withState(Record.State.ACTUAL).withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+    JsonObject jsonObject = new JsonObject("{\"hrid\":\"in001\"}");
+    Pair<Record, JsonObject> pair = Pair.of(record, jsonObject);
+    // when
+    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair);
+    // then
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
   }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -249,7 +248,13 @@ public class AdditionalFieldsUtilTest {
     String expectedParsedContent = "{\"leader\":\"00086nam  22000611a 4500\",\"fields\":[{\"001\":\"in001\"},{\"507\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"500\":{\"subfields\":[{\"a\":\"data\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     ParsedRecord parsedRecord = new ParsedRecord();
     parsedRecord.setContent(parsedContent);
-    Record record = new Record().withId(UUID.randomUUID().toString()).withParsedRecord(parsedRecord).withGeneration(0).withState(Record.State.ACTUAL).withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
+    Record record = new Record().withId(UUID.randomUUID().toString())
+      .withParsedRecord(parsedRecord)
+      .withGeneration(0)
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId("001").withInstanceHrid("in001"));
+
     JsonObject jsonObject = new JsonObject("{\"hrid\":\"in001\"}");
     Pair<Record, JsonObject> pair = Pair.of(record, jsonObject);
     // when


### PR DESCRIPTION
## Purpose
When a MARC record is imported and creates an SRS MARC Bib, if the MARC record has an 003 but no 001, then it should NOT create an 035.

## Approach
Additional condition added.

## Learning
More info: https://issues.folio.org/browse/MODSOURCE-248
Should be merged with https://github.com/folio-org/mod-source-record-manager/pull/389
