### PR TITLE
MODSOURCE-482 - One-record OCLC (Create) Data Import takes over 9 seconds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * [MODSOURCE-459](https://issues.folio.org/browse/MODSOURCE-459) Determine how to handle deleted authority records
 * [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 
+## 2022-03-xx v5.3.1-SNAPSHOT
+* [MODSOURCE-482](https://issues.folio.org/browse/MODSOURCE-482) One-record OCLC (Create) Data Import takes over 9 seconds
+
 ## 2021-02-22 v5.3.0
 * [MODSOURCE-461](https://issues.folio.org/browse/MODSOURCE-461) Upgrade RMB and Vertx versions that contain fixes for the connection pool
 * [MODSOURCE-420](https://issues.folio.org/browse/MODSOURCE-420) The support for 'maxPoolSize' (DB_MAXPOOLSIZE) from RMB was added

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
@@ -74,7 +74,9 @@ public class SourceStorageSourceRecordsImpl implements SourceStorageSourceRecord
           .and(filterRecordByDeleted(deleted))
           .and(filterRecordByLeaderRecordStatus(leaderRecordStatus))
           .and(filterRecordByUpdatedDateRange(updatedAfter, updatedBefore));
-        List<OrderField<?>> orderFields = toRecordOrderFields(orderBy, true);
+
+        boolean forOffset = offset != 0 && limit != 1;
+        List<OrderField<?>> orderFields = toRecordOrderFields(orderBy, forOffset);
         recordService.getSourceRecords(condition, toRecordType(recordType), orderFields, offset, limit, tenantId)
           .map(GetSourceStorageSourceRecordsResponse::respond200WithApplicationJson)
           .map(Response.class::cast)

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageSourceRecordsImpl.java
@@ -75,7 +75,7 @@ public class SourceStorageSourceRecordsImpl implements SourceStorageSourceRecord
           .and(filterRecordByLeaderRecordStatus(leaderRecordStatus))
           .and(filterRecordByUpdatedDateRange(updatedAfter, updatedBefore));
 
-        boolean forOffset = offset != 0 && limit != 1;
+        boolean forOffset = offset != 0 || limit != 1;
         List<OrderField<?>> orderFields = toRecordOrderFields(orderBy, forOffset);
         recordService.getSourceRecords(condition, toRecordType(recordType), orderFields, offset, limit, tenantId)
           .map(GetSourceStorageSourceRecordsResponse::respond200WithApplicationJson)


### PR DESCRIPTION
## Purpose
during single record import mod-copycat requests source record by import job Id to get a result of import. Previously default sorting was introduced [(MODSOURCE-203)](https://github.com/folio-org/mod-source-record-storage/pull/274) to keep a predictable set of records during page-by-page reading using limit and offset parameters. 
Since during single record import only one source record can be associated with import job for performance needs it makes sense not to apply default sorting. 


## Approach
* do not apply default sorting when only one record should be retrieved and specified offset=0

## Learning
[MODSOURCE-482](https://issues.folio.org/browse/MODSOURCE-482)