### PR TITLE
MODSOURCE-438 - SQL exceptions when running CREATE import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * [MODDATAIMP-623](https://issues.folio.org/browse/MODDATAIMP-623) Remove Kafka cache initialization and Maven dependency
 * [MODSOURCE-446](https://issues.folio.org/browse/MODSOURCE-446) Extend MARC-MARC matching to 9xx and 0xx fields
 * [MODSOURCE-450](https://issues.folio.org/browse/MODSOURCE-450) Increase folio-liquibase-util and liquibase schema version
+* [MODSOURCE-438](https://issues.folio.org/browse/MODSOURCE-438) Fix SQL exceptions regarding connection termination when running CREATE import 
 
 ## 2021-xx-xx v5.2.1-SNAPSHOT
 * [MODSOURCE-390](https://issues.folio.org/browse/MODSOURCE-390) Fix the effect of DI_ERROR messages when trying to duplicate records on the import job progress bar

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -212,6 +212,11 @@
       <artifactId>caffeine</artifactId>
       <version>2.8.5</version>
     </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>5.0.1</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -10,7 +10,9 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PreDestroy;
+import javax.sql.DataSource;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.folio.rest.persist.LoadConfs;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.Envs;
@@ -18,8 +20,6 @@ import org.folio.rest.tools.utils.ModuleName;
 import org.jooq.Configuration;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DefaultConfiguration;
-import org.postgresql.PGProperty;
-import org.postgresql.ds.PGPoolingDataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +54,7 @@ public class PostgresClientFactory {
 
   private static final Map<String, PgPool> POOL_CACHE = new HashMap<>();
 
-  private static final Map<String, PGPoolingDataSource> DATA_SOURCE_CACHE = new HashMap<>();
+  private static final Map<String, DataSource> DATA_SOURCE_CACHE = new HashMap<>();
 
   private static JsonObject postgresConfig;
 
@@ -189,25 +189,29 @@ public class PostgresClientFactory {
       .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId));
   }
 
-  private static PGPoolingDataSource getDataSource(String tenantId) {
+  private static DataSource getDataSource(String tenantId) {
     if (DATA_SOURCE_CACHE.containsKey(tenantId)) {
       LOG.debug("Using existing data source for tenant {}", tenantId);
       return DATA_SOURCE_CACHE.get(tenantId);
     }
     Integer maxPoolSize = postgresConfig.getInteger(DB_MAXPOOLSIZE, DB_MAXPOOLSIZE_DEFAULT_VALUE);
     LOG.info("Creating new data source for tenant {} with poolSize {}", tenantId, maxPoolSize);
-    PGPoolingDataSource source = new PGPoolingDataSource();
-    source.setDataSourceName(format("%s-data-source", tenantId));
-    source.setMaxConnections(maxPoolSize);
-    source.setServerName(postgresConfig.getString(HOST));
-    source.setPortNumber(postgresConfig.getInteger(PORT, 5432));
-    source.setDatabaseName(postgresConfig.getString(DATABASE));
-    source.setUser(postgresConfig.getString(USERNAME));
-    source.setPassword(postgresConfig.getString(PASSWORD));
-    source.setConnectTimeout(postgresConfig.getInteger(IDLE_TIMEOUT, 60000));
-    source.setProperty(PGProperty.CURRENT_SCHEMA, convertToPsqlStandard(tenantId));
-    DATA_SOURCE_CACHE.put(tenantId, source);
-    return source;
+    HikariDataSource dataSource = new HikariDataSource();
+    dataSource.setPoolName(format("%s-data-source", tenantId));
+    dataSource.setMaximumPoolSize(maxPoolSize);
+    dataSource.setMinimumIdle(0);
+    dataSource.setJdbcUrl(getJdbcUrl());
+    dataSource.setUsername(postgresConfig.getString(USERNAME));
+    dataSource.setPassword(postgresConfig.getString(PASSWORD));
+    dataSource.setIdleTimeout(postgresConfig.getLong(IDLE_TIMEOUT, 60000L));
+    dataSource.setSchema(convertToPsqlStandard(tenantId));
+    DATA_SOURCE_CACHE.put(tenantId, dataSource);
+    return dataSource;
+  }
+
+  private static String getJdbcUrl() {
+    return String.format("jdbc:postgresql://%s:%s/%s",
+      postgresConfig.getString(HOST), postgresConfig.getInteger(PORT), postgresConfig.getString(DATABASE));
   }
 
   // using RMB convention driven tenant to schema name


### PR DESCRIPTION
## Purpose
currently when a database connection is closed on DB server-side (or process serving particular connection is terminated)
then an error will occur while using such connection for DB querying


## Approach
* use connection pool providing connection validation before borrowing from the pool (hikari is proposed in the current solution)


## Learning
[MODSOURCE-438](https://issues.folio.org/browse/MODSOURCE-438)
https://github.com/brettwooldridge/HikariCP
