### PR TITLE
MODSOURCE-329 Add migration script to correct invalid Snapshot statuses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,19 @@
-## 2021-06-14 v5.2.0
+## xxxx-xx-xx v5.2.0-SNAPSHOT
+* [MODSOURCE-311](https://issues.folio.org/browse/MODSOURCE-311) Search API: Restrict to search only by marc bib
+* [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
+
+## 2021-xx-xx v5.1.3
+* [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
+
+## 2021-06-25 v5.1.2
+* [MODSOURCE-323](https://issues.folio.org/browse/MODSOURCE-323) Change dataType to have common type for MARC related subtypes
+* Update data-import-processing-core dependency to v3.1.2
+
+## 2021-06-22 v5.1.1
 * [MODSOURCE-311](https://issues.folio.org/browse/MODSOURCE-311) Search API: Restrict to search only by marc bib
 
 ## 2021-06-11 v5.1.0
-* [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches  
+* [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches
 * [MODSOURCE-269](https://issues.folio.org/browse/MODSOURCE-269) Implement presence or absence searches for indicators
 * [MODSOURCE-276](https://issues.folio.org/browse/MODSOURCE-276) Add existing records to the SRS Query API table
 * [MODSOURCE-288](https://issues.folio.org/browse/MODSOURCE-288) Migrate QM-flow to Kafka
@@ -13,16 +24,20 @@
 * [MODSOURCE-301](https://issues.folio.org/browse/MODSOURCE-301) Cannot import GOBI EDIFACT invoice
 * [MODSOURCE-316](https://issues.folio.org/browse/MODSOURCE-316) quickMARC Latency: quickMARC updates are not reflected on Inventory instance record
 
+## 2021-xx-xx v5.0.6
+* [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
 
-## 2021-05-xx v5.0.5-SNAPSHOT
+## 2021-06-17 v5.0.5
+* [MODSOURCE-318](https://issues.folio.org/browse/MODSOURCE-318) Set processingStartedDate for snapshot when updating via QM
+* [MODSOURCE-310](https://issues.folio.org/browse/MODSOURCE-310) Handling 001/003/035 handling in SRS for MARC bib records broken
 * [MODSOURCE-301](https://issues.folio.org/browse/MODSOURCE-301) Cannot import GOBI EDIFACT invoice
 * [MODSOURCE-265](https://issues.folio.org/browse/MODSOURCE-265) Implement presence or absence searches
-* [MODSOURCE-310](https://issues.folio.org/browse/MODSOURCE-310) Handling 001/003/035 handling in SRS for MARC bib records broken
-* [MODSOURCE-318](https://issues.folio.org/browse/MODSOURCE-318) Set processingStartedDate for snapshot when updating via QM
+* Update folio-kafka-wrapper to v2.0.8
+* Update data-import-processing-core to v3.0.3
 
 ## 2021-05-22 v5.0.4
 * [MODSOURCE-280](https://issues.folio.org/browse/MODSOURCE-280) Issue with database migration for Iris release
-* [MODSOURCE-278](https://issues.folio.org/browse/MODSOURCE-278) Take into account saved records from failed data import on generation calculation. Prevent import hanging if records saving failed.
+* [MODSOURCE-278](https://issues.folio.org/browse/MODSOURCE-278) Take into account saved records from failed data import on generation calculation. Prevent import hanging if records saving failed
 * [MODSOURCE-285](https://issues.folio.org/browse/MODSOURCE-285) Order of execution keeps marc updates from occurring
 * [MODSOURCE-295](https://issues.folio.org/browse/MODSOURCE-295) Multiple records are found by match criteria after subsequent updates
 

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -55,4 +55,7 @@
 
   <include file="scripts/v-0.0.4/2021-05-19--13-00-drop-unused-set-id-function.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml" relativeToChangelogFile="true"/>
+
+  <include file="scripts/v-5.0.6-5.1.3-5.2.0/2021-06-30--16-00-update-snapshot-invalid-statuses.xml" relativeToChangelogFile="true"/>
+
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.0.6-5.1.3-5.2.0/2021-06-30--16-00-update-snapshot-invalid-statuses.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.0.6-5.1.3-5.2.0/2021-06-30--16-00-update-snapshot-invalid-statuses.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+
+  <changeSet id="2021-06-30--16-00-update-snapshot-invalid-statuses" author="KaterynaSenchenko">
+    <sql>
+      UPDATE ${database.defaultSchemaName}.snapshots_lb
+      SET status = 'ERROR'
+      WHERE status != 'COMMITTED';
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
Updating of some older records failed, because they were created by some older jobs that did not complete successfully

## Approach
Add migration script to correct invalid Snapshot statuses