### PR TITLE
MODSOURCE-349 Function set_id_in_jsonb is present in migrated Juniper/Kiwi environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURMAN-724](https://issues.folio.org/browse/MODSOURMAN-724) SRM does not process and save error records
 * [MODSOURCE-477](https://issues.folio.org/browse/MODSOURCE-477) Configure job to delete authority records 
 * [MODSOURCE-447](https://issues.folio.org/browse/MODSOURCE-447) 035 created from 001/003 is not working in SRS record when using a MARC Modification action in Data Import Job Profile
+* [MODSOURCE-349](https://issues.folio.org/browse/MODSOURCE-349) Function set_id_in_jsonb is present in migrated Juniper/Kiwi environment
 
 ## 2022-03-xx v5.3.2-SNAPSHOT
 * [MODSOURCE-489](https://issues.folio.org/browse/MODSOURCE-489) Records that are overlaid multiple times via Inventory Single Record Import can't be overlaid after the second time

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-19--13-00-drop-unused-set-id-function.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-0.0.4/2021-05-19--13-00-drop-unused-set-id-function.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
 
-  <changeSet id="2021-05-19--13-00-drop-unused-set-id-function" author="VolodymyrRohach">
+  <changeSet id="2021-05-19--13-00-drop-unused-set-id-function" author="VolodymyrRohach" runAlways="true">
     <sql>
       DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_id_in_jsonb() CASCADE;
     </sql>


### PR DESCRIPTION
## Purpose
Remove unused set_id_in_jsonb function in migration.

## Approach

- Added runAlways="true" attribute to existing change set which must drop function.
![image](https://user-images.githubusercontent.com/89521577/161422525-ec1862de-03da-4768-ab4d-d927c69667bf.png)


## Learning
[MODSOURCE-349](https://issues.folio.org/browse/MODSOURCE-349)
