### PR TITLE
MODSOURCE-269 Support search by indicator presence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-04-12 v5.1.0-SNAPSHOT
 * [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches  
+* [MODSOURCE-269](https://issues.folio.org/browse/MODSOURCE-269) Implement presence or absence searches for indicators
 
 ## 2021-04-23 v5.0.3
 * [MODSOURCE-272](https://issues.folio.org/browse/MODSOURCE-272) MARC srs query API returns 0 results on bugfest

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
@@ -16,9 +16,11 @@ import static org.folio.services.util.parser.lexeme.Lexicon.BINARY_OPERATOR_NOT_
  *      "ind2": " "
  * }
  * Available search cases:
- * 240.ind1 = '1'     - simple equality, use '#' to search by empty values (240.ind2 = "#")
- * 240.ind1 ^= '1'    - left-anchored equality
- * 240.ind2 not= '0'  - not equals
+ * 240.ind1 = '1'        - simple equality, use '#' to search by empty values (240.ind2 = "#")
+ * 240.ind1 ^= '1'       - left-anchored equality
+ * 240.ind2 not= '0'     - not equals
+ * 010.ind1 is 'present' - is present
+ * 010.ind2 is 'absent'  - is absent
  */
 public class IndicatorBinaryOperand extends BinaryOperandLexeme {
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
@@ -4,6 +4,7 @@ import org.folio.services.util.parser.lexeme.Lexicon;
 
 import static java.lang.String.format;
 import static org.folio.services.util.parser.lexeme.Lexicon.BINARY_OPERATOR_EQUALS;
+import static org.folio.services.util.parser.lexeme.Lexicon.BINARY_OPERATOR_IS;
 import static org.folio.services.util.parser.lexeme.Lexicon.BINARY_OPERATOR_LEFT_ANCHORED_EQUALS;
 import static org.folio.services.util.parser.lexeme.Lexicon.BINARY_OPERATOR_NOT_EQUALS;
 
@@ -32,14 +33,17 @@ public class IndicatorBinaryOperand extends BinaryOperandLexeme {
   @Override
   public String toSqlRepresentation() {
     String[] keyParts = getKey().split("\\.");
-    String iField = "\"" + "i" + keyParts[0] + "\"";
-    String indicator = "\"" + keyParts[1] + "\"";
+    var field = keyParts[0];
+    var indicator = keyParts[1];
+    var sqlRepresentation = "\"" + "i" + field + "\"" + "." + "\"" + indicator + "\"";
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
-      return iField + "." + indicator + " like ?";
+      return sqlRepresentation + " like ?";
     } else if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {
-      return iField + "." + indicator + " = ?";
+      return sqlRepresentation + " = ?";
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator())) {
-      return iField + "." + indicator + " <> ?";
+      return sqlRepresentation + " <> ?";
+    } else if (BINARY_OPERATOR_IS.equals(getOperator())) {
+      return PresenceBinaryOperand.getSqlRepresentationForIndicator(field, indicator, value);
     }
     throw new IllegalArgumentException(format("Operator [%s] is not supported for the given Indicator operand", getOperator().getSearchValue()));
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -10,6 +10,7 @@ import static java.lang.String.format;
  * 010.a is 'absent'            - check sub field for absence
  */
 public class PresenceBinaryOperand {
+
   private static final String PRESENT = "present";
   private static final String ABSENT = "absent";
 
@@ -31,6 +32,15 @@ public class PresenceBinaryOperand {
       return "(id in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "')) ";
     } else {
       return "(id not in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "')) ";
+    }
+  }
+
+  public static String getSqlRepresentationForIndicator(String field, String indicator, String value) {
+    validateValue(value);
+    if (PRESENT.equals(value)) {
+      return "(id in (select marc_id from marc_indexers_" + field + " where " + indicator + " <> '#')) ";
+    } else {
+      return "(id in (select marc_id from marc_indexers_" + field + " where " + indicator + " = '#')) ";
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -8,6 +8,8 @@ import static java.lang.String.format;
  * 999.value is 'absent'        - check field for absence
  * 010.a is 'present'           - check sub field for presence
  * 010.a is 'absent'            - check sub field for absence
+ * 010.ind1 is 'present'        - check indicator for presence
+ * 010.ind1 is 'absent'         - check indicator for absence
  */
 public class PresenceBinaryOperand {
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -821,7 +821,9 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       "and 035.value is 'present' " +
       "and 999.value is 'absent' " +
       "and 041.g is 'present' " +
-      "and 041.z is 'absent'");
+      "and 041.z is 'absent' " +
+      "and 050.ind1 is 'present' " +
+      "and 050.ind2 is 'absent'");
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -480,6 +480,45 @@ public class SearchExpressionParserUnitTest {
     assertEquals("((\"i035\".\"subfield_no\" = 'a' and \"i035\".\"value\" = ?) and \"i036\".\"ind1\" <> ?) or (\"i036\".\"ind1\" like ? and \"i005\".\"value\" like ?) or (substring(\"i001\".\"value\", 2, 3) = ? and to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') between ? and ?)", result.getWhereExpression());
   }
 
+  @Test
+  public void shouldParseFieldsSearchExpression_for_IndicatorOperand_IsPresentOperator() {
+    // given
+    String fieldsSearchExpression = "050.ind1 is 'present'";
+    // when
+    ParseFieldsResult result = parseFieldsSearchExpression(fieldsSearchExpression);
+    // then
+    assertTrue(result.isEnabled());
+    assertEquals(emptyList(), result.getBindingParams());
+    assertEquals(emptySet(), result.getFieldsToJoin());
+    assertEquals("(id in (select marc_id from marc_indexers_050 where ind1 <> '#')) ", result.getWhereExpression());
+  }
+
+  @Test
+  public void shouldParseFieldsSearchExpression_for_IndicatorOperand_IsAbsentOperator() {
+    // given
+    String fieldsSearchExpression = "050.ind2 is 'absent'";
+    // when
+    ParseFieldsResult result = parseFieldsSearchExpression(fieldsSearchExpression);
+    // then
+    assertTrue(result.isEnabled());
+    assertEquals(emptyList(), result.getBindingParams());
+    assertEquals(emptySet(), result.getFieldsToJoin());
+    assertEquals("(id in (select marc_id from marc_indexers_050 where ind2 = '#')) ", result.getWhereExpression());
+  }
+
+  @Test
+  public void shouldThrowException_if_fieldsSearchExpression_hasWrongOperatorForIndicatorOperand() {
+    // given
+    String fieldsSearchExpression = "050.ind2 is 'empty'";
+    // when
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+      parseFieldsSearchExpression(fieldsSearchExpression);
+    });
+    // then
+    String expectedMessage = "Value [empty] is not supported for the given Presence operand";
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+
   /* - TESTING SearchExpressionParser#parseLeaderSearchExpression */
 
   @Test


### PR DESCRIPTION
## Purpose
Implement presence or absence searches for indicators

## Approach
* Add support of `is 'present/absent'` in `IndicatorBinaryOperand`. The empty indicator represents the `#` symbol in the database.