### PR TITLE
MODSOURMAN-508 - Log details for Inventory single record imports for Overlays - Part 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ## 2021-xx-xx v5.1.3
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
 * [MODSOURMAN-451](https://issues.folio.org/browse/MODSOURMAN-451) Log details for Inventory single record imports for Overlays
+* [MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508) Log details for Inventory single record imports for Overlays - Part 2
 
 ## 2021-06-25 v5.1.2
 * [MODSOURCE-323](https://issues.folio.org/browse/MODSOURCE-323) Change dataType to have common type for MARC related subtypes

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -1,14 +1,12 @@
 package org.folio.services.handlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.producer.KafkaHeader;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -40,10 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
-import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByInstanceId;
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByNotSnapshotId;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_INSTANCE_HRID_SET;
 import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
@@ -228,12 +227,12 @@ public class InstancePostProcessingEventHandler implements EventHandler {
   private void sendEventToDataImportLog(DataImportEventPayload dataImportEventPayload, Record record, List<KafkaHeader> kafkaHeaders, String key) {
     if (dataImportEventPayload.getEventType().equals(DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value()) && record.getGeneration() != null) {
       if (record.getGeneration() > 0) {
-        dataImportEventPayload.setEventType("DI_LOG_SRS_MARC_BIB_RECORD_UPDATED");
-        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), "DI_LOG_SRS_MARC_BIB_RECORD_UPDATED",
+        dataImportEventPayload.setEventType(DI_LOG_SRS_MARC_BIB_RECORD_UPDATED.value());
+        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), DI_LOG_SRS_MARC_BIB_RECORD_UPDATED.value(),
           kafkaHeaders, kafkaConfig, key);
       } else if (record.getGeneration() == 0) {
-        dataImportEventPayload.setEventType("DI_LOG_SRS_MARC_BIB_RECORD_CREATED");
-        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), "DI_LOG_SRS_MARC_BIB_RECORD_CREATED",
+        dataImportEventPayload.setEventType(DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value());
+        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value(),
           kafkaHeaders, kafkaConfig, key);
       }
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -115,11 +115,7 @@ public class InstancePostProcessingEventHandler implements EventHandler {
             sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(context), DI_SRS_MARC_BIB_INSTANCE_HRID_SET.value(),
               kafkaHeaders, kafkaConfig, key);
             // MODSOURMAN-384: sent event to log when record updated implicitly only for INSTANCE_UPDATED case
-            if (dataImportEventPayload.getEventType().equals(DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value())) {
-              dataImportEventPayload.setEventType(DI_SRS_MARC_BIB_RECORD_UPDATED.value());
-              sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), DI_SRS_MARC_BIB_RECORD_UPDATED.value(),
-                kafkaHeaders, kafkaConfig, key);
-            }
+            sendEventToDataImportLog(dataImportEventPayload, record, kafkaHeaders, key);
             future.complete(dataImportEventPayload);
           } else {
             LOG.error(FAIL_MSG, updateAr.cause());
@@ -221,12 +217,26 @@ public class InstancePostProcessingEventHandler implements EventHandler {
     return recordDao.getRecordById(record.getId(), tenantId)
       .compose(r -> {
         if (r.isPresent()) {
-          return recordDao.updateParsedRecord(record, tenantId).map(record);
+          return recordDao.updateParsedRecord(record, tenantId).map(record.withGeneration(r.get().getGeneration()));
         } else {
           record.getRawRecord().setId(record.getId());
           return recordDao.saveRecord(record, tenantId).map(record);
         }
       });
+  }
+
+  private void sendEventToDataImportLog(DataImportEventPayload dataImportEventPayload, Record record, List<KafkaHeader> kafkaHeaders, String key) {
+    if (dataImportEventPayload.getEventType().equals(DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value()) && record.getGeneration() != null) {
+      if (record.getGeneration() > 0) {
+        dataImportEventPayload.setEventType("DI_LOG_SRS_MARC_BIB_RECORD_UPDATED");
+        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), "DI_LOG_SRS_MARC_BIB_RECORD_UPDATED",
+          kafkaHeaders, kafkaConfig, key);
+      } else if (record.getGeneration() == 0) {
+        dataImportEventPayload.setEventType("DI_LOG_SRS_MARC_BIB_RECORD_CREATED");
+        sendEventToKafka(dataImportEventPayload.getTenant(), Json.encode(dataImportEventPayload), "DI_LOG_SRS_MARC_BIB_RECORD_CREATED",
+          kafkaHeaders, kafkaConfig, key);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
## Purpose
to adjust statuses on the summary page after updating an existing Instance and creating a new SRS MARC implicitly using single record imports for Overlays

## Approach
* publish DI_LOG_SRS_MARC_BIB_RECORD_CREATED event to notify data import log that record has been created during post-processing an event that instance was updated 


## Learning
[MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508)