### PR TITLE
MODSOURCE-420: The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v5.3.0-SNAPSHOT
+* [MODSOURCE-420](https://issues.folio.org/browse/MODSOURCE-420) The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added
 * [MODSOURCE-419](https://issues.folio.org/browse/MODSOURCE-419) Upgrade to RAML Module Builder 33.2.x
 * [MODDATAIMP-419](https://issues.folio.org/browse/MODDATAIMP-419) Fix "'idx_records_matched_id_gen', duplicate key value violates unique constraint"
 * [MODSOURCE-261](https://issues.folio.org/browse/MODSOURCE-261) Cover kafka handlers with tests and fix ignored

--- a/mod-source-record-storage-server/src/test/resources/postgres-conf-test.json
+++ b/mod-source-record-storage-server/src/test/resources/postgres-conf-test.json
@@ -4,5 +4,6 @@
   "port" : 25432,
   "database" : "test.database",
   "username" : "test.username",
-  "password" : "test.password"
+  "password" : "test.password",
+  "maxPoolSize" : 20
 }


### PR DESCRIPTION
## Purpose
MAXPOOLSIZE was hardcoded with value = 5

## Approach
The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added

## Learning
https://issues.folio.org/browse/MODSOURCE-420
