### PR TITLE
MODSOURCE-318 Set processingStartedDate for snapshot when updating via QM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODSOURCE-279](https://issues.folio.org/browse/MODSOURCE-279) Store MARC Authority record
 * [MODSOURCE-308](https://issues.folio.org/browse/MODSOURCE-308) Update interfaces version
 * [MODSOURCE-310](https://issues.folio.org/browse/MODSOURCE-310) Handling 001/003/035 handling in SRS for MARC bib records broken
+* [MODSOURCE-318](https://issues.folio.org/browse/MODSOURCE-318) Set processingStartedDate for snapshot when updating via QM
 
 ## 2021-05-xx v5.0.5-SNAPSHOT
 * [MODSOURCE-301](https://issues.folio.org/browse/MODSOURCE-301) Cannot import GOBI EDIFACT invoice

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -184,6 +185,7 @@ public class RecordServiceImpl implements RecordService {
       .compose(optionalRecord -> optionalRecord
         .map(existingRecord -> SnapshotDaoUtil.save(txQE, new Snapshot()
           .withJobExecutionId(snapshotId)
+          .withProcessingStartedDate(new Date())
           .withStatus(Snapshot.Status.COMMITTED)) // no processing of the record is performed apart from the update itself
             .compose(snapshot -> recordDao.saveUpdatedRecord(txQE, new Record()
               .withId(newRecordId)

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -532,6 +532,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
             context.fail(getSnapshot.cause());
           }
           context.assertTrue(getSnapshot.result().isPresent());
+          context.assertNotNull(getSnapshot.result().get().getProcessingStartedDate());
           recordDao.getRecordByCondition(RECORDS_LB.SNAPSHOT_ID.eq(UUID.fromString(snapshotId)), TENANT_ID).onComplete(getNewRecord -> {
             if (getNewRecord.failed()) {
               context.fail(getNewRecord.cause());


### PR DESCRIPTION
## Purpose
Fix bug when after editing with quickmarc data import marc updates are erroneously discarded.

https://issues.folio.org/browse/MODSOURCE-318

## Approach
`processingStartedDate` is required to be populated in snapshot table
