### PR TITLE
MODSOURMAN-724 SRM does not process and save error records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## xxxx-xx-xx v5.4.0-SNAPSHOT
 * [MODSOURCE-470](https://issues.folio.org/browse/MODSOURCE-470) Fix permission definition for updating records
 * [MODSOURCE-459](https://issues.folio.org/browse/MODSOURCE-459) Determine how to handle deleted authority records
+* [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 
 ## 2021-02-22 v5.3.0
 * [MODSOURCE-461](https://issues.folio.org/browse/MODSOURCE-461) Upgrade RMB and Vertx versions that contain fixes for the connection pool

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -383,9 +383,13 @@ public class RecordDaoImpl implements RecordDao {
           throw new BadRequestException("Batch record collection only supports single snapshot");
         }
 
+        if(Objects.nonNull(record.getRecordType())) {
+          recordTypes.add(record.getRecordType().name());
+        } else {
+          throw new BadRequestException(StringUtils.defaultIfEmpty(record.getErrorRecord().getDescription(), String.format("Record with id %s has not record type", record.getId())));
+        }
+
         // make sure only one record type
-        Optional.ofNullable(record.getRecordType()).ifPresentOrElse(recordType -> recordTypes.add(recordType.name()),
-          () -> {throw new BadRequestException(StringUtils.defaultIfEmpty(record.getErrorRecord().getDescription(), String.format("Record with id %s has not record type", record.getId())));});
         if (recordTypes.size() > 1) {
           throw new BadRequestException("Batch record collection only supports single record type");
         }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -384,7 +384,8 @@ public class RecordDaoImpl implements RecordDao {
         }
 
         // make sure only one record type
-        recordTypes.add(record.getRecordType().name());
+        Optional.ofNullable(record.getRecordType()).ifPresentOrElse(recordType -> recordTypes.add(recordType.name()),
+          () -> {throw new BadRequestException(StringUtils.defaultIfEmpty(record.getErrorRecord().getDescription(), String.format("Record with id %s has not record type", record.getId())));});
         if (recordTypes.size() > 1) {
           throw new BadRequestException("Batch record collection only supports single record type");
         }


### PR DESCRIPTION
## Purpose
Improve record type validating before trying insert to database and solve problem with records which contains erorrs at the stage preparation record.
This approach give us the oportunity to avoid NPE

## Approach

- Checked record type to null and throw exception if  it's null

## Learning
[MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724)
