### PR TITLE
MODSOURCE-538: Subscribe the module to item updated event.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * [MODSOURCE-495](https://issues.folio.org/browse/MODSOURCE-495) Logs show incorrectly formatted request id
 * [MODSOURCE-509](https://issues.folio.org/browse/MODSOURCE-509) Data Import Updates should add 035 field from 001/003, if it's not HRID or already exists
 * [MODSOURCE-531](https://issues.folio.org/browse/MODSOURCE-531) Can't update "MARC" record, which was created by stopped import job.
+* [MODSOURCE-538](https://issues.folio.org/browse/MODSOURCE-8) Subscribe the module to item updated event.
 
 ## 2022-06-02 v5.3.3
 * [MODSOURCE-508](https://issues.folio.org/browse/MODSOURCE-508) Inventory Single Record Import: Overlays for Source=MARC Instances retain 003 when they shouldn't

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
@@ -30,6 +30,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTA
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_ITEM_UPDATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_DELETE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_MARC_FOR_UPDATE_RECEIVED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
@@ -56,6 +57,7 @@ public class DataImportConsumersVerticle extends AbstractVerticle {
     DI_INVENTORY_INSTANCE_UPDATED.value(),
     DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value(),
     DI_INVENTORY_ITEM_CREATED.value(),
+    DI_INVENTORY_ITEM_UPDATED.value(),
     DI_MARC_FOR_UPDATE_RECEIVED.value(),
     DI_SRS_MARC_AUTHORITY_RECORD_CREATED.value(),
     DI_SRS_MARC_AUTHORITY_RECORD_MATCHED.value(),


### PR DESCRIPTION
## Purpose
There are cases where action profile for item update is used as an intermediate operation and other profiles should be processed after item update action profile.

## Approach
DI_INVENTORY_ITEM_UPDATED event type added.

## Learning
JIRA: https://issues.folio.org/browse/MODSOURCE-538
