### PR TITLE
MODSOURCE-488: Increase memory in ModuleDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -343,7 +343,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 603725575,
+        "Memory": 1073741824,
         "PortBindings": {
           "8081/tcp": [
             {


### PR DESCRIPTION
## Purpose
Increase memory in ModuleDescriptor for fix OutOfMemoryException on folio-snapshot.dev.folio.org 

## Approach
Increase memory in ModuleDescriptor

## Learning
https://issues.folio.org/browse/MODSOURCE-488
