### PR TITLE
MODSOURCE-257 Implement the search by position  

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## 2021-03-12 v5.0.1-SNAPSHOT
 * [MODSOURCE-222](https://issues.folio.org/browse/MODSOURCE-222) Design API & implement data structures and end-points for search functionality in mod-source-record-storage
 * [MODSOURCE-223](https://issues.folio.org/browse/MODSOURCE-223) Design and implement service layer for MARC search functionality
+* [MODSOURCE-255](https://issues.folio.org/browse/MODSOURCE-255) Return HTTP response according to the schema
+* [MODSOURCE-257](https://issues.folio.org/browse/MODSOURCE-257) Implement the search by position
 
 ## 2021-03-12 v5.0.0
 * [MODSOURMAN-385](https://issues.folio.org/browse/MODSOURMAN-385) Enable OCLC update processing.

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/Lexicon.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/Lexicon.java
@@ -1,7 +1,7 @@
 package org.folio.services.util.parser.lexeme;
 
 public enum Lexicon {
-  MARC_FIELD("^[0-9].*$"),
+  MARC_FIELD("^[0-9]{3}.*"),
   LEADER_FIELD("^p_.*"),
   OPENED_BRACKET("("),
   CLOSED_BRACKET(")"),

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/BinaryOperandLexeme.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/BinaryOperandLexeme.java
@@ -38,6 +38,8 @@ public abstract class BinaryOperandLexeme implements BinaryOperand, Lexeme {
         return new SubFieldBinaryOperand(key, lexiconOperator, value);
       } else if (ValueBinaryOperand.isApplicable(key)) {
         return new ValueBinaryOperand(key, lexiconOperator, value);
+      } else if (PositionBinaryOperand.isApplicable(key)) {
+        return new PositionBinaryOperand(key, lexiconOperator, value);
       } else {
         throw new IllegalArgumentException(format(
           "The given key is not supported [key: %s, operator: %s, value: %s]",

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
@@ -13,7 +13,7 @@ public class IndicatorBinaryOperand extends BinaryOperandLexeme {
   }
 
   public static boolean isApplicable(String key) {
-    return key.contains(".ind");
+    return key.matches("[0-9]{3}.ind[1-2]$");
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/LeaderBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/LeaderBinaryOperand.java
@@ -12,7 +12,7 @@ public class LeaderBinaryOperand extends BinaryOperandLexeme {
   }
 
   public static boolean isApplicable(String key) {
-    return key.startsWith("p_");
+    return key.matches("^p_.*");
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
@@ -1,0 +1,36 @@
+package org.folio.services.util.parser.lexeme.operand;
+
+import org.folio.services.util.parser.lexeme.Lexicon;
+
+import static java.lang.String.format;
+import static org.folio.services.util.parser.lexeme.Lexicon.OPERATOR_EQUALS;
+
+public class PositionBinaryOperand extends BinaryOperandLexeme {
+  private final String field;
+  private final int startPosition;
+  private final int endPosition;
+
+  public PositionBinaryOperand(String key, Lexicon operator, String value) {
+    super(key, operator, value);
+    this.field = key.substring(0, key.indexOf('.'));
+    this.startPosition = Integer.parseInt(key.substring(key.indexOf('.') + 1, key.indexOf('_')));
+    this.endPosition = Integer.parseInt(key.substring(key.indexOf('_') + 1));
+    if (endPosition != value.length()) {
+      throw new IllegalArgumentException(format("The length of the value [%s] should be equal to the end position [expected length = %s]", value, endPosition));
+    }
+  }
+
+  public static boolean isApplicable(String key) {
+    return key.matches("^[0-9]{3}.[0-9]{2,3}_[0-9]{2,3}$");
+  }
+
+  @Override
+  public String toSqlRepresentation() {
+    String iField = "\"" + "i" + field + "\"";
+    if (OPERATOR_EQUALS.equals(getOperator())) {
+      return "substring(" + iField + ".\"value\", " + startPosition + ", " + endPosition + ") = ?";
+    } else {
+      throw new IllegalArgumentException(format("Operator [%s] is not supported for the given PositionBinary operand", getOperator().getSearchValue()));
+    }
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
@@ -13,7 +13,7 @@ public class SubFieldBinaryOperand extends BinaryOperandLexeme {
   }
 
   public static boolean isApplicable(String key) {
-    return key.contains(".") && key.split("\\.")[1].length() == 1;
+    return key.matches("^[0-9]{3}.[0-9a-z]$");
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
@@ -13,7 +13,7 @@ public class ValueBinaryOperand extends BinaryOperandLexeme {
   }
 
   public static boolean isApplicable(String key) {
-    return key.contains(".value");
+    return key.matches("^[0-9]{3}.value$");
   }
 
   @Override

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -812,7 +812,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     postSnapshots(testContext, snapshot_2);
     postRecords(testContext, record_2);
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-    searchRequest.setFieldsSearchExpression("001.value = '393893' and 005.value ^= '2014110' and 035.ind1 = '#'");
+    searchRequest.setFieldsSearchExpression("001.value = '393893' and 005.value ^= '2014110' and 035.ind1 = '#' and 005.04_02 = '41'");
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)
@@ -1036,8 +1036,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     postSnapshots(testContext, snapshot_2);
     postRecords(testContext, record_2);
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-    searchRequest.setFieldsSearchExpression("001.value = '393893' and 005.value ^= '2014110' and 035.ind1 = '#'");
-    searchRequest.setLimit(0);
+    searchRequest.setFieldsSearchExpression("001.01_02 = '30'");
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1036,7 +1036,8 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     postSnapshots(testContext, snapshot_2);
     postRecords(testContext, record_2);
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-    searchRequest.setFieldsSearchExpression("001.01_02 = '30'");
+    searchRequest.setFieldsSearchExpression("001.value = '393893' and 005.value ^= '2014110' and 035.ind1 = '#'");
+    searchRequest.setLimit(0);
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -214,6 +214,48 @@ public class SearchExpressionParserUnitTest {
     assertEquals("\"i005\".\"value\" like ?", result.getWhereExpression());
   }
 
+
+  @Test
+  public void shouldThrowException_if_fieldsSearchExpression_hasWrongValueForPositionOperand() {
+    // given
+    String fieldsSearchExpression = "001.09_01 = 'abc'";
+    // when
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      parseFieldsSearchExpression(fieldsSearchExpression);
+    });
+    // then
+    String expectedMessage = "The length of the value [abc] should be equal to the end position [expected length = 1]";
+    String actualMessage = exception.getMessage();
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void shouldThrowException_if_fieldsSearchExpression_hasWrongOperatorForPositionOperand() {
+    // given
+    String fieldsSearchExpression = "001.09_01 ^= 'a'";
+    // when
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      parseFieldsSearchExpression(fieldsSearchExpression);
+    });
+    // then
+    String expectedMessage = "Operator [^=] is not supported for the given PositionBinary operand";
+    String actualMessage = exception.getMessage();
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void shouldParseFieldsSearchExpression_for_PositionOperand_EqualsOperator() {
+    // given
+    String fieldsSearchExpression = "005.01_04 = '2014'";
+    // when
+    ParseFieldsResult result = parseFieldsSearchExpression(fieldsSearchExpression);
+    // then
+    assertTrue(result.isEnabled());
+    assertEquals(singletonList("2014"), result.getBindingParams());
+    assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
+    assertEquals("substring(\"i005\".\"value\", 1, 4) = ?", result.getWhereExpression());
+  }
+
   @Test
   public void shouldParseFieldsSearchExpression_with_boolean_operators() {
     // given


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODSOURCE-257

In this technical story we need to come up with a syntax for search expressions needed to search by position and implement this search feature.

_Search expression example1: 001.02_05 = '3893'_
_Search expression example2: 001.02_01 = '3'_

The first position (02) is the position of the marc field (001) from where the extracting will be starting, 01 - is the very beginning of the string

The second position (05, 01) means a number of characters to be extracted from the marc field (001) 

## Approach
I created `PositionBinaryOperand` to implement the search by position using the _substring_ function https://w3resource.com/PostgreSQL/substring-function.php

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
