### PR TITLE
MODSOURCE-528: Remove 035 with actual hrId when exists

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -42,6 +42,7 @@ import static org.folio.services.util.AdditionalFieldsUtil.addControlledFieldToM
 import static org.folio.services.util.AdditionalFieldsUtil.fill035FieldInMarcRecordIfNotExists;
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
+import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrIdIfExists;
 
 public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
 
@@ -96,6 +97,8 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
             if (StringUtils.isNotBlank(incoming001) && !incoming001.equals(changed001)) {
               fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
             }
+
+            remove035WithActualHrIdIfExists(changedRecord, hrId);
             remove003FieldIfNeeded(changedRecord, hrId);
           }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -42,7 +42,7 @@ import static org.folio.services.util.AdditionalFieldsUtil.addControlledFieldToM
 import static org.folio.services.util.AdditionalFieldsUtil.fill035FieldInMarcRecordIfNotExists;
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
-import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrIdIfExists;
+import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrId;
 
 public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
 
@@ -98,7 +98,7 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
               fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
             }
 
-            remove035WithActualHrIdIfExists(changedRecord, hrId);
+            remove035WithActualHrId(changedRecord, hrId);
             remove003FieldIfNeeded(changedRecord, hrId);
           }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
@@ -46,10 +45,10 @@ public final class AdditionalFieldsUtil {
 
   public static final String HR_ID_FROM_FIELD = "001";
   private static final String HR_ID_PREFIX_FROM_FIELD = "003";
-  public static final String HR_ID_TO_FIELD = "035";
+  private static final String HR_ID_TO_FIELD = "035";
   private static final String HR_ID_FIELD = "hrid";
   private static final String ID_FIELD = "id";
-  public static final char HR_ID_FIELD_SUB = 'a';
+  private static final char HR_ID_FIELD_SUB = 'a';
   private static final char HR_ID_FIELD_IND = ' ';
   private static final String ANY_STRING = "*";
 
@@ -221,7 +220,7 @@ public final class AdditionalFieldsUtil {
     boolean isContains = false;
     if (field instanceof DataField) {
       for (Subfield sub : ((DataField) field).getSubfields(subfield)) {
-        if (isNotEmpty(sub.getData()) && sub.getData().equals(value.trim())) {
+        if (isNotEmpty(sub.getData()) && sub.getData().contains(value.trim())) {
           isContains = true;
           break;
         }
@@ -371,7 +370,7 @@ public final class AdditionalFieldsUtil {
         addControlledFieldToMarcRecord(recordInstancePair.getKey(), HR_ID_FROM_FIELD, hrId);
       }
     } else {
-      remove035WithActualHrIdIfExists(recordInstancePair.getKey(), hrId);
+      remove035WithActualHrId(recordInstancePair.getKey(), hrId);
     }
     removeField(recordInstancePair.getKey(), HR_ID_PREFIX_FROM_FIELD);
   }
@@ -440,10 +439,8 @@ public final class AdditionalFieldsUtil {
    * @param record       - source record
    * @param actualHrId   - actual HrId
    */
-  public static void remove035WithActualHrIdIfExists(Record record, String actualHrId) {
-    if (isFieldExist(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId)) {
+  public static void remove035WithActualHrId(Record record, String actualHrId) {
       removeField(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId);
-    }
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.contains;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -47,10 +46,10 @@ public final class AdditionalFieldsUtil {
 
   public static final String HR_ID_FROM_FIELD = "001";
   private static final String HR_ID_PREFIX_FROM_FIELD = "003";
-  private static final String HR_ID_TO_FIELD = "035";
+  public static final String HR_ID_TO_FIELD = "035";
   private static final String HR_ID_FIELD = "hrid";
   private static final String ID_FIELD = "id";
-  private static final char HR_ID_FIELD_SUB = 'a';
+  public static final char HR_ID_FIELD_SUB = 'a';
   private static final char HR_ID_FIELD_IND = ' ';
   private static final String ANY_STRING = "*";
 
@@ -152,12 +151,14 @@ public final class AdditionalFieldsUtil {
   /**
    * remove field from marc record
    *
-   * @param record record that needs to be updated
-   * @param field  tag of the field
+   * @param record   record that needs to be updated
+   * @param field    tag of the field
+   * @param subfield subfield of the field
+   * @param value    value of the field
    * @return true if succeeded, false otherwise
    */
-  public static boolean removeField(Record record, String field) {
-    boolean result = false;
+  public static boolean removeField(Record record, String field, char subfield, String value) {
+    boolean isFieldRemoveSucceed = false;
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
         MarcReader reader = buildMarcReader(record);
@@ -165,21 +166,64 @@ public final class AdditionalFieldsUtil {
         MarcJsonWriter marcJsonWriter = new MarcJsonWriter(baos);
         if (reader.hasNext()) {
           org.marc4j.marc.Record marcRecord = reader.next();
-          VariableField variableField = marcRecord.getVariableField(field);
-          if (variableField != null) {
-            marcRecord.removeVariableField(variableField);
+          List<VariableField> variableFields = marcRecord.getVariableFields(field);
+          for (VariableField variableField : variableFields) {
+            if (StringUtils.isEmpty(value)) {
+              marcRecord.removeVariableField(variableField);
+              isFieldRemoveSucceed = true;
+              break;
+            } else {
+              if (isFieldContainsValue(variableField, subfield, value)) {
+                marcRecord.removeVariableField(variableField);
+                isFieldRemoveSucceed = true;
+                break;
+              }
+            }
           }
-          // use stream writer to recalculate leader
-          marcStreamWriter.write(marcRecord);
-          marcJsonWriter.write(marcRecord);
-          record.setParsedRecord(record.getParsedRecord().withContent(new JsonObject(baos.toString()).encode()));
-          result = true;
+          if (isFieldRemoveSucceed) {
+            // use stream writer to recalculate leader
+            marcStreamWriter.write(marcRecord);
+            marcJsonWriter.write(marcRecord);
+            record.setParsedRecord(record.getParsedRecord().withContent(new JsonObject(baos.toString()).encode()));
+          }
         }
       }
     } catch (Exception e) {
       LOGGER.error("Failed to remove controlled field {} from record {}", field, record.getId(), e);
     }
-    return result;
+    return isFieldRemoveSucceed;
+  }
+
+  /**
+   * Checks if the field contains a certain value in the selected subfield
+   *
+   * @param field    from MARC BIB record
+   * @param subfield subfield of the field
+   * @param value    value of the field
+   * @return true if contains, false otherwise
+   */
+  private static boolean isFieldContainsValue(VariableField field, char subfield, String value) {
+    boolean isContains = false;
+    if (field instanceof DataField) {
+      for (Subfield sub : ((DataField) field).getSubfields(subfield)) {
+        if (isNotEmpty(sub.getData()) && sub.getData().equals(value.trim())) {
+          isContains = true;
+          break;
+        }
+      }
+    }
+    return isContains;
+  }
+
+  /**
+   * remove field from marc record
+   *
+   * @param record record that needs to be updated
+   * @param field  tag of the field
+   * @return true if succeeded, false otherwise
+   */
+  public static boolean removeField(Record record, String field) {
+    return removeField(record, field, '\0', null);
   }
 
   /**
@@ -304,8 +348,8 @@ public final class AdditionalFieldsUtil {
    * @return true if exist
    */
   public static boolean isFieldExist(Record record, String tag, char subfield, String value) {
-    if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
-      MarcReader reader = buildMarcReader(record);
+      if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
+        MarcReader reader = buildMarcReader(record);
       try {
         if (reader.hasNext()) {
           org.marc4j.marc.Record marcRecord = reader.next();
@@ -412,6 +456,18 @@ public final class AdditionalFieldsUtil {
   public static void remove003FieldIfNeeded(Record record, String instanceHrid) {
     if (StringUtils.isNotBlank(instanceHrid) && StringUtils.isNotBlank(AdditionalFieldsUtil.getValueFromControlledField(record, "001"))) {
       AdditionalFieldsUtil.removeField(record, HR_ID_PREFIX_FROM_FIELD);
+    }
+  }
+
+  /**
+   * Remove 035 field if 035 equals actual HrId if exists
+   *
+   * @param record       - source record
+   * @param actualHrId   - actual HrId
+   */
+  public static void remove035WithActualHrIdIfExists(Record record, String actualHrId) {
+    if (isFieldExist(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId)) {
+      removeField(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId);
     }
   }
 


### PR DESCRIPTION
## Purpose
When SRS receives 035 field that contains actual hrid value this field should be removed before saving in DB.

## Approach
Removing the incorrect 035 field.

## Learning
[MODSOURCE-528](https://issues.folio.org/browse/MODSOURCE-528)
