### PR TITLE
MODSOURCE-360 The DB type MARC did not get updated to MARC_BIB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURCE-347](https://issues.folio.org/browse/MODSOURCE-347) Upgrade to RAML Module Builder 33.x
 * [MODSOURCE-351](https://issues.folio.org/browse/MODSOURCE-351) Endpoint to verify invalid MARC Bib ids in the system
 * [MODSOURCE-357](https://issues.folio.org/browse/MODSOURCE-357) Improve "fill-instance-hrid" script for avoid failing if invalid data exists.
+* [MODSOURCE-360](https://issues.folio.org/browse/MODSOURCE-360) The DB type MARC did not get updated to MARC_BIB
 
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
 * [MODSOURMAN-515](https://issues.folio.org/browse/MODSOURMAN-515) Error log for unknown event type

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -60,4 +60,5 @@
   <include file="scripts/v-5.0.6-5.1.3-5.2.0/2021-08-04--16-00-rename-instance-hrid.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.0.6-5.1.3-5.2.0/2021-08-04--16-00-rename-instance-id.xml" relativeToChangelogFile="true"/>
 
+  <include file="scripts/v-5.2.1/2021-09-07--18-00-update-record-types.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
@@ -4,14 +4,10 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false" runOnChange="true">
+  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
-        SELECT COUNT(*)
-        FROM pg_type t
-        JOIN pg_enum e ON t.oid = e.enumtypid
-        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = '${database.defaultSchemaName}';
+        SELECT COUNT(*) FROM pg_enum as p WHERE enumlabel='MARC' ;
       </sqlCheck>
     </preConditions>
     <sql>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
@@ -7,7 +7,11 @@
   <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
-        SELECT COUNT(*) FROM pg_enum as p WHERE enumlabel='MARC' ;
+        SELECT COUNT(*)
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = ${database.defaultSchemaName};
       </sqlCheck>
     </preConditions>
     <sql>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
@@ -4,14 +4,14 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false">
+  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false" runOnChange="true">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         SELECT COUNT(*)
         FROM pg_type t
         JOIN pg_enum e ON t.oid = e.enumtypid
         JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = ${database.defaultSchemaName};
+        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = '${database.defaultSchemaName}';
       </sqlCheck>
     </preConditions>
     <sql>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.2.1/2021-09-07--18-00-update-record-types.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.2.1/2021-09-07--18-00-update-record-types.xml
@@ -1,0 +1,21 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <changeSet id="2021-09-07--18-00-rename-marc-type-to-marc-bib" author="SerhiiZdorenko" runInTransaction="false">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(*)
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = '${database.defaultSchemaName}';
+      </sqlCheck>
+    </preConditions>
+    <sql>
+      ALTER TYPE ${database.defaultSchemaName}.record_type RENAME VALUE 'MARC' TO 'MARC_BIB';
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
After updating mod-srs to version 5.1.4, data import failed with the errors:
 WARN RecordDaoImpl [376802223eqId] Error occurred on batch execution: ERROR: invalid input value for enum record_type: "MARC_BIB"

## Approach
Create a new liquibase changeset to fix bug

## Learning
https://issues.folio.org/browse/MODSOURCE-360
