### PR TITLE
MODSOURCE-508 Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * [MODSOURCE-496](https://issues.folio.org/browse/MODSOURCE-496) Single record imports show the incorrect record number in the summary log 1st column
 * [MODSOURMAN-779](https://issues.folio.org/browse/MODSOURMAN-779) Add "CANCELLED" status for Import jobs that are stopped by users.
 * [MODSOURCE-499](https://issues.folio.org/browse/MODSOURCE-499) Alleviate Eventloop Blocking During Batch Save of Records
+* [MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't
 
 
 ## 2022-03-xx v5.3.2-SNAPSHOT

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -142,7 +142,7 @@ public final class AdditionalFieldsUtil {
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to add additional controlled field {) to record {}", field, record.getId(), e);
+      LOGGER.error("Failed to add additional controlled field {} to record {}", field, record.getId(), e);
     }
     return result;
   }
@@ -175,7 +175,7 @@ public final class AdditionalFieldsUtil {
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to remove controlled field {) from record {}", field, record.getId(), e);
+      LOGGER.error("Failed to remove controlled field {} from record {}", field, record.getId(), e);
     }
     return result;
   }
@@ -201,7 +201,7 @@ public final class AdditionalFieldsUtil {
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to read controlled field {) from record {}", tag, record.getId(), e);
+      LOGGER.error("Failed to read controlled field {} from record {}", tag, record.getId(), e);
       return null;
     }
     return null;
@@ -236,7 +236,7 @@ public final class AdditionalFieldsUtil {
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to add additional data field {) to record {}", e, tag, record.getId());
+      LOGGER.error("Failed to add additional data field {} to record {}", e, tag, record.getId());
     }
     return result;
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -133,6 +133,13 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     .withMappingDetails(new MappingDetail()
       .withMarcMappingDetails(Collections.singletonList(marcMappingDetail)));
 
+  private MappingProfile updateMappingProfile = new MappingProfile()
+    .withId(UUID.randomUUID().toString())
+    .withName("Update MARC Bibs")
+    .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+    .withExistingRecordType(MARC_BIBLIOGRAPHIC)
+    .withMappingDetails(new MappingDetail());
+
   private MappingProfile marcBibModifyMappingProfile = new MappingProfile()
     .withId(UUID.randomUUID().toString())
     .withName("Modify MARC Bibs")
@@ -320,12 +327,12 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
-    mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
+    updateMappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
     profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
-        .withProfileId(mappingProfile.getId())
+        .withProfileId(updateMappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
-        .withContent(JsonObject.mapFrom(mappingProfile).getMap())));
+        .withContent(JsonObject.mapFrom(updateMappingProfile).getMap())));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withTenant(TENANT_ID)
@@ -363,7 +370,6 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
 
-    mappingProfile.getMappingDetails().withMarcMappingOption(MappingDetail.MarcMappingOption.MODIFY);
     profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(marcBibModifyMappingProfile.getId())


### PR DESCRIPTION
## Purpose
When Inventory Single Record Import is used to overlay an existing Instance, the resulting SRS MARC Bib should not have an 003 field. As of Kiwi, this was working properly. Starting in Lotus, for Instances with Source = MARC, the 003 is accidentally being retained.

## Approach
Added additional validation to split logic for modify and update actions.

## Learning
[MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801)
