### PR TITLE
MODSOURCE-263: SRS MARC Bib column indicates the MARC record was "Created" for "Update" operation

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -43,6 +43,7 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByInstanceId;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByNotSnapshotId;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_INSTANCE_HRID_SET;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
@@ -112,8 +113,9 @@ public class InstancePostProcessingEventHandler implements EventHandler {
             sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(context), DI_SRS_MARC_BIB_INSTANCE_HRID_SET.value(),
               kafkaHeaders, kafkaConfig, key);
             // MODSOURMAN-384: sent event to log when record updated implicitly only for INSTANCE_UPDATED case
-            if (dataImportEventPayload.getEventType().equals(DI_INVENTORY_INSTANCE_UPDATED.value())) {
-              sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(context), DI_SRS_MARC_BIB_RECORD_UPDATED.value(),
+            if (dataImportEventPayload.getEventType().equals(DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value())) {
+              dataImportEventPayload.setEventType(DI_SRS_MARC_BIB_RECORD_UPDATED.value());
+              sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), DI_SRS_MARC_BIB_RECORD_UPDATED.value(),
                 kafkaHeaders, kafkaConfig, key);
             }
             future.complete(dataImportEventPayload);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
-import static org.folio.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByInstanceId;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByNotSnapshotId;


### PR DESCRIPTION
## Purpose
SRS MARC Bib column indicates the MARC record was "Created" for "Update" operation.

## Approach
Fixing of sending an event after POST_PROCESSING handling.

## Learning
[MODSOURCE-263](https://issues.folio.org/browse/MODSOURCE-263)
