### PR TITLE
MODDATAIMP-623. Remove Kafka cache initialization and Maven dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks
 * [MODSOURCE-429](https://issues.folio.org/browse/MODSOURCE-429) Authority update: Implement match handler
 * [MODSOURCE-434](https://issues.folio.org/browse/MODSOURCE-434) Remove Kafka cache from QuickMarc handlers
+* [MODDATAIMP-623](https://issues.folio.org/browse/MODDATAIMP-623) Remove Kafka cache initialization and Maven dependency
 
 ## 2021-xx-xx v5.2.1-SNAPSHOT
 * [MODSOURCE-390](https://issues.folio.org/browse/MODSOURCE-390) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/README.md
+++ b/README.md
@@ -103,16 +103,17 @@ There are several properties that should be set for modules that interact with K
 After setup, it is good to check logs in all related modules for errors. Data import consumers and producers work in separate verticles that are set up in RMB's InitAPI for each module. That would be the first place to check deploy/install logs.
 
 **Environment variables** that can be adjusted for this module and default values:
-* Relevant for the **Iris** release, module versions from 5.0.0:
+* Relevant from the **Iris** release, module versions from 5.0.0:
   * "_srs.kafka.ParsedMarcChunkConsumer.instancesNumber_": 1
   * "_srs.kafka.DataImportConsumer.instancesNumber_": 1
   * "_srs.kafka.ParsedRecordChunksKafkaHandler.maxDistributionNum_": 100
   * "_srs.kafka.DataImportConsumer.loadLimit_": 5
   * "_srs.kafka.DataImportConsumerVerticle.maxDistributionNum_": 100
   * "_srs.kafka.ParsedMarcChunkConsumer.loadLimit_": 5
-* Relevant for the **Juniper** release, module versions from 5.1.0:
+* Relevant from the **Juniper** release, module versions from 5.1.0:
   * "_srs.kafka.QuickMarcConsumer.instancesNumber_": 1
   * "_srs.kafka.QuickMarcKafkaHandler.maxDistributionNum_": 100
+* Relevant from the **Juniper** release(module version from 5.1.0) to **Kiwi** release (module version from 5.2.0)
   * "_srs.kafka.cache.cleanup.interval.ms_": 3600000
   * "_srs.kafka.cache.expiration.time.hours_": 3
 ## Database schemas

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -176,7 +176,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,6 +1,5 @@
 package org.folio.config;
 
-import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,8 +8,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.cache.KafkaInternalCache;
-import org.folio.kafka.cache.util.CacheUtil;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -49,19 +46,5 @@ public class ApplicationConfig {
     LOGGER.debug("kafkaConfig: {}", kafkaConfig);
 
     return kafkaConfig;
-  }
-
-  @Bean
-  public KafkaInternalCache kafkaInternalCache(KafkaConfig kafkaConfig, Vertx vertx,
-                                               @Value("${srs.kafka.cache.cleanup.interval.ms:3600000}") long cleanupInterval,
-                                               @Value("${srs.kafka.cache.expiration.time.hours:3}") int expirationTime) {
-    KafkaInternalCache kafkaInternalCache = KafkaInternalCache.builder()
-      .kafkaConfig(kafkaConfig)
-      .build();
-
-    kafkaInternalCache.initKafkaCache();
-    CacheUtil.initCacheCleanupPeriodicTask(vertx, kafkaInternalCache, cleanupInterval, expirationTime);
-
-    return kafkaInternalCache;
   }
 }


### PR DESCRIPTION
## Purpose
Delete all kafka cache occurrences with dependencies

## Learning
https://issues.folio.org/browse/MODDATAIMP-623
