### PR TITLE
MODSOURMAN-712. Timeout when importing MARC files

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -388,7 +388,7 @@
       },
       {
         "name": "DB_MAXPOOLSIZE",
-        "value": "5"
+        "value": "15"
       },
       {
         "name": "test.mode",


### PR DESCRIPTION
## Purpose
Increase the value of max DB pool size in deployment descriptor to make it consistent with constant from java code.

## Approach
The default value of max DB pool size declared here:
https://github.com/folio-org/mod-source-record-storage/blob/master/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java#L53
In this PR we are adjusting DB_MAXPOOLSIZE value in deployment descriptor to the same value

## Learning
https://issues.folio.org/browse/MODSOURMAN-712
