### PR TITLE
MODSOURCE-341 Store MARC Holdings record

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
 * [MODSOURCE-311](https://issues.folio.org/browse/MODSOURCE-311) Search API: Restrict to search only by marc bib
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
+* [MODSOURCE-341](https://issues.folio.org/browse/MODSOURCE-341) Store MARC Holdings record
 
 ## 2021-xx-xx v5.1.3
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordType.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordType.java
@@ -34,14 +34,7 @@ public enum RecordType implements ParsedRecordType {
   MARC_BIB("marc_records_lb") {
     @Override
     public void formatRecord(Record record) throws FormatRecordException {
-      if (isParsedRecord(record)) {
-        String content = ParsedRecordDaoUtil.normalizeContent(record.getParsedRecord());
-        try {
-          record.getParsedRecord().setFormattedContent(MarcUtil.marcJsonToTxtMarc(content));
-        } catch (IOException e) {
-          throw new FormatRecordException(e);
-        }
-      }
+      formatMarcRecord(record);
     }
 
     @Override
@@ -56,26 +49,19 @@ public enum RecordType implements ParsedRecordType {
 
     @Override
     public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
-      return toDatabaseMarcRecord(parsedRecord);
+      return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
     }
 
     @Override
     public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
-      return loadInfo(dsl);
+      return dsl.loadInto(MARC_RECORDS_LB);
     }
   },
 
   MARC_AUTHORITY("marc_records_lb") {
     @Override
     public void formatRecord(Record record) throws FormatRecordException {
-      if (isParsedRecord(record)) {
-        String content = ParsedRecordDaoUtil.normalizeContent(record.getParsedRecord());
-        try {
-          record.getParsedRecord().setFormattedContent(MarcUtil.marcJsonToTxtMarc(content));
-        } catch (IOException e) {
-          throw new FormatRecordException(e);
-        }
-      }
+      formatMarcRecord(record);
     }
 
     @Override
@@ -90,26 +76,19 @@ public enum RecordType implements ParsedRecordType {
 
     @Override
     public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
-      return toDatabaseMarcRecord(parsedRecord);
+      return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
     }
 
     @Override
     public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
-      return loadInfo(dsl);
+      return dsl.loadInto(MARC_RECORDS_LB);
     }
   },
 
   MARC_HOLDING("marc_records_lb") {
     @Override
     public void formatRecord(Record record) throws FormatRecordException {
-      if (isParsedRecord(record)) {
-        String content = ParsedRecordDaoUtil.normalizeContent(record.getParsedRecord());
-        try {
-          record.getParsedRecord().setFormattedContent(MarcUtil.marcJsonToTxtMarc(content));
-        } catch (IOException e) {
-          throw new FormatRecordException(e);
-        }
-      }
+      formatMarcRecord(record);
     }
 
     @Override
@@ -124,12 +103,12 @@ public enum RecordType implements ParsedRecordType {
 
     @Override
     public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
-      return toDatabaseMarcRecord(parsedRecord);
+      return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
     }
 
     @Override
     public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
-      return loadInfo(dsl);
+      return dsl.loadInto(MARC_RECORDS_LB);
     }
   },
 
@@ -169,23 +148,22 @@ public enum RecordType implements ParsedRecordType {
     }
   };
 
+  private static void formatMarcRecord(Record record) throws FormatRecordException {
+    if (Objects.nonNull(record.getRecordType()) && Objects.nonNull(record.getParsedRecord())
+      && Objects.nonNull(record.getParsedRecord().getContent())) {
+      String content = ParsedRecordDaoUtil.normalizeContent(record.getParsedRecord());
+      try {
+        record.getParsedRecord().setFormattedContent(MarcUtil.marcJsonToTxtMarc(content));
+      } catch (IOException e) {
+        throw new FormatRecordException(e);
+      }
+    }
+  }
+
   private String tableName;
 
   RecordType(String tableName) {
     this.tableName = tableName;
-  }
-
-  private static boolean isParsedRecord(Record record) {
-    return Objects.nonNull(record.getRecordType()) && Objects.nonNull(record.getParsedRecord())
-      && Objects.nonNull(record.getParsedRecord().getContent());
-  }
-
-  private static LoaderOptionsStep<MarcRecordsLbRecord> loadInfo(DSLContext dsl) {
-    return dsl.loadInto(MARC_RECORDS_LB);
-  }
-
-  private static Record2<UUID, JSONB> toDatabaseMarcRecord(ParsedRecord parsedRecord) {
-    return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
   }
 
   public String getTableName() {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordType.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordType.java
@@ -38,13 +38,13 @@ public enum RecordType implements ParsedRecordType {
     }
 
     @Override
-    public Condition getRecordImplicitCondition() {
-      return filterRecordByType(this.name());
+    public Condition getSourceRecordImplicitCondition() {
+      return filterRecordByType(this.name()).and(RECORDS_LB.LEADER_RECORD_STATUS.isNotNull());
     }
 
     @Override
-    public Condition getSourceRecordImplicitCondition() {
-      return filterRecordByType(this.name()).and(RECORDS_LB.LEADER_RECORD_STATUS.isNotNull());
+    public Condition getRecordImplicitCondition() {
+      return filterRecordByType(this.name());
     }
 
     @Override
@@ -75,13 +75,13 @@ public enum RecordType implements ParsedRecordType {
     }
 
     @Override
-    public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
-      return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
+    public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
+      return dsl.loadInto(MARC_RECORDS_LB);
     }
 
     @Override
-    public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
-      return dsl.loadInto(MARC_RECORDS_LB);
+    public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
+      return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
     }
   },
 
@@ -97,11 +97,6 @@ public enum RecordType implements ParsedRecordType {
     }
 
     @Override
-    public Condition getSourceRecordImplicitCondition() {
-      return filterRecordByType(this.name()).and(RECORDS_LB.LEADER_RECORD_STATUS.isNotNull());
-    }
-
-    @Override
     public Record2<UUID, JSONB> toDatabaseRecord2(ParsedRecord parsedRecord) {
       return ParsedRecordDaoUtil.toDatabaseMarcRecord(parsedRecord);
     }
@@ -109,6 +104,11 @@ public enum RecordType implements ParsedRecordType {
     @Override
     public LoaderOptionsStep<MarcRecordsLbRecord> toLoaderOptionsStep(DSLContext dsl) {
       return dsl.loadInto(MARC_RECORDS_LB);
+    }
+
+    @Override
+    public Condition getSourceRecordImplicitCondition() {
+      return filterRecordByType(this.name()).and(RECORDS_LB.LEADER_RECORD_STATUS.isNotNull());
     }
   },
 
@@ -148,6 +148,12 @@ public enum RecordType implements ParsedRecordType {
     }
   };
 
+  private String tableName;
+
+  RecordType(String tableName) {
+    this.tableName = tableName;
+  }
+
   private static void formatMarcRecord(Record record) throws FormatRecordException {
     if (Objects.nonNull(record.getRecordType()) && Objects.nonNull(record.getParsedRecord())
       && Objects.nonNull(record.getParsedRecord().getContent())) {
@@ -158,12 +164,6 @@ public enum RecordType implements ParsedRecordType {
         throw new FormatRecordException(e);
       }
     }
-  }
-
-  private String tableName;
-
-  RecordType(String tableName) {
-    this.tableName = tableName;
   }
 
   public String getTableName() {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -18,6 +18,7 @@ import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.services.handlers.InstancePostProcessingEventHandler;
 import org.folio.services.handlers.MarcAuthorityEventHandler;
 import org.folio.services.handlers.MarcBibliographicMatchEventHandler;
+import org.folio.services.handlers.MarcHoldingsEventHandler;
 import org.folio.services.handlers.actions.ModifyRecordEventHandler;
 import org.folio.spring.SpringContextUtil;
 import org.folio.verticle.consumers.DataImportConsumersVerticle;
@@ -42,6 +43,9 @@ public class InitAPIImpl implements InitAPI {
 
   @Autowired
   private MarcAuthorityEventHandler marcAuthorityEventHandler;
+
+  @Autowired
+  private MarcHoldingsEventHandler marcHoldingsEventHandler;
 
   @Value("${srs.kafka.ParsedMarcChunkConsumer.instancesNumber:1}")
   private int parsedMarcChunkConsumerInstancesNumber;
@@ -76,6 +80,7 @@ public class InitAPIImpl implements InitAPI {
     EventManager.registerEventHandler(modifyRecordEventHandler);
     EventManager.registerEventHandler(marcBibliographicMatchEventHandler);
     EventManager.registerEventHandler(marcAuthorityEventHandler);
+    EventManager.registerEventHandler(marcHoldingsEventHandler);
   }
 
   private Future<?> deployConsumerVerticles(Vertx vertx) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractMarcEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractMarcEventHandler.java
@@ -2,8 +2,6 @@ package org.folio.services.handlers;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import static org.folio.rest.jaxrs.model.EntityType.MARC_HOLDINGS;
-
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
@@ -26,7 +24,7 @@ public abstract class AbstractMarcEventHandler implements EventHandler {
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
     HashMap<String, String> context = dataImportEventPayload.getContext();
 
-    if (context == null || context.isEmpty() || isEmpty(dataImportEventPayload.getContext().get(getRecordType()))){
+    if (context == null || context.isEmpty() || isEmpty(context.get(getEntityType()))){
       LOG.error(PAYLOAD_HAS_NO_DATA_MSG);
       future.completeExceptionally(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
       return future;
@@ -38,10 +36,10 @@ public abstract class AbstractMarcEventHandler implements EventHandler {
 
   @Override
   public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
-    return (dataImportEventPayload.getContext().containsKey(getRecordType()));
+    return (dataImportEventPayload.getContext().containsKey(getEntityType()));
   }
 
-  public abstract String getRecordType();
+  public abstract String getEntityType();
 
   @Override
   public boolean isPostProcessingNeeded() {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractMarcEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractMarcEventHandler.java
@@ -1,0 +1,51 @@
+package org.folio.services.handlers;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import static org.folio.rest.jaxrs.model.EntityType.MARC_HOLDINGS;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import org.folio.DataImportEventPayload;
+import org.folio.processing.events.services.handler.EventHandler;
+import org.folio.processing.exceptions.EventProcessingException;
+
+@Component
+public abstract class AbstractMarcEventHandler implements EventHandler {
+  private static final Logger LOG = LogManager.getLogger();
+  private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC data";
+
+  @Override
+  public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
+
+    CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
+    HashMap<String, String> context = dataImportEventPayload.getContext();
+
+    if (context == null || context.isEmpty() || isEmpty(dataImportEventPayload.getContext().get(getRecordType()))){
+      LOG.error(PAYLOAD_HAS_NO_DATA_MSG);
+      future.completeExceptionally(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
+      return future;
+    }
+    dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
+    future.complete(dataImportEventPayload);
+    return future;
+  }
+
+  @Override
+  public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
+    return (dataImportEventPayload.getContext().containsKey(getRecordType()));
+  }
+
+  public abstract String getRecordType();
+
+  @Override
+  public boolean isPostProcessingNeeded() {
+    return false;
+  }
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
@@ -1,47 +1,14 @@
 package org.folio.services.handlers;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.DataImportEventPayload;
-import org.folio.processing.events.services.handler.EventHandler;
-import org.folio.processing.exceptions.EventProcessingException;
-import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
-import java.util.concurrent.CompletableFuture;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_AUTHORITY;
 
+import org.springframework.stereotype.Component;
+
 @Component
-public class MarcAuthorityEventHandler implements EventHandler {
-  private static final Logger LOG = LogManager.getLogger();
-  private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC_AUTHORITY data";
+public class MarcAuthorityEventHandler extends AbstractMarcEventHandler {
 
   @Override
-  public CompletableFuture<DataImportEventPayload> handle(DataImportEventPayload dataImportEventPayload) {
-
-    CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
-    HashMap<String, String> context = dataImportEventPayload.getContext();
-
-    if (context == null || context.isEmpty() || isEmpty(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()))){
-      LOG.error(PAYLOAD_HAS_NO_DATA_MSG);
-      future.completeExceptionally(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
-      return future;
-    }
-    dataImportEventPayload.getEventsChain().add(dataImportEventPayload.getEventType());
-    future.complete(dataImportEventPayload);
-    return future;
+  public String getRecordType() {
+    return MARC_AUTHORITY.value();
   }
-
-  @Override
-  public boolean isEligible(DataImportEventPayload dataImportEventPayload) {
-    return (dataImportEventPayload.getContext().containsKey(MARC_AUTHORITY.value()));
-  }
-
-  @Override
-  public boolean isPostProcessingNeeded() {
-    return false;
-  }
-
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class MarcAuthorityEventHandler extends AbstractMarcEventHandler {
 
   @Override
-  public String getRecordType() {
+  public String getEntityType() {
     return MARC_AUTHORITY.value();
   }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcHoldingsEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcHoldingsEventHandler.java
@@ -1,0 +1,14 @@
+package org.folio.services.handlers;
+
+import static org.folio.rest.jaxrs.model.EntityType.MARC_HOLDINGS;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MarcHoldingsEventHandler extends AbstractMarcEventHandler {
+
+  @Override
+  public String getRecordType() {
+    return MARC_HOLDINGS.value();
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcHoldingsEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcHoldingsEventHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class MarcHoldingsEventHandler extends AbstractMarcEventHandler {
 
   @Override
-  public String getRecordType() {
+  public String getEntityType() {
     return MARC_HOLDINGS.value();
   }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
@@ -34,6 +34,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RE
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_HOLDING_RECORD_CREATED;
 
 public class DataImportConsumersVerticle extends AbstractVerticle {
   private static AbstractApplicationContext springGlobalContext;
@@ -42,6 +43,7 @@ public class DataImportConsumersVerticle extends AbstractVerticle {
 
   private final List<String> events = Arrays.asList(DI_SRS_MARC_BIB_RECORD_CREATED.value(),
     DI_SRS_MARC_AUTHORITY_RECORD_CREATED.value(),
+    DI_SRS_MARC_HOLDING_RECORD_CREATED.value(),
     DI_INVENTORY_INSTANCE_CREATED.value(), DI_INVENTORY_INSTANCE_UPDATED.value(),
     DI_INVENTORY_HOLDING_CREATED.value(), DI_INVENTORY_ITEM_CREATED.value(),
     DI_SRS_MARC_BIB_RECORD_MATCHED.value(), DI_SRS_MARC_BIB_RECORD_NOT_MATCHED.value(),

--- a/mod-source-record-storage-server/src/test/java/org/folio/TestMocks.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/TestMocks.java
@@ -86,6 +86,10 @@ public class TestMocks {
     return getRecords(RecordType.MARC_AUTHORITY);
   }
 
+  public static Record getMarcHoldingsRecord() {
+    return getRecords(RecordType.MARC_HOLDING);
+  }
+
   public static Record getEdifactRecord() {
     return getRecords(RecordType.EDIFACT);
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/util/QueryParamUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/util/QueryParamUtilTest.java
@@ -50,6 +50,11 @@ public class QueryParamUtilTest {
   }
 
   @Test
+  public void shouldReturnMarcHoldingsRecordType() {
+    assertEquals(RecordType.MARC_HOLDING, QueryParamUtil.toRecordType("MARC_HOLDING"));
+  }
+
+  @Test
   public void shouldReturnDefaultRecordType() {
     assertEquals(RecordType.MARC_BIB, QueryParamUtil.toRecordType(null));
     assertEquals(RecordType.MARC_BIB, QueryParamUtil.toRecordType(""));

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractMarcEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractMarcEventHandlerTest.java
@@ -1,0 +1,264 @@
+package org.folio.services;
+
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_HOLDING;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+
+import org.folio.DataImportEventPayload;
+import org.folio.TestUtil;
+import org.folio.dao.RecordDao;
+import org.folio.dao.RecordDaoImpl;
+import org.folio.dao.util.SnapshotDaoUtil;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.RawRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.Snapshot;
+import org.folio.services.handlers.AbstractMarcEventHandler;
+import org.folio.services.handlers.MarcAuthorityEventHandler;
+import org.folio.services.handlers.MarcHoldingsEventHandler;
+
+@RunWith(VertxUnitRunner.class)
+public class AbstractMarcEventHandlerTest extends AbstractLBServiceTest {
+
+  private static final String NOT_VALID_ENTITY_TYPE = "notValidEntityType";
+  private static final String PARSED_CONTENT_WITH_ADDITIONAL_FIELDS = "{\"leader\":\"01589ccm a2200373   4500\",\"fields\":[{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Neue Ausgabe sämtlicher Werke,\"}]}},{\"948\":{\"ind1\":\"\",\"ind2\":\"\",\"subfields\":[{\"a\":\"acf4f6e2-115c-4509-9d4c-536c758ef917\"},{\"b\":\"681394b4-10d8-4cb1-a618-0f9bd6152119\"},{\"d\":\"12345\"},{\"e\":\"lts\"},{\"x\":\"addfast\"}]}},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"bc37566c-0053-4e8b-bd39-15935ca36894\"}]}}]}";
+  private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC data";
+  private static final String RECORD_ID = "acf4f6e2-115c-4509-9d4c-536c758ef917";
+  private static final String SNAPSHOT_ID_1 = UUID.randomUUID().toString();
+  private static final String SNAPSHOT_ID_2 = UUID.randomUUID().toString();
+  private static RawRecord rawRecord;
+  private RecordDao recordDao;
+  private Record marcAuthorityRecord;
+  private Record marcHoldingsRecord;
+  private MarcAuthorityEventHandler marcAuthorityEventHandler;
+  private MarcHoldingsEventHandler marcHoldingsEventHandler;
+
+  @BeforeClass
+  public static void setUpClass() throws IOException {
+    rawRecord = new RawRecord().withId(RECORD_ID)
+      .withContent(new ObjectMapper().readValue(TestUtil.readFileFromPath(RAW_MARC_RECORD_CONTENT_SAMPLE_PATH), String.class));
+  }
+
+  @Before
+  public void setUp(TestContext context) {
+    MockitoAnnotations.initMocks(this);
+
+    recordDao = new RecordDaoImpl(postgresClientFactory);
+    marcAuthorityEventHandler = new MarcAuthorityEventHandler();
+    marcHoldingsEventHandler = new MarcHoldingsEventHandler();
+    Async async = context.async();
+
+    Snapshot snapshot1 = new Snapshot()
+      .withJobExecutionId(SNAPSHOT_ID_1)
+      .withProcessingStartedDate(new Date())
+      .withStatus(Snapshot.Status.COMMITTED);
+    Snapshot snapshot2 = new Snapshot()
+      .withJobExecutionId(SNAPSHOT_ID_2)
+      .withProcessingStartedDate(new Date())
+      .withStatus(Snapshot.Status.COMMITTED);
+
+    List<Snapshot> snapshots = new ArrayList<>();
+    snapshots.add(snapshot1);
+    snapshots.add(snapshot2);
+
+    this.marcAuthorityRecord = new Record()
+      .withId(RECORD_ID)
+      .withMatchedId(RECORD_ID)
+      .withSnapshotId(SNAPSHOT_ID_1)
+      .withGeneration(1)
+      .withRecordType(MARC_AUTHORITY)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(new ParsedRecord()
+        .withId(RECORD_ID)
+        .withContent(PARSED_CONTENT_WITH_ADDITIONAL_FIELDS))
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId("681394b4-10d8-4cb1-a618-0f9bd6152119")
+        .withInstanceHrid("12345"))
+      .withState(Record.State.ACTUAL);
+
+    this.marcHoldingsRecord = new Record()
+      .withId(RECORD_ID)
+      .withMatchedId(RECORD_ID)
+      .withSnapshotId(SNAPSHOT_ID_1)
+      .withGeneration(0)
+      .withRecordType(MARC_HOLDING)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(new ParsedRecord()
+        .withId(RECORD_ID)
+        .withContent(PARSED_CONTENT_WITH_ADDITIONAL_FIELDS))
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId("681394b4-10d8-4cb1-a618-0f9bd6152119")
+        .withInstanceHrid("12345"))
+      .withState(Record.State.OLD);
+
+    SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshots).onComplete(save -> {
+      if (save.failed()) {
+        context.fail(save.cause());
+      }
+      async.complete();
+    });
+
+  }
+
+  @After
+  public void cleanUp(TestContext context) {
+    Async async = context.async();
+    SnapshotDaoUtil.deleteAll(postgresClientFactory.getQueryExecutor(TENANT_ID)).onComplete(delete -> {
+      if (delete.failed()) {
+        context.fail(delete.cause());
+      }
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldHandleMarcAuthorityRecord(TestContext context) {
+    shouldHandleMarcRecord(context, marcAuthorityEventHandler, EntityType.MARC_AUTHORITY, marcAuthorityRecord);
+  }
+
+  @Test
+  public void shouldHandleMarcHoldingsRecord(TestContext context) {
+    shouldHandleMarcRecord(context, marcHoldingsEventHandler, EntityType.MARC_HOLDINGS, marcHoldingsRecord);
+  }
+
+  @Test
+  public void shouldNotHandleMarcAuthorityRecordIfContextIsNull(TestContext context) {
+    shouldNotHandleMarcRecord(context, marcAuthorityEventHandler, marcAuthorityRecord, null);
+  }
+
+  @Test
+  public void shouldNotHandleMarcHoldingsRecordIfContextIsNull(TestContext context) {
+    shouldNotHandleMarcRecord(context, marcHoldingsEventHandler, marcHoldingsRecord, null);
+  }
+
+  @Test
+  public void shouldNotHandleMarcAuthorityRecordIfContextIsEmpty(TestContext context) {
+    shouldNotHandleMarcRecord(context, marcAuthorityEventHandler, marcAuthorityRecord, new HashMap<>());
+  }
+
+  @Test
+  public void shouldNotHandleMarcHoldingsRecordIfContextIsEmpty(TestContext context) {
+    shouldNotHandleMarcRecord(context, marcHoldingsEventHandler, marcHoldingsRecord, new HashMap<>());
+  }
+
+  @Test
+  public void shouldNotHandleMarcAuthorityRecordIfContextIsNotEqualEntityType(TestContext context) {
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(NOT_VALID_ENTITY_TYPE, Json.encode(marcAuthorityRecord));
+    shouldNotHandleMarcRecord(context, marcAuthorityEventHandler, marcAuthorityRecord, payloadContext);
+  }
+
+  @Test
+  public void shouldNotHandleMarcHoldingsRecordIfContextIsNotEqualEntityType(TestContext context) {
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(NOT_VALID_ENTITY_TYPE, Json.encode(marcHoldingsRecord));
+    shouldNotHandleMarcRecord(context, marcHoldingsEventHandler, marcHoldingsRecord, payloadContext);
+  }
+
+  @Test
+  public void shouldReturnTrueIfMarcAuthorityPayloadIsEligible(TestContext context) {
+    shouldReturnMarcPayloadIsEligible(context, EntityType.MARC_AUTHORITY.value(), marcAuthorityEventHandler, marcAuthorityRecord, true);
+  }
+
+  @Test
+  public void shouldReturnTrueIfMarcHoldingsPayloadIsEligible(TestContext context) {
+    shouldReturnMarcPayloadIsEligible(context, EntityType.MARC_HOLDINGS.value(), marcHoldingsEventHandler, marcHoldingsRecord, true);
+  }
+
+  @Test
+  public void shouldReturnFalseIfMarcAuthorityPayloadIsEligible(TestContext context) {
+    shouldReturnMarcPayloadIsEligible(context, NOT_VALID_ENTITY_TYPE, marcAuthorityEventHandler, marcAuthorityRecord, false);
+  }
+
+  @Test
+  public void shouldReturnFalseIfMarcHoldingsPayloadIsEligible(TestContext context) {
+    shouldReturnMarcPayloadIsEligible(context, NOT_VALID_ENTITY_TYPE, marcHoldingsEventHandler, marcHoldingsRecord, false);
+  }
+
+  @Test
+  public void shouldReturnFalseIsPostProcessingNeeded(TestContext context) {
+    context.assertFalse(marcAuthorityEventHandler.isPostProcessingNeeded());
+    context.assertFalse(marcHoldingsEventHandler.isPostProcessingNeeded());
+  }
+
+  private void shouldReturnMarcPayloadIsEligible(TestContext context, String entityType, AbstractMarcEventHandler marcEventHandler, Record marcRecord, boolean flag) {
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(entityType, Json.encode(marcRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withContext(payloadContext);
+
+    context.assertEquals(marcEventHandler.isEligible(dataImportEventPayload), flag);
+  }
+
+  private void shouldHandleMarcRecord(TestContext context, AbstractMarcEventHandler marcEventHandler,
+                                      EntityType entityType, Record marcRecord) {
+    Async async = context.async();
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(entityType.value(), Json.encode(marcRecord));
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withContext(payloadContext)
+      .withTenant(TENANT_ID)
+      .withCurrentNode(new ProfileSnapshotWrapper()
+        .withId(UUID.randomUUID().toString())
+        .withContentType(MATCH_PROFILE));
+
+    recordDao.saveRecord(marcRecord, TENANT_ID)
+      .onComplete(context.asyncAssertSuccess())
+      .onSuccess(record -> marcEventHandler.handle(dataImportEventPayload)
+        .whenComplete((updatedEventPayload, throwable) -> {
+          context.assertNull(throwable);
+          context.assertEquals(1, updatedEventPayload.getEventsChain().size());
+          var actualRecord = new JsonObject(updatedEventPayload.getContext().get(entityType.value())).mapTo(Record.class);
+          context.assertEquals(actualRecord.getId(), record.getId());
+          context.assertEquals(actualRecord.getSnapshotId(), record.getSnapshotId());
+          context.assertEquals(actualRecord.getRawRecord(), record.getRawRecord());
+          context.assertEquals(actualRecord.getRecordType(), record.getRecordType());
+          context.assertEquals(actualRecord.getErrorRecord(), record.getErrorRecord());
+          async.complete();
+        }));
+  }
+
+  private void shouldNotHandleMarcRecord(TestContext context, AbstractMarcEventHandler marcEventHandler,
+                                         Record marcRecord, HashMap<String, String> payloadContext) {
+    Async async = context.async();
+
+    DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
+      .withContext(payloadContext)
+      .withTenant(TENANT_ID);
+
+    recordDao.saveRecord(marcRecord, TENANT_ID)
+      .onComplete(context.asyncAssertSuccess())
+      .onSuccess(record -> marcEventHandler.handle(dataImportEventPayload)
+        .whenComplete((updatedEventPayload, throwable) -> {
+          context.assertNotNull(throwable);
+          context.assertEquals(throwable.getMessage(), PAYLOAD_HAS_NO_DATA_MSG);
+          async.complete();
+        }));
+  }
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -114,6 +114,12 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldGetMarcHoldingsRecordsBySnapshotId(TestContext context) {
+    getRecordsBySnapshotId(context, "ee561342-3098-47a8-ab6e-0f3eba120b04", RecordType.MARC_HOLDING,
+      Record.RecordType.MARC_HOLDING);
+  }
+
+  @Test
   public void shouldGetEdifactRecordsBySnapshotId(TestContext context) {
     getRecordsBySnapshotId(context, "dcd898af-03bb-4b12-b8a6-f6a02e86459b", RecordType.EDIFACT, Record.RecordType.EDIFACT);
   }
@@ -164,6 +170,12 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldStreamMarcHoldingsRecordsBySnapshotId(TestContext context) {
+    streamRecordsBySnapshotId(context, "ee561342-3098-47a8-ab6e-0f3eba120b04", RecordType.MARC_HOLDING,
+      Record.RecordType.MARC_HOLDING);
+  }
+
+  @Test
   public void shouldStreamEdifactRecordsBySnapshotId(TestContext context) {
     streamRecordsBySnapshotId(context, "dcd898af-03bb-4b12-b8a6-f6a02e86459b", RecordType.EDIFACT,
       Record.RecordType.EDIFACT);
@@ -175,10 +187,15 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   public void shouldGetMarcBibRecordById(TestContext context) {
     getMarcRecordById(context, TestMocks.getMarcBibRecord());
   }
-  @Test
 
+  @Test
   public void shouldGetMarcAuthorityRecordById(TestContext context) {
     getMarcRecordById(context, TestMocks.getMarcAuthorityRecord());
+  }
+
+  @Test
+  public void shouldGetMarcHoldingsRecordById(TestContext context) {
+    getMarcRecordById(context, TestMocks.getMarcHoldingsRecord());
   }
 
   // TODO: test get by matched id not equal to id
@@ -204,6 +221,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldSaveMarcAuthorityRecord(TestContext context) {
     saveMarcRecord(context, TestMocks.getMarcAuthorityRecord(), Record.RecordType.MARC_AUTHORITY);
+  }
+
+  @Test
+  public void shouldSaveMarcHoldingsRecord(TestContext context) {
+    saveMarcRecord(context, TestMocks.getMarcHoldingsRecord(), Record.RecordType.MARC_HOLDING);
   }
 
   @Test
@@ -388,6 +410,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldStreamMarcHoldingSourceRecords(TestContext context) {
+    streamMarcSourceRecords(context, RecordType.MARC_HOLDING, Record.RecordType.MARC_HOLDING);
+  }
+
+  @Test
   public void shouldStreamEdifactSourceRecords(TestContext context) {
     streamMarcSourceRecords(context, RecordType.EDIFACT, Record.RecordType.EDIFACT);
   }
@@ -403,6 +430,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldGetMarcHoldingsSourceRecordsByListOfIds(TestContext context) {
+    getMarcSourceRecordsByListOfIds(context, Record.RecordType.MARC_HOLDING, RecordType.MARC_HOLDING);
+  }
+
+  @Test
   public void shouldGetMarcBibSourceRecordsByListOfIdsThatAreDeleted(TestContext context) {
     getMarcSourceRecordsByListOfIdsThatAreDeleted(context, Record.RecordType.MARC_BIB, RecordType.MARC_BIB);
   }
@@ -410,6 +442,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetMarcAuthoritySourceRecordsByListOfIdsThatAreDeleted(TestContext context) {
     getMarcSourceRecordsByListOfIdsThatAreDeleted(context, Record.RecordType.MARC_AUTHORITY, RecordType.MARC_AUTHORITY);
+  }
+
+  @Test
+  public void shouldGetMarcHoldingsSourceRecordsByListOfIdsThatAreDeleted(TestContext context) {
+    getMarcSourceRecordsByListOfIdsThatAreDeleted(context, Record.RecordType.MARC_HOLDING, RecordType.MARC_HOLDING);
   }
 
   // TODO: test get source records between two dates
@@ -422,6 +459,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetMarcAuthoritySourceRecordById(TestContext context) {
     getMarcSourceRecordById(context, TestMocks.getMarcAuthorityRecord());
+  }
+
+  @Test
+  public void shouldGetMarcHoldingsSourceRecordById(TestContext context) {
+    getMarcSourceRecordById(context, TestMocks.getMarcHoldingsRecord());
   }
 
   // TODO: test get by matched id not equal to id
@@ -437,6 +479,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldNotGetMarcHoldingsSourceRecordById(TestContext context) {
+    notGetMarcSourceRecordById(context, TestMocks.getMarcHoldingsRecord());
+  }
+
+  @Test
   public void shouldUpdateParsedMarcBibRecords(TestContext context) {
     updateParsedMarcRecords(context, Record.RecordType.MARC_BIB);
   }
@@ -444,6 +491,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldUpdateParsedMarcAuthorityRecords(TestContext context) {
     updateParsedMarcRecords(context, Record.RecordType.MARC_AUTHORITY);
+  }
+
+  @Test
+  public void shouldUpdateParsedMarcHoldingsRecords(TestContext context) {
+    updateParsedMarcRecords(context, Record.RecordType.MARC_HOLDING);
   }
 
   @Test
@@ -457,6 +509,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   }
 
   @Test
+  public void shouldUpdateParsedMarcHoldingsRecordsAndGetOnlyActualRecord(TestContext context) {
+    updateParsedMarcRecordsAndGetOnlyActualRecord(context, TestMocks.getMarcHoldingsRecord());
+  }
+
+  @Test
   public void shouldGetFormattedMarcBibRecord(TestContext context) {
     getFormattedMarcBibRecord(context, TestMocks.getMarcBibRecord());
   }
@@ -464,6 +521,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldGetFormattedMarcAuthorityRecord(TestContext context) {
     getFormattedMarcBibRecord(context, TestMocks.getMarcAuthorityRecord());
+  }
+
+  @Test
+  public void shouldGetFormattedMarcHoldingsRecord(TestContext context) {
+    getFormattedMarcBibRecord(context, TestMocks.getMarcHoldingsRecord());
   }
 
   @Test
@@ -493,6 +555,11 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   @Test
   public void shouldUpdateSuppressFromDiscoveryForMarcAuthorityRecord(TestContext context) {
     updateSuppressFromDiscoveryForMarcRecord(context, TestMocks.getMarcAuthorityRecord());
+  }
+
+  @Test
+  public void shouldUpdateSuppressFromDiscoveryForMarcHoldingsRecord(TestContext context) {
+    updateSuppressFromDiscoveryForMarcRecord(context, TestMocks.getMarcHoldingsRecord());
   }
 
   @Test

--- a/mod-source-record-storage-server/src/test/resources/mock/records/3187432f-9434-40a8-8782-35a111a1491e.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/records/3187432f-9434-40a8-8782-35a111a1491e.json
@@ -1,0 +1,11 @@
+{
+  "id": "3187432f-9434-40a8-8782-35a111a1491e",
+  "snapshotId": "ee561342-3098-47a8-ab6e-0f3eba120b04",
+  "matchedId": "3187432f-9434-40a8-8782-35a111a1491e",
+  "generation": 0,
+  "recordType": "MARC_HOLDING",
+  "deleted": false,
+  "leaderRecordStatus": "n",
+  "order": 0,
+  "state": "ACTUAL"
+}

--- a/mod-source-record-storage-server/src/test/resources/mock/sourceRecords/3187432f-9434-40a8-8782-35a111a1491e.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/sourceRecords/3187432f-9434-40a8-8782-35a111a1491e.json
@@ -1,0 +1,258 @@
+{
+  "recordId" : "3187432f-9434-40a8-8782-35a111a1491e",
+  "snapshotId": "ee561342-3098-47a8-ab6e-0f3eba120b04",
+  "recordType" : "MARC_HOLDING",
+  "rawRecord" : {
+    "id" : "3187432f-9434-40a8-8782-35a111a1491e",
+    "content" : "{\"leader\":\"01463nja a2200313 c 4500\",\"fields\":[{\"001\":\"inst000000000007\"},{\"003\":\"DE-601\"},{\"005\":\"20180118183625.0\"},{\"007\":\"su\\\\uuuuuuuuuuu\"},{\"008\":\"180118s2017\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\000\\\\0\\\\ger\\\\d\"},{\"035\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"(DE-599)GBV1011162431\"}]}},{\"035\":\"1011162431\"},{\"040\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"b\":\"ger\"},{\"c\":\"GBVCP\"},{\"e\":\"rda\"}]}},{\"041\":{\"ind1\":\"0\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"ger\"}]}},{\"100\":{\"ind1\":\"1\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Bach, Johann Sebastian\"},{\"e\":\"KomponistIn\"},{\"4\":\"cmp\"},{\"0\":\"(DE-601)134579348\"},{\"0\":\"(DE-588)11850553X\"}]}},{\"240\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"0\":\"(DE-601)701589477\"},{\"0\":\"(DE-588)300007736\"},{\"a\":\"Ich habe genung\"}]}},{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Cantatas for bass\"},{\"n\":\"4\"},{\"p\":\"Ich habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor\"}]}},{\"246\":{\"ind1\":\"1\",\"ind2\":\"3\",\"subfields\":[{\"i\":\"Abweichender Titel\"},{\"a\":\"Ich habe genung\"}]}},{\"300\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Track 10-14\"}]}},{\"336\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"aufgeführte Musik\"},{\"b\":\"prm\"},{\"2\":\"rdacontent\"}]}},{\"337\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"audio\"},{\"b\":\"s\"},{\"2\":\"rdamedia\"}]}},{\"338\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Audiodisk\"},{\"b\":\"sd\"},{\"2\":\"rdacarrier\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Arfken, Katharina\"},{\"e\":\"InstrumentalmusikerIn\"},{\"4\":\"itr\"},{\"0\":\"(DE-601)576364940\"},{\"0\":\"(DE-588)135158265\"}]}},{\"700\":{\"ind1\":\"1\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Goltz, Gottfried von der\"},{\"e\":\"DirigentIn\"},{\"4\":\"cnd\"},{\"0\":\"(DE-601)081724969\"},{\"0\":\"(DE-588)122080912\"}]}},{\"710\":{\"ind1\":\"2\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"Freiburger Barockorchester\"},{\"e\":\"InstrumentalmusikerIn\"},{\"4\":\"itr\"},{\"0\":\"(DE-601)12121060X\"},{\"0\":\"(DE-588)5066798-1\"}]}},{\"773\":{\"ind1\":\"0\",\"ind2\":\"\\\\\",\"subfields\":[{\"w\":\"(DE-601)895161729\"},{\"t\":\"Cantatas for bass, Bach, Johann Sebastian. - Arles : Harmonia Mundi\"}]}},{\"900\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"a\":\"GBV\"},{\"b\":\"SBB-PK Berlin <1+1A>\"}]}},{\"954\":{\"ind1\":\"\\\\\",\"ind2\":\"\\\\\",\"subfields\":[{\"0\":\"SBB-PK Berlin <1+1A>\"},{\"a\":\"11\"},{\"b\":\"1742288871\"},{\"c\":\"01\"},{\"x\":\"0001\"}]}},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"3187432f-9434-40a8-8782-35a111a1491e\"},{\"i\":\"ce00bca2-9270-4c6b-b096-b83a2e56e8e9\"}]}}]}"
+  },
+  "parsedRecord" : {
+    "id" : "3187432f-9434-40a8-8782-35a111a1491e",
+    "content" : {
+      "fields" : [ {
+        "001" : "inst000000000007"
+      }, {
+        "003" : "DE-601"
+      }, {
+        "005" : "20180118183625.0"
+      }, {
+        "007" : "su\\uuuuuuuuuuu"
+      }, {
+        "008" : "180118s2017\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\000\\0\\ger\\d"
+      }, {
+        "035" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "(DE-599)GBV1011162431"
+          } ]
+        }
+      }, {
+        "035" : "1011162431"
+      }, {
+        "040" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "b" : "ger"
+          }, {
+            "c" : "GBVCP"
+          }, {
+            "e" : "rda"
+          } ]
+        }
+      }, {
+        "041" : {
+          "ind1" : "0",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "ger"
+          } ]
+        }
+      }, {
+        "100" : {
+          "ind1" : "1",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Bach, Johann Sebastian"
+          }, {
+            "e" : "KomponistIn"
+          }, {
+            "4" : "cmp"
+          }, {
+            "0" : "(DE-601)134579348"
+          }, {
+            "0" : "(DE-588)11850553X"
+          } ]
+        }
+      }, {
+        "240" : {
+          "ind1" : "1",
+          "ind2" : "0",
+          "subfields" : [ {
+            "0" : "(DE-601)701589477"
+          }, {
+            "0" : "(DE-588)300007736"
+          }, {
+            "a" : "Ich habe genung"
+          } ]
+        }
+      }, {
+        "245" : {
+          "ind1" : "1",
+          "ind2" : "0",
+          "subfields" : [ {
+            "a" : "Cantatas for bass"
+          }, {
+            "n" : "4"
+          }, {
+            "p" : "Ich habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor"
+          } ]
+        }
+      }, {
+        "246" : {
+          "ind1" : "1",
+          "ind2" : "3",
+          "subfields" : [ {
+            "i" : "Abweichender Titel"
+          }, {
+            "a" : "Ich habe genung"
+          } ]
+        }
+      }, {
+        "300" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Track 10-14"
+          } ]
+        }
+      }, {
+        "336" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "aufgeführte Musik"
+          }, {
+            "b" : "prm"
+          }, {
+            "2" : "rdacontent"
+          } ]
+        }
+      }, {
+        "337" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "audio"
+          }, {
+            "b" : "s"
+          }, {
+            "2" : "rdamedia"
+          } ]
+        }
+      }, {
+        "338" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Audiodisk"
+          }, {
+            "b" : "sd"
+          }, {
+            "2" : "rdacarrier"
+          } ]
+        }
+      }, {
+        "700" : {
+          "ind1" : "1",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Arfken, Katharina"
+          }, {
+            "e" : "InstrumentalmusikerIn"
+          }, {
+            "4" : "itr"
+          }, {
+            "0" : "(DE-601)576364940"
+          }, {
+            "0" : "(DE-588)135158265"
+          } ]
+        }
+      }, {
+        "700" : {
+          "ind1" : "1",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Goltz, Gottfried von der"
+          }, {
+            "e" : "DirigentIn"
+          }, {
+            "4" : "cnd"
+          }, {
+            "0" : "(DE-601)081724969"
+          }, {
+            "0" : "(DE-588)122080912"
+          } ]
+        }
+      }, {
+        "710" : {
+          "ind1" : "2",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "Freiburger Barockorchester"
+          }, {
+            "e" : "InstrumentalmusikerIn"
+          }, {
+            "4" : "itr"
+          }, {
+            "0" : "(DE-601)12121060X"
+          }, {
+            "0" : "(DE-588)5066798-1"
+          } ]
+        }
+      }, {
+        "773" : {
+          "ind1" : "0",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "w" : "(DE-601)895161729"
+          }, {
+            "t" : "Cantatas for bass, Bach, Johann Sebastian. - Arles : Harmonia Mundi"
+          } ]
+        }
+      }, {
+        "900" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "a" : "GBV"
+          }, {
+            "b" : "SBB-PK Berlin <1+1A>"
+          } ]
+        }
+      }, {
+        "954" : {
+          "ind1" : "\\",
+          "ind2" : "\\",
+          "subfields" : [ {
+            "0" : "SBB-PK Berlin <1+1A>"
+          }, {
+            "a" : "11"
+          }, {
+            "b" : "1742288871"
+          }, {
+            "c" : "01"
+          }, {
+            "x" : "0001"
+          } ]
+        }
+      }, {
+        "999" : {
+          "ind1" : "f",
+          "ind2" : "f",
+          "subfields" : [ {
+            "s" : "3187432f-9434-40a8-8782-35a111a1491e"
+          }, {
+            "i" : "ce00bca2-9270-4c6b-b096-b83a2e56e8e9"
+          } ]
+        }
+      } ],
+      "leader" : "01463nja a2200313 c 4500"
+    },
+    "formattedContent" : "LEADER 01463nja a2200313 c 4500\n001 inst000000000007\n003 DE-601\n005 20180118183625.0\n007 su\\uuuuuuuuuuu\n008 180118s2017\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\000\\0\\ger\\d\n035 1011162431\n035 \\\\$a(DE-599)GBV1011162431\n040 \\\\$bger$cGBVCP$erda\n041 0\\$ager\n100 1\\$aBach, Johann Sebastian$eKomponistIn$4cmp$0(DE-601)134579348$0(DE-588)11850553X\n240 10$0(DE-601)701589477$0(DE-588)300007736$aIch habe genung\n245 10$aCantatas for bass$n4$pIch habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor\n246 13$iAbweichender Titel$aIch habe genung\n300 \\\\$aTrack 10-14\n336 \\\\$aaufgeführte Musik$bprm$2rdacontent\n337 \\\\$aaudio$bs$2rdamedia\n338 \\\\$aAudiodisk$bsd$2rdacarrier\n700 1\\$aArfken, Katharina$eInstrumentalmusikerIn$4itr$0(DE-601)576364940$0(DE-588)135158265\n700 1\\$aGoltz, Gottfried von der$eDirigentIn$4cnd$0(DE-601)081724969$0(DE-588)122080912\n710 2\\$aFreiburger Barockorchester$eInstrumentalmusikerIn$4itr$0(DE-601)12121060X$0(DE-588)5066798-1\n773 0\\$w(DE-601)895161729$tCantatas for bass, Bach, Johann Sebastian. - Arles : Harmonia Mundi\n900 \\\\$aGBV$bSBB-PK Berlin <1+1A>\n954 \\\\$0SBB-PK Berlin <1+1A>$a11$b1742288871$c01$x0001\n999 ff$s3187432f-9434-40a8-8782-35a111a1491e$ice00bca2-9270-4c6b-b096-b83a2e56e8e9\n"
+  },
+  "deleted" : false,
+  "externalIdsHolder" : {
+    "instanceId" : "ce00bca2-9270-4c6b-b096-b83a2e56e8e9"
+  },
+  "additionalInfo" : {
+    "suppressDiscovery" : false
+  },
+  "metadata" : {
+    "createdDate" : "2020-03-19T16:43:00.436+0000",
+    "createdByUserId" : "4547e8af-638a-4595-8af8-4d396d6a9f7a",
+    "updatedDate" : "2020-03-19T16:43:01.442+0000",
+    "updatedByUserId" : "4547e8af-638a-4595-8af8-4d396d6a9f7a"
+  }
+}


### PR DESCRIPTION
## Purpose
Storing Marc holdings into SRS

## Approach
- Added enum MARC_HOLDING in the RecordType
- Added DI_SRS_MARC_HOLDING_RECORD_CREATED in the list of events for DataImportConsumersVerticle
- Created MarcHoldingEventHandler
- Registered MarcHoldingEventHandler in the registerEventHandlers into InitAPIImpl

## Learning
https://issues.folio.org/browse/MODSOURCE-341
