### PR TITLE
MODSOURCE-442 Set HRID after update when the record is Authority

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -623,6 +623,7 @@ public final class RecordDaoUtil {
       externalHridOptional.ifPresent(externalIdsHolder::setHoldingsHrid);
     } else if (RecordType.MARC_AUTHORITY == pojo.getRecordType()) {
       externalIdOptional.ifPresent(externalIdsHolder::setAuthorityId);
+      externalHridOptional.ifPresent(externalIdsHolder::setAuthorityHrid);
     }
     return externalIdsHolder;
   }


### PR DESCRIPTION
HRID not set after update was made in MarcAuthorityUpdateModifyEventHandler. It's a bug with converting DB row to Record.
The fix should be done in RecordDaoUtil.toExternalIdsHolder method: add populating of HRID when the record is Authority