### PR TITLE
MODSOURCE-360 The DB type MARC did not get updated to MARC_BIB

### DIFF
--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-27--14-00-update-record-types.xml
@@ -4,10 +4,14 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false">
+  <changeSet id="2021-05-27--14-00-rename-marc-type-to-marc-bib" author="OleksandrDekin" runInTransaction="false" runOnChange="true">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
-        SELECT COUNT(*) FROM pg_enum as p WHERE enumlabel='MARC' ;
+        SELECT COUNT(*)
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        WHERE e.enumlabel='MARC' AND t.typname = 'record_type' AND n.nspname = '${database.defaultSchemaName}';
       </sqlCheck>
     </preConditions>
     <sql>


### PR DESCRIPTION
## Purpose
After updating mod-srs to version 5.1.4, data import failed with the errors:
 WARN RecordDaoImpl [376802223eqId] Error occurred on batch execution: ERROR: invalid input value for enum record_type: "MARC_BIB"

## Approach
Create a new liquibase changeset to fix bug

## Learning
https://issues.folio.org/browse/MODSOURCE-360
