### PR TITLE
MODSOURCE-285 - Order of execution keeps marc updates from occurring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ## 2021-05-xx v5.0.4-SNAPSHOT
 * [MODSOURCE-278](https://issues.folio.org/browse/MODSOURCE-278) Take into account saved records from failed data import on generation calculation. Prevent import hanging if records saving failed.
-* [MODDATAIMP-422](https://issues.folio.org/browse/MODDATAIMP-422) Order of execution keeps marc updates from occurring
+* [MODSOURCE-285](https://issues.folio.org/browse/MODSOURCE-285) Order of execution keeps marc updates from occurring
 
 ## 2021-04-23 v5.0.3
 * [MODSOURCE-272](https://issues.folio.org/browse/MODSOURCE-272) MARC srs query API returns 0 results on bugfest

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 ## 2021-04-12 v5.1.0-SNAPSHOT
 * [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches  
 * [MODSOURCE-269](https://issues.folio.org/browse/MODSOURCE-269) Implement presence or absence searches for indicators
-* [MODSOURCE-278](https://issues.folio.org/browse/MODSOURCE-278) Take into account saved records from failed data import on generation calculation. Prevent import hanging if records saving failed.  
+
+## 2021-05-xx v5.0.4-SNAPSHOT
+* [MODSOURCE-278](https://issues.folio.org/browse/MODSOURCE-278) Take into account saved records from failed data import on generation calculation. Prevent import hanging if records saving failed.
+* [MODDATAIMP-422](https://issues.folio.org/browse/MODDATAIMP-422) Order of execution keeps marc updates from occurring
 
 ## 2021-04-23 v5.0.3
 * [MODSOURCE-272](https://issues.folio.org/browse/MODSOURCE-272) MARC srs query API returns 0 results on bugfest

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
@@ -22,10 +22,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_HOLDING_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_BIB_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MATCHED;
@@ -39,6 +41,7 @@ public class DataImportConsumersVerticle extends AbstractVerticle {
 
   private final List<String> events = Arrays.asList(DI_SRS_MARC_BIB_RECORD_CREATED.value(),
     DI_INVENTORY_INSTANCE_CREATED.value(), DI_INVENTORY_INSTANCE_UPDATED.value(),
+    DI_INVENTORY_HOLDING_CREATED.value(), DI_INVENTORY_ITEM_CREATED.value(),
     DI_SRS_MARC_BIB_RECORD_MATCHED.value(), DI_SRS_MARC_BIB_RECORD_NOT_MATCHED.value(),
     DI_SRS_MARC_BIB_RECORD_MODIFIED.value(),
     DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING.value(),


### PR DESCRIPTION
## Purpose
to process "modify record" action that placed at the end of the actions chain. 
Users need to be able to delete unwanted fields from the MARC record after they have been used for entities creation.
For instance, a user can set up 4 actions: create instance, create holdings, create item (using 947 field as item barcode), modify record (delete 947 field from MARC bib). As a result source marc record is created, instance, holdings, item records are created; data from marc field 947 is used as item barcode. Field 947 should be deleted from marc record.

## Approach
* subscribe dataImportConsumerVerticle to DI_INVENTORY_HOLDING_CREATED, DI_INVENTORY_ITEM_CREATED events to provide further event processing by srs if it's needed


## Learning
[MODSOURCE-285](https://issues.folio.org/browse/MODDATAIMP-422)