### PR TITLE
MODSOURCE-267: View Source does not update when Data Import updates bib record [BUGFIX].

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-04-12 v5.1.0-SNAPSHOT
 * [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches  
+* [MODSOURCE-267](https://issues.folio.org/browse/MODSOURCE-267) View Source does not update when Data Import updates bib record [BUGFIX]
 
 ## 2021-03-12 v5.0.1-SNAPSHOT
 * [MODSOURCE-222](https://issues.folio.org/browse/MODSOURCE-222) Design API & implement data structures and end-points for search functionality in mod-source-record-storage

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -736,7 +736,8 @@ public class RecordDaoImpl implements RecordDao {
   @Override
   public Future<Optional<Record>> getRecordByExternalId(ReactiveClassicGenericQueryExecutor txQE,
       String externalId, ExternalIdType externalIdType) {
-    Condition condition = RecordDaoUtil.getExternalIdCondition(externalId, externalIdType);
+    Condition condition = RecordDaoUtil.getExternalIdCondition(externalId, externalIdType)
+      .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL));
     return txQE.findOneRow(dsl -> dsl.selectFrom(RECORDS_LB)
       .where(condition)
       .orderBy(RECORDS_LB.GENERATION.sort(SortOrder.DESC))


### PR DESCRIPTION
## Purpose
Bug review: When we overlay a bib record using Data Import, the Instance updates with the new data, but the View Source record retains the old version of the record. When you open the record with quickMARC however, the updated bib record appears for editing. Saving a change in quickMARC then pushes the updated record into View Source.

## Approach
It seems like the root cause of this issue is about retrieving not-ACTUAL records from DB. So, there was added one more condition: for the "ACTUAL"-state.

## Learning
More info: https://issues.folio.org/browse/MODSOURCE-267
