### PR TITLE
MODSOURMAN-515  Error log for unknown event type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
+* [MODSOURMAN-515](https://issues.folio.org/browse/MODSOURMAN-515) Error log for unknown event type
 * [MODSOURCE-311](https://issues.folio.org/browse/MODSOURCE-311) Search API: Restrict to search only by marc bib
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/ParsedRecordChunksKafkaHandler.java
@@ -42,8 +42,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ERROR;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_PARSED_RECORDS_CHUNK_SAVED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 
 @Component
 @Qualifier("ParsedRecordChunksKafkaHandler")
@@ -163,7 +163,8 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
       DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
         .withEventType(DI_ERROR.value())
         .withJobExecutionId(jobExecutionId)
-        .withEventsChain(List.of(DI_SRS_MARC_BIB_RECORD_CREATED.value()))
+        .withEventsChain(List.of(DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value()))
+        .withTenant(tenantId)
         .withContext(new HashMap<>(){{
           put(EntityType.MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
           put(ERROR_KEY, message);


### PR DESCRIPTION
## Purpose
It is necessary to ensure that while data import record save and error appearing in mod-source-record-storage, used eventChain type available in mod-source-record-manager’s JournalParams enum

## Approach
- Applied eventChain type in mod-source-record-storage available in JournalParams enum which participates in handling of data import record in mod-source-record-manager.
- Covered with test

## Learning
https://issues.folio.org/browse/MODSOURMAN-515