### PR TITLE
MODSOURCE-434 SRS. Remove Kafka cache from QuickMarc handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,6 @@
 * [MODSOURCE-402](https://issues.folio.org/browse/MODSOURCE-402) Properly handle DB failures during events processing
 * [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks
 * [MODSOURCE-429](https://issues.folio.org/browse/MODSOURCE-429) Authority update: Implement match handler
-### 2022-xx-xx
 * [MODSOURCE-434](https://issues.folio.org/browse/MODSOURCE-434) Remove Kafka cache from QuickMarc handlers
 
 ## 2021-xx-xx v5.2.1-SNAPSHOT

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 * [MODSOURCE-402](https://issues.folio.org/browse/MODSOURCE-402) Properly handle DB failures during events processing
 * [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks
 * [MODSOURCE-429](https://issues.folio.org/browse/MODSOURCE-429) Authority update: Implement match handler
+### 2022-xx-xx
+* [MODSOURCE-434](https://issues.folio.org/browse/MODSOURCE-434) Remove Kafka cache from QuickMarc handlers
 
 ## 2021-xx-xx v5.2.1-SNAPSHOT
 * [MODSOURCE-390](https://issues.folio.org/browse/MODSOURCE-390) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/QuickMarcKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/QuickMarcKafkaHandler.java
@@ -40,7 +40,6 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
 
   private static final Logger log = LogManager.getLogger();
 
-  private static final String EVENT_ID_PREFIX = QuickMarcKafkaHandler.class.getSimpleName();
   private static final String PARSED_RECORD_DTO_KEY = "PARSED_RECORD_DTO";
   private static final String SNAPSHOT_ID_KEY = "SNAPSHOT_ID";
   private static final String ERROR_KEY = "ERROR";


### PR DESCRIPTION
Kafka Cache is used in QuickMarcKafkaHandler in mod-source-record-storage. Just remove Kafka cache (consumer receiving QM_COMPLETED supports deduplication).
![image](https://user-images.githubusercontent.com/97015525/148926790-a6befd26-a156-4ea3-ba2f-58ad7d94cae4.png)
