### PR TITLE
MODSOURCE-468: Upgrade RMB to 3.2.6 and Vertx to 4.2.5

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.25</version>
+      <version>${postgres.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -226,7 +226,7 @@
     <jackson.jaxb.version>2.10.0</jackson.jaxb.version>
     <jooq.version>3.13.6</jooq.version>
     <vertx-jooq.version>6.1.1</vertx-jooq.version>
-    <postgres.version>42.2.25</postgres.version>
+    <postgres.version>42.3.3</postgres.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <lombok.version>1.18.20</lombok.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -144,6 +144,10 @@
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.validation</groupId>
+          <artifactId>validation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/mod-source-record-storage-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-storage-server/src/main/resources/log4j2.properties
@@ -21,6 +21,12 @@ logger.folio_consumers.level = debug
 logger.folio_consumers.additivity = false
 logger.folio_consumers.appenderRef.stdout.ref = STDOUT
 
+#disable ProducerConfig/ConsumerConfig messages in log
+logger.kafka.name = org.apache.kafka
+logger.kafka.level = warn
+logger.kafka.additivity = false
+logger.kafka.appenderRef.stdout.ref = STDOUT
+
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>33.2.5</raml-module-builder.version>
+    <raml-module-builder.version>33.2.6</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <main.basedir>${project.basedir}</main.basedir>
     <vertx.version>4.2.5</vertx.version>
     <junit.version>4.13.1</junit.version>
-    <rest-assured.version>4.3.1</rest-assured.version>
+    <rest-assured.version>4.5.1</rest-assured.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>
   </properties>
 


### PR DESCRIPTION
## Purpose
Upgrade RMB and Vertx versions that contain fixes for the connection pool

## Learning
https://issues.folio.org/browse/MODSOURCE-468
