### PR TITLE
MODSOURCE-317: Update RMB from 32.1.0 to 32.2.3 fix maven.indexdata.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <raml-module-builder.version>32.2.3</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
     <vertx.version>4.0.0</vertx.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
## Purpose

This fixes the security issue
https://issues.folio.org/browse/FOLIO-3045 =
https://issues.folio.org/browse/FOLIO-3106 =
https://nvd.nist.gov/vuln/detail/CVE-2021-26291

This also enables to build using maven >= 3.8.1
that no longer allows to use http maven repositories.
_Describe the purpose of the pull request. Include background information if necessary._

## Approach
Update RMB from 32.1.0 to 32.2.3.