### PR TITLE
MODSOURCE-509 Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODSOURCE-499](https://issues.folio.org/browse/MODSOURCE-499) Alleviate Eventloop Blocking During Batch Save of Records
 * [MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't
 * [MODSOURCE-495](https://issues.folio.org/browse/MODSOURCE-495) Logs show incorrectly formatted request id
+* [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists
 
 
 ## 2022-03-xx v5.3.2-SNAPSHOT

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -257,7 +257,8 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     setExternalIds(externalIdsHolder, externalId, externalHrid);
     boolean isAddedField = addFieldToMarcRecord(record, TAG_999, 'i', externalId);
     if (isHridFillingNeeded()) {
-      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity));
+      // isUpdateOption is always false because there is no postProcessing for update action
+      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), false);
     }
     if (!isAddedField) {
       throw new PostProcessingException(

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -4,12 +4,12 @@ import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import static org.folio.ActionProfile.Action.MODIFY;
 import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.services.util.AdditionalFieldsUtil.HR_ID_FROM_FIELD;
 import static org.folio.services.util.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
+import static org.folio.services.util.AdditionalFieldsUtil.fillHrIdFieldInMarcRecord;
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
 
@@ -24,6 +24,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,6 +81,10 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
       String userId = (String) payload.getAdditionalProperties().get(USER_ID_HEADER);
       preparePayload(payload);
 
+      var eventContext = payload.getContext();
+      String entityAsString = eventContext.get(getMatchedMarcKey());
+      String recordAsString = getRecordAsString(payload, marcMappingOption);
+
       mappingParametersCache.get(payload.getJobExecutionId(), RestUtil.retrieveOkapiConnectionParams(payload, vertx))
         .compose(parametersOptional -> parametersOptional
           .map(mappingParams -> modifyRecord(payload, mappingProfile, mappingParams))
@@ -87,9 +92,15 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
         .onSuccess(v -> prepareModificationResult(payload, marcMappingOption))
         .map(v -> Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class))
         .onSuccess(changedRecord -> {
-          if(isHridFillingNeeded() || isUpdateOption(marcMappingOption)) {
+          if (isHridFillingNeeded()) {
             addControlledFieldToMarcRecord(changedRecord, HR_ID_FROM_FIELD, hrId, true);
             remove003FieldIfNeeded(changedRecord, hrId);
+          }
+          if (isUpdateOption(marcMappingOption)) {
+            Record record = Json.decodeValue(recordAsString, Record.class);
+            JsonObject externalEntity = new JsonObject(entityAsString);
+
+            fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), true);
           }
           increaseGeneration(changedRecord);
           setUpdatedBy(changedRecord, userId);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -294,21 +294,23 @@ public final class AdditionalFieldsUtil {
    *
    * @param recordInstancePair pair of related instance and record
    */
-  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair) {
+  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair, boolean isUpdateOption) {
     String hrId = recordInstancePair.getValue().getString(HR_ID_FIELD);
     String valueFrom001 = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrId = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrIdPrefix = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
     originalHrId = mergeFieldsFor035(originalHrIdPrefix, originalHrId);
     if (StringUtils.isNotEmpty(hrId) && StringUtils.isNotEmpty(originalHrId)) {
-      removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
       removeField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
-      addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+      if (!isUpdateOption) {
+        removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
+        addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+      }
       if (valueFrom001 != null && !isFieldExist(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_SUB, originalHrId)) {
         addDataFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, originalHrId);
       }
-    } else if (StringUtils.isNotEmpty(hrId)) {
-      addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+    } else if (StringUtils.isNotEmpty(hrId) && !isUpdateOption) {
+        addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
     }
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -48,7 +48,7 @@ public class AdditionalFieldsUtilTest {
     JsonArray fields = content.getJsonArray("fields");
     String newLeader = content.getString("leader");
     Assert.assertNotEquals(leader, newLeader);
-    Assert.assertTrue(!fields.isEmpty());
+    Assert.assertFalse(fields.isEmpty());
     int totalFieldsCount = 0;
     for (int i = fields.size(); i-- > 0; ) {
       JsonObject targetField = fields.getJsonObject(i);
@@ -258,7 +258,7 @@ public class AdditionalFieldsUtilTest {
     JsonObject jsonObject = new JsonObject("{\"hrid\":\"in001\"}");
     Pair<Record, JsonObject> pair = Pair.of(record, jsonObject);
     // when
-    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair);
+    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair, false);
     // then
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
   }


### PR DESCRIPTION
## Purpose
When Inventory Single Record Import (or Data Import Update) is used to overlay an existing Instance, the resulting SRS MARC Bib should have correct 035 field (001 should not be HRID of an existing record or 035$a field already exists)

## Approach
Changed HRID manipulation logic for UPDATE actions (moved from SRM to SRS).

#### TODOS and Open Questions
- [ ] Merge only with mod-source-record-manager changes.
- [ ] Change logic for 001 field validation after comments in [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) added
- [ ] Cover with tests if needed

## Learning
[MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509)
