### PR TITLE
Fix permission definition for updating records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## xxxx-xx-xx v5.4.0-SNAPSHOT
+* [MODSOURCE-470](https://issues.folio.org/browse/MODSOURCE-470) Fix permission definition for updating records 
+
 ## 2021-02-22 v5.3.0
 * [MODSOURCE-461](https://issues.folio.org/browse/MODSOURCE-461) Upgrade RMB and Vertx versions that contain fixes for the connection pool
 * [MODSOURCE-420](https://issues.folio.org/browse/MODSOURCE-420) The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -298,7 +298,7 @@
       "description": "Put Record"
     },
     {
-      "permissionName": "source-storage.record.update",
+      "permissionName": "source-storage.records.update",
       "displayName": "Source Storage - update record",
       "description": "Update Record's fields"
     },
@@ -331,7 +331,7 @@
         "source-storage.records.post",
         "source-storage.records.put",
         "source-storage.records.delete",
-        "source-storage.record.update",
+        "source-storage.records.update",
         "source-storage.sourceRecords.get",
         "source-storage.verified.records"
       ],


### PR DESCRIPTION
## Purpose
Undefined permission 'source-storage.records.update'

## Approach
Fix the typo in permissions definition