### PR TITLE
MODSOURCE-382 Remove dependency on SRM client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODSOURCE-368](https://issues.folio.org/browse/MODSOURCE-368) Fix "fill-instance-hrid" script for envs where it was applied before
 * [MODSOURCE-326](https://issues.folio.org/browse/MODSOURCE-326) /source-storage/records?limit=0 returns "totalRecords": 0
 * [MODSOURCE-286](https://issues.folio.org/browse/MODSOURCE-286) Remove zipping mechanism for data import event payloads and use cache for params
+* [MODSOURCE-382](https://issues.folio.org/browse/MODSOURCE-382) Remove dependency on SRM client
 
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
 * [MODSOURMAN-515](https://issues.folio.org/browse/MODSOURMAN-515) Error log for unknown event type

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -223,11 +223,6 @@
       <artifactId>mod-data-import-converter-storage-client</artifactId>
       <version>1.12.0-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>mod-source-record-manager-client</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/ModifyRecordEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/ModifyRecordEventHandlerTest.java
@@ -12,6 +12,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
@@ -134,6 +135,9 @@ public class ModifyRecordEventHandlerTest extends AbstractLBServiceTest {
     WireMockConfiguration.wireMockConfig()
       .dynamicPort()
       .notifier(new Slf4jNotifier(true)));
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @BeforeClass
   public static void setUpClass() throws IOException {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
@@ -28,9 +28,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.rest.jaxrs.model.MappingMetadataDto;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,6 +52,9 @@ import org.folio.services.util.AdditionalFieldsUtil;
 
 @RunWith(VertxUnitRunner.class)
 public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessingEventHandlerTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @Override
   protected Record.RecordType getMarcType() {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -9,6 +9,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
@@ -26,6 +27,7 @@ import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.services.util.AdditionalFieldsUtil;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +53,9 @@ import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 @RunWith(VertxUnitRunner.class)
 public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessingEventHandlerTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @Override
   protected Record.RecordType getMarcType() {

--- a/ramls/source-record-storage-records.raml
+++ b/ramls/source-record-storage-records.raml
@@ -23,6 +23,7 @@ types:
   dataImportEventPayload: !include raml-storage/schemas/common/dataImportEventPayload.json
   marcData: !include raml-storage/schemas/mod-data-import-converter-storage/mapping-profile-detail/marcData.json
   errors: !include raml-storage/raml-util/schemas/errors.schema
+  mappingMetadataDto: !include raml-storage/schemas/dto/mappingMetadataDto.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml


### PR DESCRIPTION
## Purpose
Remove dependency on SRM client. Use simple http call to SRM to retrieve mapping metadata from SRM

## Approach
Removed SRM dependency from SRS.

## Learning
[MODSOURCE-382](https://issues.folio.org/browse/MODSOURCE-382)
