### PR TITLE
MODSOURCE-316 Change event payload to contain MARC_BIB

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/QuickMarcKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/QuickMarcKafkaHandler.java
@@ -42,7 +42,7 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
   private static final String PARSED_RECORD_DTO_KEY = "PARSED_RECORD_DTO";
   private static final String SNAPSHOT_ID_KEY = "SNAPSHOT_ID";
   private static final String ERROR_KEY = "ERROR";
-  private static final String MARC_KEY = "MARC";
+  private static final String MARC_KEY = "MARC_BIB";
 
   private static final AtomicInteger indexer = new AtomicInteger();
 


### PR DESCRIPTION
## Purpose
Fix: quickMARC updates are not reflected on the Inventory instance record
https://issues.folio.org/browse/MODSOURCE-316

## Approach
mod-inventory expects to have MARC_BIB in event payload.