### PR TITLE
[MODSOURCE-368] Fix "fill-instance-hrid" script for envs where it was applied before

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-09-08 v5.1.6
+* [MODSOURCE-368](https://issues.folio.org/browse/MODSOURCE-368) Fix "fill-instance-hrid" script for envs where it was applied before
+
 ## 2021-09-02 v5.1.5
 * [MODSOURCE-357](https://issues.folio.org/browse/MODSOURCE-357) Improve "fill-instance-hrid" script for avoid failing if invalid data exists.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-xx-xx v5.1.5
+* [MODSOURCE-357](https://issues.folio.org/browse/MODSOURCE-357) Improve "fill-instance-hrid" script for avoid failing if invalid data exists.
+
 ## 2021-08-04 v5.1.4
 * [MODSOURCE-345](https://issues.folio.org/browse/MODSOURCE-345) Error log for unknown event type
 * [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-09-09--15-00-fill-instance-hrid.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-09-09--15-00-fill-instance-hrid.xml
@@ -14,7 +14,7 @@
       (SELECT fields
       FROM ${database.defaultSchemaName}.marc_records_lb
       CROSS JOIN LATERAL jsonb_array_elements((marc_records_lb.content #>> '{}')::jsonb -> 'fields') AS fields
-      WHERE fields ?? '001' AND records_lb.id = ${database.defaultSchemaName}.marc_records_lb.id) ->> '001'
+      WHERE fields ?? '001' AND records_lb.id = ${database.defaultSchemaName}.marc_records_lb.id LIMIT 1) ->> '001'
       WHERE records_lb.instance_id NOTNULL;
     </sql>
   </changeSet>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-09-09--15-00-fill-instance-hrid.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.2/2020-09-09--15-00-fill-instance-hrid.xml
@@ -5,6 +5,7 @@
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
 
   <changeSet id="2020-09-09--15-00-fill-instance-hrid" author="VolodymyrRohach">
+    <validCheckSum>ANY</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <tableExists tableName="records_lb" schemaName="${database.defaultSchemaName}"/>
     </preConditions>


### PR DESCRIPTION
Currently script to fill instance hrid not passes cheksum validation on envs where it was successfully applied before and this error is triggered:
` liquibase/tenant/scripts/v-0.0.2/2020-09-09--15-00-fill-instance-hrid.xml::2020-09-09--15-00-fill-instance-hrid::VolodymyrRohach was: 8:590448842073a494c41e9c242da24966 but is now: 8:fe37e90b4e88dfcb0784f26aed7ed33f`

`12:16:44.332 [vert.x-eventloop-thread-1] ERROR LiquibaseUtil        [6436779eqId] Error while initializing schema fs00001013_mod_source_record_storage for tenant fs00001013
liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum`
     
Adding  `<validCheckSum>ANY</validCheckSum>`  will disable checksum validation, I tested locally where this script was already applied previously and I changed liquibase change set content and liqubiase update command was not fail when`<validCheckSum>ANY</validCheckSum>` presented