### PR TITLE
MODPUBSUB-187 Add support for max.request.size configuration for Kafk…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,14 @@
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
 * [MODSOURCE-341](https://issues.folio.org/browse/MODSOURCE-341) Store MARC Holdings record
 
-## 2021-xx-xx v5.1.3
+## xxxx-xx-xx v5.1.4
+* [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
+
+## 2021-07-21 v5.1.3
 * [MODSOURCE-329](https://issues.folio.org/browse/MODSOURCE-329) Create script to clean up Snapshot statuses in mod-source-record-storage
 * [MODSOURMAN-451](https://issues.folio.org/browse/MODSOURMAN-451) Log details for Inventory single record imports for Overlays
 * [MODSOURMAN-508](https://issues.folio.org/browse/MODSOURMAN-508) Log details for Inventory single record imports for Overlays - Part 2
+* Update data-import-processing-core dependency to v3.1.3
 
 ## 2021-06-25 v5.1.2
 * [MODSOURCE-323](https://issues.folio.org/browse/MODSOURCE-323) Change dataType to have common type for MARC related subtypes

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -29,6 +29,8 @@ public class ApplicationConfig {
   private String okapiUrl;
   @Value("${REPLICATION_FACTOR:1}")
   private int replicationFactor;
+  @Value("${MAX_REQUEST_SIZE:1048576}")
+  private int maxRequestSize;
   @Value("${ENV:folio}")
   private String envId;
 
@@ -40,6 +42,7 @@ public class ApplicationConfig {
       .kafkaPort(kafkaPort)
       .okapiUrl(okapiUrl)
       .replicationFactor(replicationFactor)
+      .maxRequestSize(maxRequestSize)
       .build();
     LOGGER.debug("kafkaConfig: {}", kafkaConfig);
 


### PR DESCRIPTION
…a messages

## Purpose
When attempting to import a file the import job does not complete due to the following error
org.apache.kafka.common.errors.RecordTooLargeException: The message is 1287037 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.

## Approach
Add support for max.request.size configuration for Kafka messages

