### PR TITLE
MODSOURCE-387 - Optimistic locking: mod-source-record-storage modifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-xx-xx v5.3.0-SNAPSHOT
 * [MODSOURCE-261](https://issues.folio.org/browse/MODSOURCE-261) Cover kafka handlers with tests and fix ignored
+* [MODSOURCE-387](https://issues.folio.org/browse/MODSOURCE-387) Optimistic locking: mod-source-record-storage modifications
 
 ## 2021-09-30 v5.2.0
 * [MODSOURCE-347](https://issues.folio.org/browse/MODSOURCE-347) Upgrade to RAML Module Builder 33.x

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
@@ -122,7 +122,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
       .withId(record.getMatchedId())
       .withParsedRecord(new ParsedRecord()
         .withContent(UPDATED_PARSED_RECORD_CONTENT))
-      .withQmRecordVersion("1")
+      .withRelatedRecordVersion("1")
       .withRecordType(ParsedRecordDto.RecordType.MARC_BIB);
 
     var payload = new HashMap<String, String>();

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
@@ -122,6 +122,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
       .withId(record.getMatchedId())
       .withParsedRecord(new ParsedRecord()
         .withContent(UPDATED_PARSED_RECORD_CONTENT))
+      .withQmRecordVersion("1")
       .withRecordType(ParsedRecordDto.RecordType.MARC_BIB);
 
     var payload = new HashMap<String, String>();


### PR DESCRIPTION
## Purpose
In the scope of the Optimistic locking feature, mod-source-record-storage needs to pass along 'relatedRecordVersion' through the event chain. This story intended to add this field and update test(s).

## Approach
updated raml storage to have the latest updates from the master branch
updated test with new property 'relatedRecordVersion'


