### PR TITLE
MODSOURCE-402 Properly handle DB failures during events processing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURCE-387](https://issues.folio.org/browse/MODSOURCE-387) Optimistic locking: mod-source-record-storage modifications
 * [MODSOURCE-290](https://issues.folio.org/browse/MODSOURCE-290) Implement ProcessRecordErrorHandler for Kafka Consumers
 * [MODSOURCE-401](https://issues.folio.org/browse/MODSOURCE-401) Left anchored srs api queries don't complete on kiwi bugfest
+* [MODSOURCE-402](https://issues.folio.org/browse/MODSOURCE-402) Properly handle DB failures during events processing
 
 ## 2021-xx-xx v5.2.1-SNAPSHOT
 * [MODSOURCE-390](https://issues.folio.org/browse/MODSOURCE-390) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/exceptions/DuplicateEventException.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/exceptions/DuplicateEventException.java
@@ -1,0 +1,8 @@
+package org.folio.dao.exceptions;
+
+public class DuplicateEventException extends RuntimeException {
+
+  public DuplicateEventException(String message) {
+    super(message);
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
@@ -8,6 +8,7 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dao.exceptions.DuplicateEventException;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaHeaderUtils;
@@ -57,7 +58,11 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
     String jobExecutionId = okapiConnectionParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);
     String tenantId = okapiConnectionParams.getTenantId();
 
-    sendErrorRecordsSavingEvents(recordCollection, throwable.getMessage(), kafkaHeaders, jobExecutionId, tenantId);
+    if(throwable instanceof DuplicateEventException) {
+      LOGGER.warn("Error parsing event for jobExecutionId: {} , tenantId: {}, cause: {}", jobExecutionId, tenantId, throwable.getMessage());
+    } else {
+      sendErrorRecordsSavingEvents(recordCollection, throwable.getMessage(), kafkaHeaders, jobExecutionId, tenantId);
+    }
   }
 
   private void sendErrorRecordsSavingEvents(RecordCollection recordCollection, String message, List<KafkaHeader> kafkaHeaders, String jobExecutionId, String tenantId) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
@@ -59,7 +59,7 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
     String tenantId = okapiConnectionParams.getTenantId();
 
     if(throwable instanceof DuplicateEventException) {
-      LOGGER.warn("Error parsing event for jobExecutionId: {} , tenantId: {}, cause: {}", jobExecutionId, tenantId, throwable.getMessage());
+      LOGGER.warn("Duplicate event received, skipping processing fot jobExecutionId: {} , tenantId: {}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, recordCollection.getTotalRecords(), throwable.getMessage());
     } else {
       sendErrorRecordsSavingEvents(recordCollection, throwable.getMessage(), kafkaHeaders, jobExecutionId, tenantId);
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
@@ -40,6 +40,7 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
 
   public static final String ERROR_KEY = "ERROR";
   public static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
+  public static final String CORRELATION_ID_HEADER = "correlationId";
   public static final String RECORD_ID_HEADER = "recordId";
 
   @Autowired
@@ -56,10 +57,11 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
 
     String jobExecutionId = okapiConnectionParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);
+    String correlationId = okapiConnectionParams.getHeaders().get(CORRELATION_ID_HEADER);
     String tenantId = okapiConnectionParams.getTenantId();
 
     if(throwable instanceof DuplicateEventException) {
-      LOGGER.warn("Duplicate event received, skipping processing fot jobExecutionId: {} , tenantId: {}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, recordCollection.getTotalRecords(), throwable.getMessage());
+      LOGGER.warn("Duplicate event received, skipping processing for jobExecutionId: {} , tenantId: {}, correlationId:{}, totalRecords: {}, cause: {}", jobExecutionId, tenantId, correlationId, recordCollection.getTotalRecords(), throwable.getMessage());
     } else {
       sendErrorRecordsSavingEvents(recordCollection, throwable.getMessage(), kafkaHeaders, jobExecutionId, tenantId);
     }


### PR DESCRIPTION
## Purpose
Prevent sending events from srs during duplicate event

## Approach
- Finding a duplicate event by throwing a unique constraint violation
- Throws a custom exception and handles in ParsedRecordChunksErrorHandler (only output to logs, do not send DI_ERROR)

## Learning
https://issues.folio.org/browse/MODSOURCE-402
