### PR TITLE
MODSOURCE-531: Can't update "MARC" record, which was created by stopped import job.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [MODSOURMAN-801](https://issues.folio.org/browse/MODSOURMAN-801) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't
 * [MODSOURCE-495](https://issues.folio.org/browse/MODSOURCE-495) Logs show incorrectly formatted request id
 * [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists
+* [MODSOURCE-531](https://issues.folio.org/browse/MODSOURCE-531) Can't update "MARC" record, which was created by stopped import job.
 
 ## 2022-06-02 v5.3.3
 * [MODSOURCE-508](https://issues.folio.org/browse/MODSOURCE-508) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -460,7 +460,7 @@ public class RecordDaoImpl implements RecordDao {
             .from(RECORDS_LB)
             .innerJoin(SNAPSHOTS_LB).on(RECORDS_LB.SNAPSHOT_ID.eq(SNAPSHOTS_LB.ID))
             .where(RECORDS_LB.MATCHED_ID.in(matchedIds)
-              .and(SNAPSHOTS_LB.STATUS.in(JobExecutionStatus.COMMITTED, JobExecutionStatus.ERROR))
+              .and(SNAPSHOTS_LB.STATUS.in(JobExecutionStatus.COMMITTED, JobExecutionStatus.ERROR, JobExecutionStatus.CANCELLED))
               .and(SNAPSHOTS_LB.UPDATED_DATE.lessThan(dsl
                 .select(SNAPSHOTS_LB.PROCESSING_STARTED_DATE)
                 .from(SNAPSHOTS_LB)

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -671,7 +671,7 @@ public class RecordDaoImpl implements RecordDao {
     return txQE.query(dsl -> dsl.select(max(RECORDS_LB.GENERATION).as(RECORDS_LB.GENERATION))
       .from(RECORDS_LB.innerJoin(SNAPSHOTS_LB).on(RECORDS_LB.SNAPSHOT_ID.eq(SNAPSHOTS_LB.ID)))
       .where(RECORDS_LB.MATCHED_ID.eq(UUID.fromString(record.getMatchedId()))
-        .and(SNAPSHOTS_LB.STATUS.in(JobExecutionStatus.COMMITTED, JobExecutionStatus.ERROR))
+        .and(SNAPSHOTS_LB.STATUS.in(JobExecutionStatus.COMMITTED, JobExecutionStatus.ERROR, JobExecutionStatus.CANCELLED))
         .and(SNAPSHOTS_LB.UPDATED_DATE.lessThan(dsl.select(SNAPSHOTS_LB.PROCESSING_STARTED_DATE)
           .from(SNAPSHOTS_LB)
           .where(SNAPSHOTS_LB.ID.eq(UUID.fromString(record.getSnapshotId())))))))


### PR DESCRIPTION
## Purpose
 If import of "MARC" records was stopped by user, the created records impossible to update via "Data import" app because it leads to error. The error message: "io.vertx.pgclient.PgException: ERROR: duplicate key value violates unique constraint "idx_records_matched_id_gen" (23505)" displaying when user click on the name of imported record.

## Approach
Extended statuses via CANCELLED.

JIRA: https://issues.folio.org/browse/MODSOURCE-531
