### PR TITLE
MODSOURCE-385. Remove dependency on converter-storage client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURCE-326](https://issues.folio.org/browse/MODSOURCE-326) /source-storage/records?limit=0 returns "totalRecords": 0
 * [MODSOURCE-286](https://issues.folio.org/browse/MODSOURCE-286) Remove zipping mechanism for data import event payloads and use cache for params
 * [MODSOURCE-382](https://issues.folio.org/browse/MODSOURCE-382) Remove dependency on SRM client
+* [MODSOURCE-385](https://issues.folio.org/browse/MODSOURCE-385) Remove dependency on converter-storage client
 
 ## xxxx-xx-xx v5.2.0-SNAPSHOT
 * [MODSOURMAN-515](https://issues.folio.org/browse/MODSOURMAN-515) Error log for unknown event type

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -246,6 +246,16 @@
       ]
     }
   ],
+  "optional": [
+    {
+      "id": "mapping-metadata-provider",
+      "version": "1.0"
+    },
+    {
+      "id": "data-import-converter-storage",
+      "version": "1.2"
+    }
+  ],
   "permissionSets": [
     {
       "permissionName": "source-storage.populate.records",

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -218,11 +218,6 @@
       <artifactId>caffeine</artifactId>
       <version>2.8.5</version>
     </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>mod-data-import-converter-storage-client</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/caches/JobProfileSnapshotCacheTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/caches/JobProfileSnapshotCacheTest.java
@@ -11,11 +11,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.dataimport.util.RestUtil;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-import org.folio.services.caches.JobProfileSnapshotCache;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +38,9 @@ public class JobProfileSnapshotCacheTest {
 
   private Vertx vertx = Vertx.vertx();
   private JobProfileSnapshotCache jobProfileSnapshotCache = new JobProfileSnapshotCache(vertx);
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(


### PR DESCRIPTION
## Purpose
Remove dependency on converter-storage client. Use simple http call to converter-storage to retrieve job profile snapshots from converter-storage.

Add converter storage as optional dependency

## Approach
By deleting dependency from pom and using RestUtils to perform REST requests.
Converter-storage and srm became as optional interfaces.
Docs regarding optional interfaces: https://github.com/folio-org/okapi/blob/master/doc/guide.md#optional-interfaces
Story to introduce optional interfaces in Okapi: https://issues.folio.org/browse/OKAPI-509

