### PR TITLE
MODSOURCE-535: Upgrade folio-di-support, folio-liquibase-util, PostgreSQL, Vert.x

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -113,13 +113,13 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.0</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
       <type>jar</type>
       <exclusions>
         <exclusion>
@@ -236,7 +236,7 @@
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jooq.version>3.13.6</jooq.version>
     <vertx-jooq.version>6.1.1</vertx-jooq.version>
-    <postgres.version>42.3.3</postgres.version>
+    <postgres.version>42.5.0</postgres.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <lombok.version>1.18.20</lombok.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <raml-module-builder.version>34.1.0</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <vertx.version>4.3.1</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.5.1</rest-assured.version>
     <kafkaclients.version>3.1.0</kafkaclients.version>


### PR DESCRIPTION
Upgrade folio-di-support from 1.4.1 to 1.6.0. This upgrades spring-beans fixing https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrade folio-liquibase-util from 1.4.0 to 1.5.0. This upgrades liquibase-core fixing https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Upgrade PostgreSQL JDBC from 42.3.3 to 42.5.0 fixing https://nvd.nist.gov/vuln/detail/CVE-2022-31197

Upgrade Vert.x from 4.3.1 to 4.3.3 fixing disabled SSL: https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web