### PR TITLE
MODSOURCE-255 - Return HTTP response according to the schema

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -56,7 +56,7 @@ public interface RecordDao {
 
 
   /**
-   * Stream {@link Record id} of the marc record by search expressions with offset and limit
+   * Stream {@link Record instanceId} of the marc record by search expressions with offset and limit
    *
    * @param parseLeaderResult     result of parsing leaderSearchExpression
    * @param parseFieldsResult     result of parsing fieldsSearchExpression

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -67,7 +67,7 @@ public interface RecordDao {
    * @param tenantId              tenant id
    * @return {@link Flowable} of {@link Record id}
    */
-  Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, int offset, int limit, String tenantId);
+  Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
 
   /**
    * Searches for {@link Record} by id

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import io.vertx.sqlclient.Row;
 import org.folio.dao.util.ExternalIdType;
 import org.folio.dao.util.RecordType;
 import org.folio.rest.jaxrs.model.ParsedRecord;
@@ -56,7 +57,7 @@ public interface RecordDao {
 
 
   /**
-   * Stream {@link Record instanceId} of the marc record by search expressions with offset and limit
+   * Stream [instanceId, totalCount] of the marc record by search expressions with offset and limit
    *
    * @param parseLeaderResult     result of parsing leaderSearchExpression
    * @param parseFieldsResult     result of parsing fieldsSearchExpression
@@ -67,7 +68,7 @@ public interface RecordDao {
    * @param tenantId              tenant id
    * @return {@link Flowable} of {@link Record id}
    */
-  Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
+  Flowable<Row> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
 
   /**
    * Searches for {@link Record} by id

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -47,7 +47,6 @@ import org.jooq.JSONB;
 import org.jooq.Name;
 import org.jooq.OrderField;
 import org.jooq.Record2;
-import org.jooq.SelectHavingStep;
 import org.jooq.SelectJoinStep;
 import org.jooq.SortOrder;
 import org.jooq.Table;
@@ -93,8 +92,6 @@ import static org.jooq.impl.DSL.countDistinct;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.name;
-import static org.jooq.impl.DSL.select;
-import static org.jooq.impl.DSL.selectCount;
 import static org.jooq.impl.DSL.table;
 import static org.jooq.impl.DSL.trueCondition;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -192,7 +192,7 @@ public class RecordDaoImpl implements RecordDao {
 
   @Override
   public Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId) {
-    Field<?>[] recordFields = new Field<?>[]{RECORDS_LB.ID};
+    Field<?>[] recordFields = new Field<?>[]{RECORDS_LB.INSTANCE_ID};
     SelectJoinStep step = DSL.selectDistinct(recordFields).from(RECORDS_LB);
     appendJoin(step, parseLeaderResult, parseFieldsResult);
     appendWhere(step, parseLeaderResult, parseFieldsResult, deleted, suppress);

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -191,12 +191,18 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, int offset, int limit, String tenantId) {
+  public Flowable<String> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId) {
     Field<?>[] recordFields = new Field<?>[]{RECORDS_LB.ID};
     SelectJoinStep step = DSL.selectDistinct(recordFields).from(RECORDS_LB);
     appendJoin(step, parseLeaderResult, parseFieldsResult);
     appendWhere(step, parseLeaderResult, parseFieldsResult, deleted, suppress);
-    String sql = step.offset(offset).limit(limit).getSQL(ParamType.INLINED);
+    if (offset != null) {
+      step.offset(offset);
+    }
+    if (limit != null) {
+      step.limit(limit);
+    }
+    String sql = step.getSQL(ParamType.INLINED);
 
     return getCachedPool(tenantId)
       .rxGetConnection()

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageStreamImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageStreamImpl.java
@@ -1,5 +1,38 @@
 package org.folio.rest.impl;
 
+import io.reactivex.Flowable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.Json;
+import io.vertx.core.streams.Pump;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.reactivex.FlowableHelper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dataimport.util.ExceptionHelper;
+import org.folio.rest.jaxrs.model.MarcRecordSearchRequest;
+import org.folio.rest.jaxrs.resource.SourceStorageStream;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.services.RecordService;
+import org.folio.spring.SpringContextUtil;
+import org.jooq.Condition;
+import org.jooq.OrderField;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
 import static io.netty.util.internal.StringUtil.COMMA;
 import static io.vertx.core.http.HttpHeaders.CONNECTION;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
@@ -14,41 +47,6 @@ import static org.folio.dao.util.RecordDaoUtil.filterRecordBySuppressFromDiscove
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByUpdatedDateRange;
 import static org.folio.dao.util.RecordDaoUtil.toRecordOrderFields;
 import static org.folio.rest.util.QueryParamUtil.toRecordType;
-
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
-import javax.ws.rs.core.Response;
-
-import org.apache.commons.lang3.StringUtils;
-import org.folio.dataimport.util.ExceptionHelper;
-import org.folio.rest.jaxrs.model.MarcRecordSearchRequest;
-import org.folio.rest.jaxrs.resource.SourceStorageStream;
-import org.folio.rest.tools.utils.TenantTool;
-import org.folio.services.RecordService;
-import org.folio.spring.SpringContextUtil;
-import org.jooq.Condition;
-import org.jooq.OrderField;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import io.reactivex.Flowable;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.Json;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import io.vertx.core.streams.Pump;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.reactivex.FlowableHelper;
 
 public class SourceStorageStreamImpl implements SourceStorageStream {
 
@@ -109,10 +107,14 @@ public class SourceStorageStreamImpl implements SourceStorageStream {
   @Override
   public void postSourceStorageStreamMarcRecordIdentifiers(MarcRecordSearchRequest request, RoutingContext routingContext, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     HttpServerResponse response = prepareStreamResponse(routingContext);
-    // will fix the default values in schema
-    int offset = request.getOffset() == null ? 0 : request.getOffset();
-    int limit = request.getLimit() == null ? 10_000_000 : request.getLimit();
-    Flowable<Buffer> flowable = recordService.streamMarcRecordIds(request.getLeaderSearchExpression(), request.getFieldsSearchExpression(), request.getDeleted(), request.getSuppressFromDiscovery(), offset, limit, tenantId)
+    Flowable<Buffer> flowable = recordService.streamMarcRecordIds(
+      request.getLeaderSearchExpression(),
+      request.getFieldsSearchExpression(),
+      request.getDeleted(),
+      request.getSuppressFromDiscovery(),
+      request.getOffset(),
+      request.getLimit(),
+      tenantId)
       .map(Json::encodeToBuffer)
       .map(buffer -> buffer.appendString(COMMA + StringUtils.LF));
     processStream(response, flowable, cause -> {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
@@ -7,17 +7,25 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.sqlclient.Row;
+
 import static java.lang.String.format;
 
+/**
+ * The stream needed to build HTTP response following the pre-defined schema:
+ * {
+ *    "records" : array of instance UUIDs,
+ *    "totalCount" : integer
+ * }
+ */
 public class SearchRecordIdsWriteStream implements WriteStream<Row> {
   private final HttpServerResponse delegate;
-  private int writeIndex = 0;
-  private int totalCount = 0;
-  private String COMMA = ",";
-  private String DOUBLE_QUOTE = "\"";
   private final String emptyResponse = "{\n  \"records\" : [ ],\n  \"totalCount\" : 0\n}";
   private final String responseBeginning = "{\n  \"records\" : [%s";
   private final String responseEnding = "],\n  \"totalCount\" : %s\n}";
+  private final String COMMA = ",";
+  private final String DOUBLE_QUOTE = "\"";
+  private int writeIndex = 0;
+  private int totalCount = 0;
 
   public SearchRecordIdsWriteStream(HttpServerResponse delegate) {
     this.delegate = delegate;

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
@@ -35,7 +35,7 @@ public class SearchRecordIdsWriteStream implements WriteStream<Row> {
   public Future<Void> write(Row row) {
     String instanceId = row.getUUID("instance_id").toString();
     if (writeIndex == 0) {
-      this.totalCount = row.getInteger("totalCount");
+      this.totalCount = row.getInteger("count");
       this.writeIndex++;
       return this.delegate.write(format(responseBeginning, DOUBLE_QUOTE + instanceId + DOUBLE_QUOTE));
     } else {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/wrapper/SearchRecordIdsWriteStream.java
@@ -1,0 +1,83 @@
+package org.folio.rest.impl.wrapper;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.sqlclient.Row;
+import static java.lang.String.format;
+
+public class SearchRecordIdsWriteStream implements WriteStream<Row> {
+  private final HttpServerResponse delegate;
+  private int writeIndex = 0;
+  private int totalCount = 0;
+  private String COMMA = ",";
+  private String DOUBLE_QUOTE = "\"";
+  private final String emptyResponse = "{\n  \"records\" : [ ],\n  \"totalCount\" : 0\n}";
+  private final String responseBeginning = "{\n  \"records\" : [%s";
+  private final String responseEnding = "],\n  \"totalCount\" : %s\n}";
+
+  public SearchRecordIdsWriteStream(HttpServerResponse delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Future<Void> write(Row row) {
+    String instanceId = row.getUUID("instance_id").toString();
+    if (writeIndex == 0) {
+      this.totalCount = row.getInteger("totalCount");
+      this.writeIndex++;
+      return this.delegate.write(format(responseBeginning, DOUBLE_QUOTE + instanceId + DOUBLE_QUOTE));
+    } else {
+      this.writeIndex++;
+      return this.delegate.write(COMMA + DOUBLE_QUOTE + instanceId + DOUBLE_QUOTE);
+    }
+  }
+
+  @Override
+  public void write(Row row, Handler<AsyncResult<Void>> handler) {
+    throw new UnsupportedOperationException("The method is not supported");
+  }
+
+  @Override
+  public void end(Handler<AsyncResult<Void>> handler) {
+    if (this.totalCount == 0) {
+      this.delegate.write(emptyResponse).onSuccess(ar -> {
+        this.delegate.end(handler);
+      });
+    } else {
+      this.delegate.write(format(responseEnding, totalCount)).onSuccess(ar -> {
+        this.delegate.end(handler);
+      });
+    }
+  }
+
+  @Override
+  public WriteStream<Row> exceptionHandler(Handler<Throwable> handler) {
+    delegate.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public WriteStream<Row> setWriteQueueMaxSize(int maxSize) {
+    delegate.setWriteQueueMaxSize(maxSize);
+    return this;
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return delegate.writeQueueFull();
+  }
+
+  @Override
+  public WriteStream<Row> drainHandler(@Nullable Handler<Void> handler) {
+    delegate.drainHandler(handler);
+    return this;
+  }
+
+  public void close() {
+    this.delegate.close();
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -121,7 +121,7 @@ public interface RecordService {
    * @param tenantId            tenant id
    * @return {@link Flowable} of {@link Record id}
    */
-  Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, int offset, int limit, String tenantId);
+  Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
   /**
    * Searches for {@link SourceRecord} where id in a list of ids defined by id type. i.e. INSTANCE or RECORD
    *

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import io.vertx.sqlclient.Row;
 import org.folio.dao.util.ExternalIdType;
 import org.folio.dao.util.RecordType;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
@@ -110,7 +111,7 @@ public interface RecordService {
   Flowable<SourceRecord> streamSourceRecords(Condition condition, RecordType recordType, Collection<OrderField<?>> orderFields, int offset, int limit, String tenantId);
 
   /**
-   * Stream {@link Record instanceId} of the marc record by search expressions with offset and limit
+   * Stream [instanceId, totalCount]  of the marc record by search expressions with offset and limit
    *
    * @param leaderExpression    expression to search by the leader of marc records
    * @param fieldsExpression    expression to search by the marc fields of marc records
@@ -121,7 +122,7 @@ public interface RecordService {
    * @param tenantId            tenant id
    * @return {@link Flowable} of {@link Record id}
    */
-  Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
+  Flowable<Row> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId);
   /**
    * Searches for {@link SourceRecord} where id in a list of ids defined by id type. i.e. INSTANCE or RECORD
    *

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -110,7 +110,7 @@ public interface RecordService {
   Flowable<SourceRecord> streamSourceRecords(Condition condition, RecordType recordType, Collection<OrderField<?>> orderFields, int offset, int limit, String tenantId);
 
   /**
-   * Stream {@link Record id} of the marc record by search expressions with offset and limit
+   * Stream {@link Record instanceId} of the marc record by search expressions with offset and limit
    *
    * @param leaderExpression    expression to search by the leader of marc records
    * @param fieldsExpression    expression to search by the marc fields of marc records

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -130,7 +130,7 @@ public class RecordServiceImpl implements RecordService {
   }
 
   @Override
-  public Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, int offset, int limit, String tenantId) {
+  public Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId) {
     if (leaderExpression == null && fieldsExpression == null) {
       throw new IllegalArgumentException("The 'leaderSearchExpression' and the 'fieldsSearchExpression' are missing");
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -3,6 +3,7 @@ package org.folio.services;
 import io.reactivex.Flowable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.RecordDao;
@@ -130,7 +131,7 @@ public class RecordServiceImpl implements RecordService {
   }
 
   @Override
-  public Flowable<String> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId) {
+  public Flowable<Row> streamMarcRecordIds(String leaderExpression, String fieldsExpression, Boolean deleted, Boolean suppress, Integer offset, Integer limit, String tenantId) {
     if (leaderExpression == null && fieldsExpression == null) {
       throw new IllegalArgumentException("The 'leaderSearchExpression' and the 'fieldsSearchExpression' are missing");
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/Lexicon.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/Lexicon.java
@@ -2,7 +2,7 @@ package org.folio.services.util.parser.lexeme;
 
 public enum Lexicon {
   MARC_FIELD("^[0-9].*$"),
-  LEADER_FIELD("p_"),
+  LEADER_FIELD("^p_.*"),
   OPENED_BRACKET("("),
   CLOSED_BRACKET(")"),
   OPERATOR_AND("and"),

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -40,7 +40,6 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -1022,7 +1021,8 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .withParsedRecord(record_2.getParsedRecord())
       .withMatchedId(record_2.getMatchedId())
       .withState(Record.State.ACTUAL)
-      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true));
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withExternalIdsHolder(record_2.getExternalIdsHolder());
     postSnapshots(testContext, snapshot_2);
     postRecords(testContext, suppressedRecord);
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1050,7 +1050,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
     assertEquals(0, responseBody.getJsonArray("records").size());
-    assertEquals(0, responseBody.getInteger("totalCount").intValue());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1086,7 +1086,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     postSnapshots(testContext, snapshot_2);
     postRecords(testContext, record_2);
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-    searchRequest.setFieldsSearchExpression("001.value = '393893' and 005.value ^= '2014110' and 035.ind1 = '#'");
+    searchRequest.setFieldsSearchExpression("001.value = '393893'");
     searchRequest.setOffset(1);
     // when
     ExtractableResponse<Response> response = RestAssured.given()
@@ -1100,7 +1100,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
     assertEquals(0, responseBody.getJsonArray("records").size());
-    assertEquals(0, responseBody.getInteger("totalCount").intValue());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1,16 +1,12 @@
 package org.folio.rest.impl;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -20,7 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -802,12 +797,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(EMPTY, responseBody);
+    assertEquals(0, responseBody.getJsonArray("records").size());
+    assertEquals(0, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -827,13 +821,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -853,13 +845,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -880,14 +870,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -922,12 +909,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(EMPTY, responseBody);
+    assertEquals(0, responseBody.getJsonArray("records").size());
+    assertEquals(0, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -963,13 +949,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1000,12 +984,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(EMPTY, responseBody);
+    assertEquals(0, responseBody.getJsonArray("records").size());
+    assertEquals(0, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1038,13 +1021,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1065,12 +1046,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(EMPTY, responseBody);
+    assertEquals(0, responseBody.getJsonArray("records").size());
+    assertEquals(0, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1091,13 +1071,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
-    String[] ids = responseBody.split(",");
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, ids.length);
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 
@@ -1118,12 +1096,11 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .post("/source-storage/stream/marc-record-identifiers")
       .then()
       .extract();
-    String responseBody = new BufferedReader(new InputStreamReader(response.asInputStream(), StandardCharsets.UTF_8))
-      .lines()
-      .collect(Collectors.joining(","));
+    JsonObject responseBody = new JsonObject(response.body().asString());
     // then
     assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(EMPTY, responseBody);
+    assertEquals(0, responseBody.getJsonArray("records").size());
+    assertEquals(0, responseBody.getInteger("totalCount").intValue());
     async.complete();
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -131,7 +131,7 @@ public class SearchExpressionParserUnitTest {
       parseFieldsSearchExpression(fieldsSearchExpression);
     });
     // then
-    String expectedMessage = "The given expression part xxx.a is not parsable";
+    String expectedMessage = "The given expression [xxx.a = '1'] is not parsable";
     String actualMessage = exception.getMessage();
     assertEquals(expectedMessage, actualMessage);
   }
@@ -334,7 +334,7 @@ public class SearchExpressionParserUnitTest {
       parseLeaderSearchExpression(leaderSearchExpression);
     });
     // then
-    String expectedMessage = "The given expression part xxx.a is not parsable";
+    String expectedMessage = "The given expression [xxx.a = '1'] is not parsable";
     String actualMessage = exception.getMessage();
     assertEquals(expectedMessage, actualMessage);
   }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODSOURCE-255
Now the backend returns only a list of record UUIDs. In this technical story the response should follow the schema described below, and return instanceUUIDs.

Requirements/Scope:

- Results should contain a JSON response with keys: records (array of associated instance UUIDS), recordCount (integer)
- A search with no results should have an empty records array and count of 0

## Approach
Created a custom implementation of io.vertx.core.streams.WriteStream to be able to build HTTP response following the schema:
```
 {
     "records" : array of instance UUIDs,
     "totalCount" : integer
 }
```

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
