### PR TITLE
MODSOURCE-310: Handling 001/003/035 handling in SRS for MARC bib records broken

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURCE-276](https://issues.folio.org/browse/MODSOURCE-276) Add existing records to the SRS Query API table
 * [MODSOURCE-288](https://issues.folio.org/browse/MODSOURCE-288) Migrate QM-flow to Kafka
 * [MODSOURCE-279](https://issues.folio.org/browse/MODSOURCE-279) Store MARC Authority record
+* [MODSOURCE-310](https://issues.folio.org/browse/MODSOURCE-310) Handling 001/003/035 handling in SRS for MARC bib records broken
 
 ## 2021-05-xx v5.0.5-SNAPSHOT
 * [MODSOURCE-301](https://issues.folio.org/browse/MODSOURCE-301) Cannot import GOBI EDIFACT invoice

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -1,12 +1,14 @@
 package org.folio.services.handlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -169,7 +171,7 @@ public class InstancePostProcessingEventHandler implements EventHandler {
             result.complete();
           } else {
             result.fail(ar.cause());
-            LOG.error( "ERROR during update old records state for instance chane event", ar.cause());
+            LOG.error("ERROR during update old records state for instance chane event", ar.cause());
           }
         });
         return result.future();
@@ -188,8 +190,15 @@ public class InstancePostProcessingEventHandler implements EventHandler {
     }
     if (isNotEmpty(record.getExternalIdsHolder().getInstanceId())
       || isNotEmpty(record.getExternalIdsHolder().getInstanceHrid())) {
+      if (AdditionalFieldsUtil.ifFillingFieldsNeeded(record, instance)) {
+        executeHridManipulation(record, instance);
+      }
       return;
     }
+    executeHridManipulation(record, instance);
+  }
+
+  private void executeHridManipulation(Record record, JsonObject instance) {
     String instanceId = instance.getString("id");
     String instanceHrid = instance.getString("hrid");
     record.getExternalIdsHolder().setInstanceHrid(instanceHrid);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
@@ -1,7 +1,9 @@
 package org.folio.services.handlers.actions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.json.JsonObject;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.ActionProfile;
@@ -72,6 +74,7 @@ public class ModifyRecordEventHandler implements EventHandler {
 
       Record changedRecord = OBJECT_MAPPER.readValue(payloadContext.get(MARC_BIBLIOGRAPHIC.value()), Record.class);
       AdditionalFieldsUtil.addControlledFieldToMarcRecord(changedRecord, AdditionalFieldsUtil.HR_ID_FROM_FIELD, hrId, true);
+      AdditionalFieldsUtil.remove003FieldIfNeeded(changedRecord, hrId);
 
       payloadContext.put(MARC_BIBLIOGRAPHIC.value(), OBJECT_MAPPER.writeValueAsString(changedRecord));
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -39,6 +39,7 @@ import org.marc4j.marc.Subfield;
 import org.marc4j.marc.VariableField;
 
 import io.vertx.core.json.JsonObject;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -55,6 +55,7 @@ public final class AdditionalFieldsUtil {
   private static final String HR_ID_PREFIX_FROM_FIELD = "003";
   private static final String HR_ID_TO_FIELD = "035";
   private static final String HR_ID_FIELD = "hrid";
+  private static final String ID_FIELD = "id";
   private static final char HR_ID_FIELD_SUB = 'a';
   private static final char HR_ID_FIELD_IND = ' ';
   private static final String ANY_STRING = "*";
@@ -356,6 +357,29 @@ public final class AdditionalFieldsUtil {
         throw new PostProcessingException(format("Failed to update field '005' to record with id '%s'", record.getId()));
       }
     }
+  }
+
+  /**
+   * Remove 003 field if hrid is not empty (ffrom instance and marc-record)
+   * @param record - source record
+   * @param instanceHrid - existing instanceHrid
+   */
+  public static void remove003FieldIfNeeded(Record record, String instanceHrid) {
+    if (StringUtils.isNotBlank(instanceHrid) && StringUtils.isNotBlank(AdditionalFieldsUtil.getValueFromControlledField(record, "001"))) {
+      AdditionalFieldsUtil.removeField(record, HR_ID_PREFIX_FROM_FIELD);
+    }
+  }
+
+  /**
+   * Check if record should be filled by specific fields.
+   * @param record - source record.
+   * @param instance - source instance.
+   * @return - true if need.
+   */
+  public static boolean ifFillingFieldsNeeded(Record record, JsonObject instance) {
+    return (StringUtils.isNotEmpty(record.getExternalIdsHolder().getInstanceId()) && StringUtils.isNotEmpty(record.getExternalIdsHolder().getInstanceHrid())) &&
+      (instance.getString(ID_FIELD).equals(record.getExternalIdsHolder().getInstanceId())
+        && !instance.getString(HR_ID_FIELD).equals(record.getExternalIdsHolder().getInstanceHrid()));
   }
 
   /**

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/ModifyRecordEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/ModifyRecordEventHandlerTest.java
@@ -235,6 +235,49 @@ public class ModifyRecordEventHandlerTest extends AbstractLBServiceTest {
     });
   }
 
+  @Test
+  public void shouldModifyMarcRecordAndRemove003Field(TestContext context) {
+    // given
+    Async async = context.async();
+
+    String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
+    record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
+    payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
+    payloadContext.put("MAPPING_PARAMS", Json.encode(new MappingParameters()));
+
+    mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
+    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+      .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
+        .withProfileId(mappingProfile.getId())
+        .withContentType(MAPPING_PROFILE)
+        .withContent(JsonObject.mapFrom(mappingProfile).getMap())));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withTenant(TENANT_ID)
+      .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
+      .withContext(payloadContext)
+      .withProfileSnapshot(profileSnapshotWrapper)
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+
+    // when
+    CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
+
+    // then
+    future.whenComplete((eventPayload, throwable) -> {
+      context.assertNull(throwable);
+      context.assertEquals(DI_SRS_MARC_BIB_RECORD_MODIFIED.value(), eventPayload.getEventType());
+
+      Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
+      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
+      async.complete();
+    });
+  }
+
   @Test(expected = ExecutionException.class)
   public void shouldReturnFailedFutureWhenHasNoMarcRecord() throws InterruptedException, ExecutionException, TimeoutException {
     // given


### PR DESCRIPTION
## Purpose
Fix logic for 001/003/035 handling for overlaying.

## Approach

- For instance=MARC: was added mechanism for removing 003 field, if it`s needed.
- For instance=Folio: 001/003/035 logic wasn't applied because ExternalHoldersIds wasn't empty(before we have check, and don`t execute it if ExternalHoldersIds is not empty). **This bug caused that the updated instance can't be saved in mod-inventory, because the new instance has an invalid hrid** (ocm12345, for example, not in0000001). So, in this PR was added a condition, that if instance.id==record.externalHolderIds.instanceId AND  instace.hrid!=record.externalHolderIds.instanceHrid(in this case it reveales, ocm1234!=in0000001), then this mechanism will be executed. This specific case (for not equals between marc-record and instance) was in this bug. 

## Learning
More info: https://issues.folio.org/browse/MODSOURCE-310

**NOTE: Tests are in progress!**
