### PR TITLE
MODSOURCE-528: Improve generation fo 035 field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODSOURCE-499](https://issues.folio.org/browse/MODSOURCE-499) Alleviate Eventloop Blocking During Batch Save of Records
 * [MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't
 * [MODSOURCE-495](https://issues.folio.org/browse/MODSOURCE-495) Logs show incorrectly formatted request id
+* [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists
 
 ## 2022-06-02 v5.3.3
 * [MODSOURCE-508](https://issues.folio.org/browse/MODSOURCE-508) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -257,7 +257,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     setExternalIds(externalIdsHolder, externalId, externalHrid);
     boolean isAddedField = addFieldToMarcRecord(record, TAG_999, 'i', externalId);
     if (isHridFillingNeeded()) {
-      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), false);
+      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity));
     }
     if (!isAddedField) {
       throw new PostProcessingException(

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -257,7 +257,8 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     setExternalIds(externalIdsHolder, externalId, externalHrid);
     boolean isAddedField = addFieldToMarcRecord(record, TAG_999, 'i', externalId);
     if (isHridFillingNeeded()) {
-      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity));
+      // isUpdateOption is always false because there is no postProcessing for update action
+      fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), false);
     }
     if (!isAddedField) {
       throw new PostProcessingException(

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -257,7 +257,6 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     setExternalIds(externalIdsHolder, externalId, externalHrid);
     boolean isAddedField = addFieldToMarcRecord(record, TAG_999, 'i', externalId);
     if (isHridFillingNeeded()) {
-      // isUpdateOption is always false because there is no postProcessing for update action
       fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), false);
     }
     if (!isAddedField) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -1,5 +1,31 @@
 package org.folio.services.handlers.actions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.processing.events.services.handler.EventHandler;
+import org.folio.processing.exceptions.EventProcessingException;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.processing.mapping.mapper.writer.marc.MarcRecordModifier;
+import org.folio.rest.jaxrs.model.*;
+import org.folio.services.RecordService;
+import org.folio.services.caches.MappingParametersSnapshotCache;
+import org.folio.services.util.RestUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -9,40 +35,9 @@ import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.services.util.AdditionalFieldsUtil.HR_ID_FROM_FIELD;
 import static org.folio.services.util.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
-import static org.folio.services.util.AdditionalFieldsUtil.fillHrIdFieldInMarcRecord;
+import static org.folio.services.util.AdditionalFieldsUtil.fill035FieldInMarcRecordIfNotExists;
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import org.folio.ActionProfile;
-import org.folio.DataImportEventPayload;
-import org.folio.MappingProfile;
-import org.folio.processing.events.services.handler.EventHandler;
-import org.folio.processing.exceptions.EventProcessingException;
-import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
-import org.folio.processing.mapping.mapper.writer.marc.MarcRecordModifier;
-import org.folio.rest.jaxrs.model.EntityType;
-import org.folio.rest.jaxrs.model.MappingDetail;
-import org.folio.rest.jaxrs.model.Metadata;
-import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-import org.folio.rest.jaxrs.model.Record;
-import org.folio.services.RecordService;
-import org.folio.services.caches.MappingParametersSnapshotCache;
-import org.folio.services.util.RestUtil;
 
 public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
 
@@ -79,11 +74,9 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
       MappingDetail.MarcMappingOption marcMappingOption = getMarcMappingOption(mappingProfile);
       String hrId = retrieveHrid(payload, marcMappingOption);
       String userId = (String) payload.getAdditionalProperties().get(USER_ID_HEADER);
+      Record record = Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class);
+      String incoming001 = getValueFromControlledField(record, HR_ID_FROM_FIELD);
       preparePayload(payload);
-
-      var eventContext = payload.getContext();
-      String entityAsString = eventContext.get(getMatchedMarcKey());
-      String recordAsString = getRecordAsString(payload, marcMappingOption);
 
       mappingParametersCache.get(payload.getJobExecutionId(), RestUtil.retrieveOkapiConnectionParams(payload, vertx))
         .compose(parametersOptional -> parametersOptional
@@ -92,16 +85,16 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
         .onSuccess(v -> prepareModificationResult(payload, marcMappingOption))
         .map(v -> Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class))
         .onSuccess(changedRecord -> {
-          if (isHridFillingNeeded()) {
+          if (isHridFillingNeeded() || isUpdateOption(marcMappingOption)) {
             addControlledFieldToMarcRecord(changedRecord, HR_ID_FROM_FIELD, hrId, true);
+
+            String changed001 = getValueFromControlledField(changedRecord, HR_ID_FROM_FIELD);
+            if (StringUtils.isNotBlank(incoming001) && !incoming001.equals(changed001)) {
+              fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
+            }
             remove003FieldIfNeeded(changedRecord, hrId);
           }
-          if (isUpdateOption(marcMappingOption)) {
-            Record record = Json.decodeValue(recordAsString, Record.class);
-            JsonObject externalEntity = new JsonObject(entityAsString);
 
-            fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), true);
-          }
           increaseGeneration(changedRecord);
           setUpdatedBy(changedRecord, userId);
           payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -4,12 +4,12 @@ import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import static org.folio.ActionProfile.Action.MODIFY;
 import static org.folio.ActionProfile.Action.UPDATE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.services.util.AdditionalFieldsUtil.HR_ID_FROM_FIELD;
 import static org.folio.services.util.AdditionalFieldsUtil.addControlledFieldToMarcRecord;
+import static org.folio.services.util.AdditionalFieldsUtil.fillHrIdFieldInMarcRecord;
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
 
@@ -24,6 +24,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,6 +81,10 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
       String userId = (String) payload.getAdditionalProperties().get(USER_ID_HEADER);
       preparePayload(payload);
 
+      var eventContext = payload.getContext();
+      String entityAsString = eventContext.get(getMatchedMarcKey());
+      String recordAsString = getRecordAsString(payload, marcMappingOption);
+
       mappingParametersCache.get(payload.getJobExecutionId(), RestUtil.retrieveOkapiConnectionParams(payload, vertx))
         .compose(parametersOptional -> parametersOptional
           .map(mappingParams -> modifyRecord(payload, mappingProfile, mappingParams))
@@ -87,9 +92,15 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
         .onSuccess(v -> prepareModificationResult(payload, marcMappingOption))
         .map(v -> Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class))
         .onSuccess(changedRecord -> {
-          if(isHridFillingNeeded() || isUpdateOption(marcMappingOption)) {
+          if (isHridFillingNeeded()) {
             addControlledFieldToMarcRecord(changedRecord, HR_ID_FROM_FIELD, hrId, true);
             remove003FieldIfNeeded(changedRecord, hrId);
+          }
+          if (isUpdateOption(marcMappingOption)) {
+            Record record = Json.decodeValue(recordAsString, Record.class);
+            JsonObject externalEntity = new JsonObject(entityAsString);
+
+            fillHrIdFieldInMarcRecord(Pair.of(record, externalEntity), true);
           }
           increaseGeneration(changedRecord);
           setUpdatedBy(changedRecord, userId);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -294,21 +294,23 @@ public final class AdditionalFieldsUtil {
    *
    * @param recordInstancePair pair of related instance and record
    */
-  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair) {
+  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair, boolean isUpdateOption) {
     String hrId = recordInstancePair.getValue().getString(HR_ID_FIELD);
     String valueFrom001 = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrId = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrIdPrefix = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
     originalHrId = mergeFieldsFor035(originalHrIdPrefix, originalHrId);
     if (StringUtils.isNotEmpty(hrId) && StringUtils.isNotEmpty(originalHrId)) {
-      removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
       removeField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
-      addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+      if (!isUpdateOption) {
+        removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
+        addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+      }
       if (valueFrom001 != null && !isFieldExist(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_SUB, originalHrId)) {
         addDataFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, originalHrId);
       }
-    } else if (StringUtils.isNotEmpty(hrId)) {
-      addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
+    } else if (StringUtils.isNotEmpty(hrId) && !isUpdateOption) {
+        addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -314,6 +314,14 @@ public final class AdditionalFieldsUtil {
     }
   }
 
+  public static void fill035FieldInMarcRecordIfNotExists(Record record, String incoming001) {
+    String originalHrIdPrefix = getValueFromControlledField(record, HR_ID_PREFIX_FROM_FIELD);
+    String incoming035 = mergeFieldsFor035(originalHrIdPrefix, incoming001);
+    if (StringUtils.isNotEmpty(incoming001) && !isFieldExist(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, incoming035)) {
+      addDataFieldToMarcRecord(record, HR_ID_TO_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, incoming035);
+    }
+  }
+
   private static String mergeFieldsFor035(String valueFrom003, String valueFrom001) {
     if (isBlank(valueFrom003)) {
       return valueFrom001;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -294,7 +294,7 @@ public final class AdditionalFieldsUtil {
    *
    * @param recordInstancePair pair of related instance and record
    */
-  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair, boolean isUpdateOption) {
+  public static void fillHrIdFieldInMarcRecord(Pair<Record, JsonObject> recordInstancePair) {
     String hrId = recordInstancePair.getValue().getString(HR_ID_FIELD);
     String valueFrom001 = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
     String originalHrId = getValueFromControlledField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
@@ -302,14 +302,12 @@ public final class AdditionalFieldsUtil {
     originalHrId = mergeFieldsFor035(originalHrIdPrefix, originalHrId);
     if (StringUtils.isNotEmpty(hrId) && StringUtils.isNotEmpty(originalHrId)) {
       removeField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
-      if (!isUpdateOption) {
         removeField(recordInstancePair.getKey(), HR_ID_FROM_FIELD);
         addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
-      }
       if (valueFrom001 != null && !isFieldExist(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_SUB, originalHrId)) {
         addDataFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_TO_FIELD, HR_ID_FIELD_IND, HR_ID_FIELD_IND, HR_ID_FIELD_SUB, originalHrId);
       }
-    } else if (StringUtils.isNotEmpty(hrId) && !isUpdateOption) {
+    } else if (StringUtils.isNotEmpty(hrId)) {
         addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
     }
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -258,7 +258,7 @@ public class AdditionalFieldsUtilTest {
     JsonObject jsonObject = new JsonObject("{\"hrid\":\"in001\"}");
     Pair<Record, JsonObject> pair = Pair.of(record, jsonObject);
     // when
-    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair, false);
+    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair);
     // then
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AdditionalFieldsUtilTest.java
@@ -48,7 +48,7 @@ public class AdditionalFieldsUtilTest {
     JsonArray fields = content.getJsonArray("fields");
     String newLeader = content.getString("leader");
     Assert.assertNotEquals(leader, newLeader);
-    Assert.assertTrue(!fields.isEmpty());
+    Assert.assertFalse(fields.isEmpty());
     int totalFieldsCount = 0;
     for (int i = fields.size(); i-- > 0; ) {
       JsonObject targetField = fields.getJsonObject(i);
@@ -258,7 +258,7 @@ public class AdditionalFieldsUtilTest {
     JsonObject jsonObject = new JsonObject("{\"hrid\":\"in001\"}");
     Pair<Record, JsonObject> pair = Pair.of(record, jsonObject);
     // when
-    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair);
+    AdditionalFieldsUtil.fillHrIdFieldInMarcRecord(pair, false);
     // then
     Assert.assertEquals(expectedParsedContent, parsedRecord.getContent());
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
@@ -245,7 +245,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -291,7 +291,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -15,43 +15,24 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
-import org.folio.JobProfile;
-import org.folio.MappingProfile;
-import org.folio.TestUtil;
+import org.folio.*;
 import org.folio.dao.RecordDao;
 import org.folio.dao.RecordDaoImpl;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
-import org.folio.rest.jaxrs.model.Data;
-import org.folio.rest.jaxrs.model.MappingDetail;
-import org.folio.rest.jaxrs.model.MappingMetadataDto;
-import org.folio.rest.jaxrs.model.MarcField;
-import org.folio.rest.jaxrs.model.MarcMappingDetail;
-import org.folio.rest.jaxrs.model.MarcSubfield;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.ParsedRecord;
-import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.Record;
-import org.folio.rest.jaxrs.model.Snapshot;
+import org.folio.rest.jaxrs.model.*;
 import org.folio.services.caches.MappingParametersSnapshotCache;
 import org.folio.services.handlers.actions.MarcBibUpdateModifyEventHandler;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.UUID;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -63,9 +44,7 @@ import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MappingDetail.MarcMappingOption.UPDATE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
-import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.*;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 
 @RunWith(VertxUnitRunner.class)
@@ -315,6 +294,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
   }
 
   @Test
+  @Ignore //urgent fix, investigation is in progress
   public void shouldUpdateMarcRecordAndRemove003Field(TestContext context) {
     // given
     Async async = context.async();

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -253,7 +253,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -294,13 +294,12 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
   }
 
   @Test
-  @Ignore //urgent fix, investigation is in progress
-  public void shouldUpdateMarcRecordAndRemove003Field(TestContext context) {
+  public void shouldUpdateMarcRecordAndCreate035FieldAndRemove003Field(TestContext context) {
     // given
     Async async = context.async();
 
-    String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"2300089\"},{\"003\":\"LTSCA\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00138nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"(LTSCA)2300089\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();


### PR DESCRIPTION
## Purpose
Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists

## Approach
The data from 001 and from 003 fields should not be lost and field 035 should not contain duplicates.
The field 003 should be deleted during import.
For creating MARC BIB records:
- when 035 field isn't present in MARC BIB, this field should be created;

For updating MARC BIB records:
- when 001 field is not equal to hrId then this data should be saved in a new unique 035 field.

## Learning
[MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-528)