### PR TITLE
MODSOURCE-351 Endpoint to verify invalid MARC Bib ids in the system

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## xxxx-xx-xx v5.3.0-SNAPSHOT
 * [MODSOURCE-347](https://issues.folio.org/browse/MODSOURCE-347) Upgrade to RAML Module Builder 33.x
+* [MODSOURCE-351](https://issues.folio.org/browse/MODSOURCE-351) Endpoint to verify invalid MARC Bib ids in the system
 
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
 * [MODSOURMAN-515](https://issues.folio.org/browse/MODSOURMAN-515) Error log for unknown event type

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -195,7 +195,7 @@
     },
     {
       "id": "source-storage-batch",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -214,6 +214,15 @@
           "permissionsRequired": [
             "source-storage.records.put"
           ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/source-storage/batch/verified-records",
+          "permissionsRequired": [
+            "source-storage.verified.records"
+          ]
         }
       ]
     },
@@ -294,6 +303,11 @@
       "description": "Get Results"
     },
     {
+      "permissionName": "source-storage.verified.records",
+      "displayName": "Source Storage - validate marc bib ids in the system",
+      "description": "Return marc bib ids, which doesn't exist in the system"
+    },
+    {
       "permissionName": "source-storage.all",
       "displayName": "Source Record Storage - all permissions",
       "description": "Entire set of permissions needed to manage snapshots and records",
@@ -308,7 +322,8 @@
         "source-storage.records.put",
         "source-storage.records.delete",
         "source-storage.record.update",
-        "source-storage.sourceRecords.get"
+        "source-storage.sourceRecords.get",
+        "source-storage.verified.records"
       ],
       "visible": false
     }

--- a/mod-source-record-storage-client/pom.xml
+++ b/mod-source-record-storage-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.2.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.2.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -309,7 +309,7 @@ public interface RecordDao {
   /**
    * Search for non-existent mark bib ids in the system
    *
-   * @param marcBibIds list of invalid marc bib ids
+   * @param marcBibIds list of marc bib ids
    * @param tenantId tenant id
    * @return future with list of invalid marc bib ids
    */

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import io.vertx.sqlclient.Row;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;
+import org.folio.rest.jaxrs.model.MarcBibCollection;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ParsedRecordsBatchResponse;
 import org.folio.rest.jaxrs.model.Record;
@@ -304,4 +305,13 @@ public interface RecordDao {
    * @return future with generic type
    */
   <T> Future<T> executeInTransaction(Function<ReactiveClassicGenericQueryExecutor, Future<T>> action, String tenantId);
+
+  /**
+   * Search for non-existent mark bib ids in the system
+   *
+   * @param marcBibIds list of invalid marc bib ids
+   * @param tenantId tenant id
+   * @return future with list of invalid marc bib ids
+   */
+  Future<MarcBibCollection> verifyMarcBibRecords(List<String> marcBibIds, String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -93,6 +93,7 @@ import static org.folio.rest.jooq.Tables.ERROR_RECORDS_LB;
 import static org.folio.rest.jooq.Tables.RAW_RECORDS_LB;
 import static org.folio.rest.jooq.Tables.RECORDS_LB;
 import static org.folio.rest.jooq.Tables.SNAPSHOTS_LB;
+import static org.folio.rest.jooq.enums.RecordType.MARC_BIB;
 import static org.folio.rest.util.QueryParamUtil.toRecordType;
 import static org.jooq.impl.DSL.countDistinct;
 import static org.jooq.impl.DSL.field;
@@ -781,9 +782,9 @@ public class RecordDaoImpl implements RecordDao {
       dsl.selectDistinct(marcHrid)
         .from("(SELECT unnest(" + DSL.array(marcBibIds.toArray()) + ") as hrid) as marc")
         .leftJoin(RECORDS_LB)
-        .on(RECORDS_LB.INSTANCE_HRID.eq(marcHrid.cast(String.class))
+        .on(RECORDS_LB.EXTERNAL_HRID.eq(marcHrid.cast(String.class))
           .and(RECORDS_LB.RECORD_TYPE.equal(MARC_BIB)))
-        .where(RECORDS_LB.INSTANCE_HRID.isNull())
+        .where(RECORDS_LB.EXTERNAL_HRID.isNull())
     )).map(this::toMarcBibCollection);
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -781,7 +781,8 @@ public class RecordDaoImpl implements RecordDao {
       dsl.selectDistinct(marcHrid)
         .from("(SELECT unnest(" + DSL.array(marcBibIds.toArray()) + ") as hrid) as marc")
         .leftJoin(RECORDS_LB)
-        .on(RECORDS_LB.INSTANCE_HRID.eq(marcHrid.cast(String.class)))
+        .on(RECORDS_LB.INSTANCE_HRID.eq(marcHrid.cast(String.class))
+          .and(RECORDS_LB.RECORD_TYPE.equal(MARC_BIB)))
         .where(RECORDS_LB.INSTANCE_HRID.isNull())
     )).map(this::toMarcBibCollection);
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageBatchImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageBatchImpl.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -33,6 +34,22 @@ public class SourceStorageBatchImpl implements SourceStorageBatch {
   public SourceStorageBatchImpl(Vertx vertx, String tenantId) { //NOSONAR
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
     this.tenantId = TenantTool.calculateTenantId(tenantId);
+  }
+
+  @Override
+  public void postSourceStorageBatchVerifiedRecords(List<String> marcBibIds, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext(v -> {
+      try {
+        recordService.verifyMarcBibRecords(marcBibIds, tenantId)
+          .map(PostSourceStorageBatchVerifiedRecordsResponse::respond200WithApplicationJson)
+          .map(Response.class::cast)
+          .otherwise(ExceptionHelper::mapExceptionToResponse)
+          .onComplete(asyncResultHandler);
+      } catch (Exception e) {
+        LOG.error("Failed to receive marc bib records", e);
+        asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(e)));
+      }
+    });
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -195,7 +195,7 @@ public interface RecordService {
    * Find marc bib ids by incoming arrays from SRM and exclude all valid marc bib and return only marc bib ids,
    * which does not exists in the system
    *
-   * @param marcBibIds list of invalid marc bib ids
+   * @param marcBibIds list of marc bib ids
    * @param tenantId tenant id
    * @return future with list of invalid marc bib ids
    */

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.sqlclient.Row;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -4,9 +4,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.sqlclient.Row;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;
+import org.folio.rest.jaxrs.model.MarcBibCollection;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
 import org.folio.rest.jaxrs.model.ParsedRecordsBatchResponse;
 import org.folio.rest.jaxrs.model.Record;
@@ -189,4 +191,13 @@ public interface RecordService {
    */
   Future<Record> updateSourceRecord(ParsedRecordDto parsedRecordDto, String snapshotId, String tenantId);
 
+  /**
+   * Find marc bib ids by incoming arrays from SRM and exclude all valid marc bib and return only marc bib ids,
+   * which does not exists in the system
+   *
+   * @param marcBibIds list of invalid marc bib ids
+   * @param tenantId tenant id
+   * @return future with list of invalid marc bib ids
+   */
+  Future<MarcBibCollection> verifyMarcBibRecords(List<String> marcBibIds, String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -1,15 +1,40 @@
 package org.folio.services;
 
+import static java.lang.String.format;
+
+import static org.folio.dao.util.RecordDaoUtil.RECORD_NOT_FOUND_TEMPLATE;
+import static org.folio.dao.util.RecordDaoUtil.ensureRecordForeignKeys;
+import static org.folio.dao.util.RecordDaoUtil.ensureRecordHasId;
+import static org.folio.dao.util.RecordDaoUtil.ensureRecordHasSuppressDiscovery;
+import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
+import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
+import static org.folio.rest.util.QueryParamUtil.toRecordType;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+
 import io.reactivex.Flowable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.sqlclient.Row;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jooq.Condition;
+import org.jooq.OrderField;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
 import org.folio.dao.RecordDao;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;
 import org.folio.dao.util.SnapshotDaoUtil;
+import org.folio.rest.jaxrs.model.MarcBibCollection;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
 import org.folio.rest.jaxrs.model.ParsedRecordsBatchResponse;
@@ -20,31 +45,10 @@ import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.folio.rest.jaxrs.model.SourceRecordCollection;
+import org.folio.services.util.EventHandlingUtil;
 import org.folio.services.util.parser.ParseFieldsResult;
 import org.folio.services.util.parser.ParseLeaderResult;
 import org.folio.services.util.parser.SearchExpressionParser;
-import org.jooq.Condition;
-import org.jooq.OrderField;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
-import static java.lang.String.format;
-import static org.folio.dao.util.RecordDaoUtil.RECORD_NOT_FOUND_TEMPLATE;
-import static org.folio.dao.util.RecordDaoUtil.ensureRecordForeignKeys;
-import static org.folio.dao.util.RecordDaoUtil.ensureRecordHasId;
-import static org.folio.dao.util.RecordDaoUtil.ensureRecordHasSuppressDiscovery;
-import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
-import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
-import static org.folio.rest.util.QueryParamUtil.toRecordType;
 
 @Service
 public class RecordServiceImpl implements RecordService {
@@ -202,6 +206,11 @@ public class RecordServiceImpl implements RecordService {
               .withMetadata(parsedRecordDto.getMetadata()), existingRecord.withState(Record.State.OLD))))
         .orElse(Future.failedFuture(new NotFoundException(
           format(RECORD_NOT_FOUND_TEMPLATE, parsedRecordDto.getId()))))), tenantId);
+  }
+
+  @Override
+  public Future<MarcBibCollection> verifyMarcBibRecords(List<String> marcBibIds, String tenantId) {
+    return recordDao.verifyMarcBibRecords(marcBibIds, tenantId);
   }
 
   private Record formatMarcRecord(Record record) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
 import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
@@ -27,6 +28,7 @@ import org.folio.dao.PostgresClientFactory;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.rest.jaxrs.model.AdditionalInfo;
 import org.folio.rest.jaxrs.model.ErrorRecord;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ParsedRecordsBatchResponse;
 import org.folio.rest.jaxrs.model.RawRecord;
@@ -35,6 +37,9 @@ import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.rest.jaxrs.model.Snapshot;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +56,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
 
   private static final String SOURCE_STORAGE_BATCH_RECORDS_PATH = "/source-storage/batch/records";
+  private static final String SOURCE_STORAGE_BATCH_VERIFIED_RECORDS = "/source-storage/batch/verified-records";
   private static final String SOURCE_STORAGE_BATCH_PARSED_RECORDS_PATH = "/source-storage/batch/parsed-records";
 
   private static final String INVALID_POST_REQUEST = "{\"records\":[{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"snapshotId\":\"7f939c0b-618c-4eab-8276-a14e0bfe5728\",\"matchedId\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"generation\":0,\"recordType\":\"MARC_BIB\",\"rawRecord\":{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"content\":\"01104cam \"},\"parsedRecord\":{\"id\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"content\":{\"leader\":\"00000cam a2200277   4500\",\"fields\":[{\"001\":\"in00000000007\"},{\"005\":\"20120817205822.0\"},{\"008\":\"690410s1965    dcu          f000 0 eng  \"},{\"010\":{\"subfields\":[{\"a\":\"65062892\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"600\":{\"subfields\":[{\"a\":\"Ross, Arthur M.\"},{\"q\":\"(Arthur Max),\"},{\"d\":\"1916-1970.\"},{\"0\":\"http://id.loc.gov/authorities/names/n50047449\"}],\"ind1\":\"1\",\"ind2\":\"0\"}}],\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"96fbcc07-d67e-47bd-900d-90ae261edb73\",\"i\":\"5b38b5e6-dfa3-4f51-8b7f-858421310aa7\"}]}}},\"deleted\":false,\"order\":0,\"externalIdsHolder\":{\"instanceId\":\"5b38b5e6-dfa3-4f51-8b7f-858421310aa7\"},\"additionalInfo\":{\"suppressDiscovery\":false},\"state\":\"ACTUAL\",\"leaderRecordStatus\":\"c\"}],\"totalRecords\":1}";
@@ -59,6 +65,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
   private static final String THIRD_UUID = UUID.randomUUID().toString();
   private static final String FOURTH_UUID = UUID.randomUUID().toString();
   private static final String FIFTH_UUID = UUID.randomUUID().toString();
+  public static final String VALID_HRID = "12345";
 
   private static RawRecord rawRecord;
   private static ParsedRecord marcRecord;
@@ -427,6 +434,87 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .body("records.size()", is(1))
       .body("errorMessages.size()", is(1))
       .body("totalRecords", is(1));
+    async.complete();
+  }
+
+  @Test
+  public void shouldNotReturnIdsWhenMarcBibIsExists(TestContext testContext) {
+    searchMarcBibIdsByMatcher(testContext, Collections.singletonList(VALID_HRID), Matchers.empty());
+  }
+
+  @Test
+  public void shouldReturnIdsWhenOneMarcBibIsExistsAndOthersNot(TestContext testContext) {
+    var ids = Arrays.asList(VALID_HRID, "222222", "333333");
+    searchMarcBibIdsByMatcher(testContext, ids, contains("222222", "333333"));
+  }
+
+  @Test
+  public void shouldReturnMarcBibIdsWhichDoesNotExistsInDatabase(TestContext testContext) {
+    var invalidIds = Arrays.asList("111111", "222222");
+    searchMarcBibIdsByMatcher(testContext, invalidIds, contains("111111", "222222"));
+  }
+
+  @Test
+  public void shouldReturnEmptyMarcBibIdsWhenMarcBibIdsAreEmpty(TestContext testContext) {
+    searchMarcBibIdsByMatcher(testContext, Collections.emptyList(), Matchers.empty());
+  }
+
+  public void searchMarcBibIdsByMatcher(TestContext testContext, List<String> ids, Matcher matcher){
+    postSnapshots(testContext, snapshot_1, snapshot_2);
+
+    Record recordWithOldStatus = new Record()
+      .withId(FOURTH_UUID)
+      .withSnapshotId(snapshot_2.getJobExecutionId())
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(marcRecord)
+      .withMatchedId(FOURTH_UUID)
+      .withOrder(1)
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId(UUID.randomUUID().toString())
+        .withInstanceHrid(VALID_HRID))
+      .withState(Record.State.OLD);
+
+    postRecords(testContext, record_1, record_2, record_3, recordWithOldStatus);
+
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(ids)
+      .when()
+      .post(SOURCE_STORAGE_BATCH_VERIFIED_RECORDS)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("invalidMarcBibIds", matcher);
+
+    async.complete();
+  }
+
+  @Test
+  public void shouldReturnBadRequestIfMarcBibIdsAreNotDefined(TestContext testContext) {
+    postSnapshots(testContext, snapshot_1, snapshot_2);
+
+    Record recordWithOldStatus = new Record()
+      .withId(FOURTH_UUID)
+      .withSnapshotId(snapshot_2.getJobExecutionId())
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(marcRecord)
+      .withMatchedId(FOURTH_UUID)
+      .withOrder(1)
+      .withState(Record.State.OLD);
+
+    postRecords(testContext, record_1, record_2, record_3, recordWithOldStatus);
+
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .post(SOURCE_STORAGE_BATCH_VERIFIED_RECORDS)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body(containsString("The object to be validated must not be null."));
+
     async.complete();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-source-record-storage</artifactId>
-  <version>5.2.0-SNAPSHOT</version>
+  <version>5.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/ramls/source-record-storage-batch.raml
+++ b/ramls/source-record-storage-batch.raml
@@ -14,11 +14,37 @@ types:
   recordsBatchResponse: !include raml-storage/schemas/dto/recordsBatchResponse.json
   parsedRecordsBatchResponse: !include raml-storage/schemas/dto/parsedRecordsBatchResponse.json
   errors: !include raml-storage/raml-util/schemas/errors.schema
+  marcBibCollection: !include raml-storage/schemas/dto/marcBibCollection.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml
 
 /source-storage/batch:
+  /verified-records:
+     displayName: Verify Marc Holdings Records 004 field
+     description: Verify Marc Holdings Records 004 field
+     post:
+       description: Get a list of invalid Marc Bib Record IDs, which doesn't exists in the system
+       is: [validate]
+       body:
+         application/json:
+           description: List of Marc Bib Record IDs
+           type: string[]
+       responses:
+         200:
+           body:
+             application/json:
+               type: marcBibCollection
+         400:
+           description: Bad request
+           body:
+             text/plain:
+               example: "Bad request"
+         500:
+           description: Internal server error
+           body:
+             text/plain:
+               example: "Internal server error"
   /records:
     post:
       description: "Creates records from a record collection. It returns both saved records and error messages for records that were not saved."


### PR DESCRIPTION
## Purpose
Search MARC BIB ids in the system and return invalid HRID 

## Approach
- Create endpoint for searching invalid MARC BIb ids
- Extend or create new raml for endpoint
- Create DTO for returning response into SRM
- Implement DAO and service layer
- Сhange module descriptor
- Update new version
- Write tests

## Learning
https://issues.folio.org/browse/MODSOURCE-351
