### PR TITLE
MODSOURCE-354 Filtering the number of MARC Bib ids in the SRS

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -194,7 +194,7 @@ public interface RecordService {
    * Find marc bib ids by incoming arrays from SRM and exclude all valid marc bib and return only marc bib ids,
    * which does not exists in the system
    *
-   * @param marcBibIds list of marc bib ids
+   * @param marcBibIds list of marc bib ids (max size - 32767)
    * @param tenantId tenant id
    * @return future with list of invalid marc bib ids
    */

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -210,6 +210,7 @@ public class RecordServiceImpl implements RecordService {
 
   @Override
   public Future<MarcBibCollection> verifyMarcBibRecords(List<String> marcBibIds, String tenantId) {
+    if (marcBibIds.size() > Short.MAX_VALUE) throw new BadRequestException("The number of IDs should not exceed 32767");
     return recordDao.verifyMarcBibRecords(marcBibIds, tenantId);
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
@@ -996,4 +996,30 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
     async.complete();
   }
 
+  @Test
+  public void shouldReturnIdsWhenQueryParamListNotExceedMaxSize(TestContext testContext) {
+    String [] ids = new String[32767];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i]= "invalidId";
+    }
+    searchMarcBibIdsByMatcher(testContext, Arrays.asList(ids), contains("invalidId"));
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenQueryParamListExceedMaxSize(TestContext testContext){
+    postSnapshots(testContext, snapshot_1, snapshot_2);
+    postRecords(testContext, record_1, record_2, record_3);
+
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .body(Arrays.asList(new String[32768]))
+      .when()
+      .post(SOURCE_STORAGE_BATCH_VERIFIED_RECORDS)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body(containsString("The number of IDs should not exceed 32767"));
+
+    async.complete();
+  }
 }


### PR DESCRIPTION
## Purpose
Due to the fact that the Postgres has restrictions on the number of query parameters, it is necessary to create a filter for the number of МАRC Bib ids

## Approach
Add checking number of HRID for endpoint: /source-storage/batch/verified-records.    The number of IDs should not exceed 32767.

## Learning
https://issues.folio.org/browse/MODSOURCE-354
