### PR TITLE
MODSOURMAN-451- Log details for Inventory single record imports for Overlays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ## 2021-xx-xx v5.1.3
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
+* [MODSOURMAN-451](https://issues.folio.org/browse/MODSOURMAN-451) Log details for Inventory single record imports for Overlays
 
 ## 2021-06-25 v5.1.2
 * [MODSOURCE-323](https://issues.folio.org/browse/MODSOURCE-323) Change dataType to have common type for MARC related subtypes

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
@@ -2,6 +2,7 @@ package org.folio.services.handlers.actions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
 import org.apache.logging.log4j.LogManager;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.isNull;
@@ -106,7 +108,9 @@ public class ModifyRecordEventHandler implements EventHandler {
   private void prepareModificationResult(DataImportEventPayload dataImportEventPayload, MappingDetail.MarcMappingOption marcMappingOption) {
     HashMap<String, String> context = dataImportEventPayload.getContext();
     if (marcMappingOption == MappingDetail.MarcMappingOption.UPDATE) {
-      context.put(MARC_BIBLIOGRAPHIC.value(), context.remove(MATCHED_MARC_BIB_KEY));
+      Record changedRecord = Json.decodeValue(context.remove(MATCHED_MARC_BIB_KEY), Record.class);
+      changedRecord.setSnapshotId(dataImportEventPayload.getJobExecutionId());
+      context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(changedRecord));
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/ModifyRecordEventHandler.java
@@ -110,6 +110,8 @@ public class ModifyRecordEventHandler implements EventHandler {
     if (marcMappingOption == MappingDetail.MarcMappingOption.UPDATE) {
       Record changedRecord = Json.decodeValue(context.remove(MATCHED_MARC_BIB_KEY), Record.class);
       changedRecord.setSnapshotId(dataImportEventPayload.getJobExecutionId());
+      changedRecord.setGeneration(null);
+      changedRecord.setId(UUID.randomUUID().toString());
       context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(changedRecord));
     }
   }


### PR DESCRIPTION
## Purpose
to adjust statuses on the summary page after updating an existing Instance and SRS MARC using single record imports for Overlays

## Approach
* save record updating result as a new version of the existing record
* link updated record to current import job

## Learning
[MODSOURMAN-451](https://issues.folio.org/browse/MODSOURMAN-451)