### PR TITLE
MODSOURCE-495: Logs show incorrectly formatted request id.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * [MODSOURMAN-779](https://issues.folio.org/browse/MODSOURMAN-779) Add "CANCELLED" status for Import jobs that are stopped by users.
 * [MODSOURCE-499](https://issues.folio.org/browse/MODSOURCE-499) Alleviate Eventloop Blocking During Batch Save of Records
 * [MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't
+* [MODSOURCE-495](https://issues.folio.org/browse/MODSOURCE-495) Logs show incorrectly formatted request id
 
 
 ## 2022-03-xx v5.3.2-SNAPSHOT

--- a/mod-source-record-storage-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-storage-server/src/main/resources/log4j2.properties
@@ -1,10 +1,19 @@
 status = warn
 name = PropertiesConfig
 
+packages = org.folio.okapi.common.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] [$${FolioLoggingContext:requestid}] %-5p %-20.20C{1} %m%n
 
 logger.folio_services.name = org.folio.services
 logger.folio_services.level = debug

--- a/mod-source-record-storage-server/src/main/resources/log4j2.properties
+++ b/mod-source-record-storage-server/src/main/resources/log4j2.properties
@@ -3,11 +3,6 @@ name = PropertiesConfig
 
 packages = org.folio.okapi.common.logging
 
-filters = threshold
-
-filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
-
 appenders = console
 
 appender.console.type = Console


### PR DESCRIPTION
## Purpose
Improve logging. Added FOLIO-approach for retrieving properties for logging.

## Approach
Retreiving properties from FolioLoggingContext.

#### TODOS and Open Questions

- It seems like these properties are available only for REST-requests.

## Learning
https://issues.folio.org/browse/MODSOURCE-495
