### PR TITLE
MODSOURCE-461. Upgrade RMB and Vertx versions that contain fixes for the connection pool

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2021-xx-xx v5.3.0-SNAPSHOT
+* [MODSOURCE-461](https://issues.folio.org/browse/MODSOURCE-461) Upgrade RMB and Vertx versions that contain fixes for the connection pool
 * [MODSOURCE-420](https://issues.folio.org/browse/MODSOURCE-420) The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added
 * [MODSOURCE-419](https://issues.folio.org/browse/MODSOURCE-419) Upgrade to RAML Module Builder 33.2.x
 * [MODDATAIMP-419](https://issues.folio.org/browse/MODDATAIMP-419) Fix "'idx_records_matched_id_gen', duplicate key value violates unique constraint"

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -266,7 +266,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
       .withMetadata(valid.getMetadata());
     recordService.saveRecord(invalid, TENANT_ID).onComplete(save -> {
       context.assertTrue(save.failed());
-      String expected = "null value in column \\\"matched_id\\\" violates not-null constraint";
+      String expected = "null value in column \"matched_id\" violates not-null constraint";
       context.assertTrue(save.cause().getMessage().contains(expected));
       async.complete();
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SnapshotServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SnapshotServiceTest.java
@@ -134,7 +134,7 @@ public class SnapshotServiceTest extends AbstractLBServiceTest {
       .withMetadata(valid.getMetadata());
     snapshotService.saveSnapshot(invalid, TENANT_ID).onComplete(save -> {
       context.assertTrue(save.failed());
-      String expected = "null value in column \\\"status\\\" violates not-null constraint";
+      String expected = "null value in column \"status\" violates not-null constraint";
       context.assertTrue(save.cause().getMessage().contains(expected));
       async.complete();
     });

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>33.2.0</raml-module-builder.version>
+    <raml-module-builder.version>33.2.5</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>


### PR DESCRIPTION
## Approach
New 2.4.2 version of Vertx recenly released.

https://github.com/vert-x3/wiki/wiki/4.2.4-Release-Notes#vertx

It contains fixes related to the connection pool that can help to resolve Connect timeout issues, that we observe in logs of the recent vagrant boxes when importing large files.

RMB 33.2.5 also contains Vertx version of 4.2.4.

So expected versions set in module pom:
RMB - 33.2.5
Vertx - 4.2.4

## Learning
https://issues.folio.org/browse/MODSOURCE-461