### PR TITLE
MODSOURCE-403 Support authority id for MARC Authority

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
@@ -4,6 +4,7 @@ public enum IdType {
 
   INSTANCE("instanceId"),
   HOLDINGS("holdingsId"),
+  AUTHORITY("authorityId"),
   EXTERNAL("externalId"),
   // NOTE: not really external id but is default from dto
   RECORD("matchedId");

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -620,6 +620,8 @@ public final class RecordDaoUtil {
     } else if (RecordType.MARC_HOLDING == pojo.getRecordType()) {
       externalIdOptional.ifPresent(externalIdsHolder::setHoldingsId);
       externalHridOptional.ifPresent(externalIdsHolder::setHoldingsHrid);
+    } else if (RecordType.MARC_AUTHORITY == pojo.getRecordType()) {
+      externalIdOptional.ifPresent(externalIdsHolder::setAuthorityId);
     }
     return externalIdsHolder;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -312,12 +312,10 @@ public final class RecordDaoUtil {
       return externalIdsHolder.getInstanceId();
     } else if (Record.RecordType.MARC_HOLDING == recordType) {
       return externalIdsHolder.getHoldingsId();
-    }  else if (Record.RecordType.MARC_AUTHORITY == recordType) {
+    } else if (Record.RecordType.MARC_AUTHORITY == recordType) {
       return externalIdsHolder.getAuthorityId();
     }
-    else {
-      return null;
-    }
+    return null;
   }
 
   public static String getExternalHrid(ExternalIdsHolder externalIdsHolder, Record.RecordType recordType) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
@@ -313,7 +312,10 @@ public final class RecordDaoUtil {
       return externalIdsHolder.getInstanceId();
     } else if (Record.RecordType.MARC_HOLDING == recordType) {
       return externalIdsHolder.getHoldingsId();
-    } else {
+    }  else if (Record.RecordType.MARC_AUTHORITY == recordType) {
+      return externalIdsHolder.getAuthorityId();
+    }
+    else {
       return null;
     }
   }
@@ -657,6 +659,9 @@ public final class RecordDaoUtil {
     } else if (idType == IdType.INSTANCE) {
       idTypeToUse = IdType.EXTERNAL;
       recordType = RecordType.MARC_BIB;
+    } else if (idType == IdType.AUTHORITY) {
+      idTypeToUse = IdType.EXTERNAL;
+      recordType = RecordType.MARC_AUTHORITY;
     }
     var idField = RECORDS_LB.field(LOWER_CAMEL.to(LOWER_UNDERSCORE, idTypeToUse.getIdField()), UUID.class);
     return idFieldToConditionMapper.apply(idField).and(getRecordTypeCondition(recordType));

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -17,7 +17,6 @@ import org.folio.processing.events.EventManager;
 import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.services.handlers.HoldingsPostProcessingEventHandler;
 import org.folio.services.handlers.InstancePostProcessingEventHandler;
-import org.folio.services.handlers.MarcAuthorityEventHandler;
 import org.folio.services.handlers.MarcBibliographicMatchEventHandler;
 import org.folio.services.handlers.actions.ModifyRecordEventHandler;
 import org.folio.spring.SpringContextUtil;
@@ -43,9 +42,6 @@ public class InitAPIImpl implements InitAPI {
 
   @Autowired
   private MarcBibliographicMatchEventHandler marcBibliographicMatchEventHandler;
-
-  @Autowired
-  private MarcAuthorityEventHandler marcAuthorityEventHandler;
 
   @Value("${srs.kafka.ParsedMarcChunkConsumer.instancesNumber:1}")
   private int parsedMarcChunkConsumerInstancesNumber;
@@ -80,7 +76,6 @@ public class InitAPIImpl implements InitAPI {
     EventManager.registerEventHandler(holdingsPostProcessingEventHandler);
     EventManager.registerEventHandler(modifyRecordEventHandler);
     EventManager.registerEventHandler(marcBibliographicMatchEventHandler);
-    EventManager.registerEventHandler(marcAuthorityEventHandler);
   }
 
   private Future<?> deployConsumerVerticles(Vertx vertx) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/MarcAuthorityEventHandler.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_AUTHORITY;
 
-@Component
+//TODO remove or change this handler after MODSOURCE-409
 public class MarcAuthorityEventHandler implements EventHandler {
   private static final Logger LOG = LogManager.getLogger();
   private static final String PAYLOAD_HAS_NO_DATA_MSG = "Failed to handle event payload, cause event payload context does not contain MARC_AUTHORITY data";

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -304,6 +304,11 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
   }
 
   @Test
+  public void shouldReturnSpecificMarcAuthoritySourceRecordOnGetByDefaultExternalId(TestContext testContext) {
+    returnSpecificMarcSourceRecordOnGetByDefaultExternalId(testContext, snapshot_4, RecordType.MARC_AUTHORITY);
+  }
+
+  @Test
   public void shouldReturnSpecificSourceRecordOnGetByInstanceExternalId(TestContext testContext) {
     returnSpecificMarcSourceRecordOnGetByExternalId(testContext, snapshot_2, RecordType.MARC_BIB);
   }
@@ -311,6 +316,11 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
   @Test
   public void shouldReturnSpecificMarcHoldingsSourceRecordOnGetByHoldingsExternalId(TestContext testContext) {
     returnSpecificMarcSourceRecordOnGetByExternalId(testContext, snapshot_5, RecordType.MARC_HOLDING);
+  }
+
+  @Test
+  public void shouldReturnSpecificMarcAuthoritySourceRecordOnGetByHoldingsExternalId(TestContext testContext) {
+    returnSpecificMarcSourceRecordOnGetByExternalId(testContext, snapshot_4, RecordType.MARC_AUTHORITY);
   }
 
   @Test
@@ -1324,6 +1334,9 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
     } else if (recordType == RecordType.MARC_HOLDING) {
       validatableResponse
         .body("externalIdsHolder.holdingsId", is(SECOND_UUID));
+    } else if (recordType == RecordType.MARC_AUTHORITY) {
+      validatableResponse
+        .body("externalIdsHolder.authorityId", is(SECOND_UUID));
     }
     async.complete();
   }
@@ -1405,7 +1418,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
     async.complete();
 
     async = testContext.async();
-    var idType = recordType == RecordType.MARC_BIB ? "INSTANCE" : "HOLDINGS";
+    var idType = getIdType(recordType);
     var validatableResponse = RestAssured.given()
       .spec(spec)
       .when()
@@ -1419,8 +1432,23 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
     } else if (recordType == RecordType.MARC_HOLDING) {
       validatableResponse
         .body("externalIdsHolder.holdingsId", is(externalId));
+    } else if (recordType == RecordType.MARC_AUTHORITY) {
+      validatableResponse
+        .body("externalIdsHolder.authorityId", is(externalId));
     }
     async.complete();
+  }
+
+  private String getIdType(RecordType recordType){
+    if (Record.RecordType.MARC_BIB == recordType) {
+      return Record.RecordType.MARC_BIB.name();
+    } else if (Record.RecordType.MARC_HOLDING == recordType) {
+      return Record.RecordType.MARC_HOLDING.name();
+    } else if (Record.RecordType.MARC_AUTHORITY == recordType) {
+      return Record.RecordType.MARC_AUTHORITY.name();
+    } else {
+      return null;
+    }
   }
 
   private void returnSpecificNumberOfMarcSourceRecordsOnGetByExternalHrid(TestContext testContext,
@@ -1529,6 +1557,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       record.setExternalIdsHolder(new ExternalIdsHolder().withInstanceId(id).withInstanceHrid(hrid));
     } else if (recordType == RecordType.MARC_HOLDING) {
       record.setExternalIdsHolder(new ExternalIdsHolder().withHoldingsId(id).withHoldingsHrid(hrid));
+    } else if (recordType == RecordType.MARC_AUTHORITY) {
+      record.setExternalIdsHolder(new ExternalIdsHolder().withAuthorityId(id));
     }
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -1441,11 +1441,11 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
 
   private String getIdType(RecordType recordType){
     if (Record.RecordType.MARC_BIB == recordType) {
-      return Record.RecordType.MARC_BIB.name();
+      return "INSTANCE";
     } else if (Record.RecordType.MARC_HOLDING == recordType) {
-      return Record.RecordType.MARC_HOLDING.name();
+      return "HOLDINGS";
     } else if (Record.RecordType.MARC_AUTHORITY == recordType) {
-      return Record.RecordType.MARC_AUTHORITY.name();
+      return "AUTHORITY";
     } else {
       return null;
     }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/util/QueryParamUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/util/QueryParamUtilTest.java
@@ -29,6 +29,11 @@ public class QueryParamUtilTest {
   }
 
   @Test
+  public void shouldReturnExternalIdTypeOnAuthority() {
+    assertEquals(IdType.AUTHORITY, QueryParamUtil.toExternalIdType("AUTHORITY"));
+  }
+
+  @Test
   public void shouldReturnDefaultExternalIdType() {
     assertEquals(IdType.RECORD, QueryParamUtil.toExternalIdType(null));
     assertEquals(IdType.RECORD, QueryParamUtil.toExternalIdType(""));

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcEventHandlerTest.java
@@ -19,6 +19,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
@@ -37,7 +38,7 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.services.handlers.MarcAuthorityEventHandler;
 
-@RunWith(VertxUnitRunner.class)
+@Ignore("These tests will be changed in scope of story - MODSOURCE-409")
 public class MarcEventHandlerTest extends AbstractLBServiceTest {
 
   private static final String NOT_VALID_ENTITY_TYPE = "notValidEntityType";

--- a/mod-source-record-storage-server/src/test/resources/mock/sourceRecords/db70de02-9205-4e05-8333-5848163b82b5.json
+++ b/mod-source-record-storage-server/src/test/resources/mock/sourceRecords/db70de02-9205-4e05-8333-5848163b82b5.json
@@ -244,6 +244,7 @@
   },
   "deleted" : false,
   "externalIdsHolder" : {
+    "authorityId": "ce00bca2-9270-4c6b-b096-b83a2e56e8e9"
   },
   "additionalInfo" : {
     "suppressDiscovery" : false


### PR DESCRIPTION
## Purpose
To extend enum with authorityId for record with type - MARC_AUTHORITY, refactoring handler

## Approach
- added authorityId in the IdType
- commented handler for authority
- populated authorityId for record with MARC_AUTHORITY type
- added test case

## Learning
https://issues.folio.org/browse/MODSOURCE-403
