### PR TITLE
MODSOURCE-439 Remove zipping/unzipping of Kafka events for quickMarc …

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/QuickMarcKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/QuickMarcKafkaHandler.java
@@ -6,7 +6,6 @@ import static org.folio.kafka.KafkaHeaderUtils.kafkaHeadersToMap;
 import static org.folio.services.util.EventHandlingUtil.createProducer;
 import static org.folio.services.util.EventHandlingUtil.createProducerRecord;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,6 @@ import org.springframework.stereotype.Component;
 import org.folio.dao.util.QMEventTypes;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaConfig;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
 import org.folio.rest.util.OkapiConnectionParams;
@@ -106,7 +104,7 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
     Promise<Boolean> promise = Promise.promise();
     try {
       var producer = producerMap.get(eventType);
-      var record = createProducerRecord(eventPayload, eventType.name(), key, tenantId, kafkaHeaders, kafkaConfig, true);
+      var record = createProducerRecord(eventPayload, eventType.name(), key, tenantId, kafkaHeaders, kafkaConfig);
       producer.write(record, war -> {
         if (war.succeeded()) {
           log.info("Event with type {} was sent to kafka", eventType);
@@ -127,9 +125,9 @@ public class QuickMarcKafkaHandler implements AsyncRecordHandler<String, String>
   @SuppressWarnings("unchecked")
   private Future<HashMap<String, String>> getEventPayload(Event event) {
     try {
-      var eventPayload = Json.decodeValue(ZIPArchiver.unzip(event.getEventPayload()), HashMap.class);
+      var eventPayload = Json.decodeValue(event.getEventPayload(), HashMap.class);
       return Future.succeededFuture(eventPayload);
-    } catch (IOException e) {
+    } catch (Exception e) {
       return Future.failedFuture(e);
     }
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -1,6 +1,5 @@
 package org.folio.services.util;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.kafka.KafkaConfig;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.processing.events.utils.PomReaderUtil;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.tools.utils.ModuleName;
@@ -44,12 +42,8 @@ public final class EventHandlingUtil {
   public static Future<Boolean> sendEventToKafka(String tenantId, String eventPayload, String eventType,
                                                  List<KafkaHeader> kafkaHeaders, KafkaConfig kafkaConfig, String key) {
     KafkaProducerRecord<String, String> record;
-    try {
-      record = createProducerRecord(eventPayload, eventType, key, tenantId, kafkaHeaders, kafkaConfig, false);
-    } catch (IOException e) {
-      LOGGER.error("Failed to construct an event for eventType {}", eventType, e);
-      return Future.failedFuture(e);
-    }
+
+    record = createProducerRecord(eventPayload, eventType, key, tenantId, kafkaHeaders, kafkaConfig);
 
     Promise<Boolean> promise = Promise.promise();
 
@@ -75,12 +69,11 @@ public final class EventHandlingUtil {
   public static KafkaProducerRecord<String, String> createProducerRecord(String eventPayload, String eventType,
                                                                          String key, String tenantId,
                                                                          List<KafkaHeader> kafkaHeaders,
-                                                                         KafkaConfig kafkaConfig,
-                                                                         boolean zippedPayload) throws IOException {
+                                                                         KafkaConfig kafkaConfig) {
     Event event = new Event()
       .withId(UUID.randomUUID().toString())
       .withEventType(eventType)
-      .withEventPayload(zippedPayload ? ZIPArchiver.zip(eventPayload) : eventPayload)
+      .withEventPayload(eventPayload)
       .withEventMetadata(new EventMetadata()
         .withTenantId(tenantId)
         .withEventTTL(1)

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
@@ -15,7 +15,6 @@ import org.folio.dao.RecordDao;
 import org.folio.dao.RecordDaoImpl;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.SnapshotDaoUtil;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ParsedRecordDto;
@@ -111,7 +110,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   @Test
-  public void shouldUpdateParsedRecordAndSendRecordUpdatedEvent(TestContext context) throws IOException, InterruptedException {
+  public void shouldUpdateParsedRecordAndSendRecordUpdatedEvent(TestContext context) throws InterruptedException {
     Async async = context.async();
 
     ParsedRecord parsedRecord = record.getParsedRecord();
@@ -170,7 +169,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   @Test
-  public void shouldSendErrorEventWhenNoDataInPayload() throws IOException, InterruptedException {
+  public void shouldSendErrorEventWhenNoDataInPayload() throws InterruptedException {
     cluster.send(createRequest(new HashMap<>()));
 
     String observeTopic = formatTopicName(kafkaConfig.getEnvId(), getDefaultNameSpace(), TENANT_ID, QM_ERROR.name());
@@ -179,9 +178,9 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
       .build());
   }
 
-  private SendKeyValues<String, String> createRequest(HashMap<String, String> payload) throws IOException {
+  private SendKeyValues<String, String> createRequest(HashMap<String, String> payload) {
     String topic = formatTopicName(kafkaConfig.getEnvId(), getDefaultNameSpace(), TENANT_ID, QM_RECORD_UPDATED.name());
-    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(ZIPArchiver.zip(Json.encode(payload)));
+    Event event = new Event().withId(UUID.randomUUID().toString()).withEventPayload(Json.encode(payload));
     KeyValue<String, String> eventRecord = new KeyValue<>(KAFKA_KEY_NAME, Json.encode(event));
     eventRecord.addHeader(OkapiConnectionParams.OKAPI_URL_HEADER, OKAPI_URL, Charset.defaultCharset());
     eventRecord.addHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID, Charset.defaultCharset());


### PR DESCRIPTION
The custom zipping/unzipping approach that we are currently using for quick-marc flow is not needed. We should rely on Kafka's zipping approach.