### PR TITLE
MODSOURCE-438 - SQL exceptions when running CREATE import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-02-xx v5.2.8
+* [MODSOURCE-438](https://issues.folio.org/browse/MODSOURCE-438) Fix SQL exceptions regarding connection termination when running CREATE import
+
 ## 2022-01-13 v5.2.7
 * [MODSOURCE-444](https://issues.folio.org/browse/MODSOURCE-444) Fix schema migration error
 

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -218,6 +218,11 @@
       <artifactId>caffeine</artifactId>
       <version>2.8.5</version>
     </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>5.0.1</version>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
## Purpose
currently when a database connection is closed on DB server-side (or process serving particular connection is terminated)
then an error will occur while using such connection for DB querying


## Approach
* use connection pool providing connection validation before borrowing from the pool (hikari is proposed in the current solution)


## Learning
[MODSOURCE-438](https://issues.folio.org/browse/MODSOURCE-438)
