### PR TITLE
MODSOURCE-496 Single record imports show the incorrect record number in the summary log 1st column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODSOURCE-477](https://issues.folio.org/browse/MODSOURCE-477) Configure job to delete authority records 
 * [MODSOURCE-447](https://issues.folio.org/browse/MODSOURCE-447) 035 created from 001/003 is not working in SRS record when using a MARC Modification action in Data Import Job Profile
 * [MODSOURCE-349](https://issues.folio.org/browse/MODSOURCE-349) Function set_id_in_jsonb is present in migrated Juniper/Kiwi environment
+* [MODSOURCE-496](https://issues.folio.org/browse/MODSOURCE-496) Single record imports show the incorrect record number in the summary log 1st column
 
 ## 2022-03-xx v5.3.2-SNAPSHOT
 * [MODSOURCE-489](https://issues.folio.org/browse/MODSOURCE-489) Records that are overlaid multiple times via Inventory Single Record Import can't be overlaid after the second time

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -88,6 +88,7 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
             remove003FieldIfNeeded(changedRecord, hrId);
           }
           increaseGeneration(changedRecord);
+          changedRecord.setOrder(0);
           payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));
         })
         .compose(changedRecord -> recordService.saveRecord(changedRecord, payload.getTenant()))

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -88,7 +88,6 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
             remove003FieldIfNeeded(changedRecord, hrId);
           }
           increaseGeneration(changedRecord);
-          changedRecord.setOrder(0);
           payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));
         })
         .compose(changedRecord -> recordService.saveRecord(changedRecord, payload.getTenant()))
@@ -169,6 +168,8 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
       changedRecord.setSnapshotId(payload.getJobExecutionId());
       changedRecord.setGeneration(null);
       changedRecord.setId(UUID.randomUUID().toString());
+      Record incomingRecord = Json.decodeValue(context.get(modifiedEntityType().value()), Record.class);
+      changedRecord.setOrder(incomingRecord.getOrder());
       context.put(modifiedEntityType().value(), Json.encode(changedRecord));
     }
   }


### PR DESCRIPTION
## Purpose
When a record was part of a previous multi-record import, and is then updated via single record import, the wrong record number shows in the log for the Inventory single record import

## Approach
Added forced set of order when it is update action. 

## Learning
[MODSOURCE-496](https://issues.folio.org/browse/MODSOURCE-496)

## Note
There are a lot of test cases that can only be checked manually.
Also need regression testing for this ticket.