### PR TITLE
MODSOURCE-542: scala 2.13.9, kafkaclients 3.1.2, httpclient 4.5.13

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -139,23 +139,9 @@
       <version>${vertx-jooq.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.raml.jaxrs</groupId>
-      <artifactId>jaxrs-code-generator</artifactId>
-      <version>3.0.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.json</groupId>
-          <artifactId>json</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.validation</groupId>
-          <artifactId>validation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -168,6 +154,12 @@
           <artifactId>jopt-simple</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.8.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -186,7 +178,7 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>${kafkaclients.version}</version>
+      <version>${kafkajunit.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -206,7 +198,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.1</version>
+      <version>2.13.9</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
     <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.5.1</rest-assured.version>
-    <kafkaclients.version>3.1.0</kafkaclients.version>
+    <kafkaclients.version>3.1.2</kafkaclients.version>
+    <kafkajunit.version>3.1.0</kafkajunit.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>
   </properties>
 


### PR DESCRIPTION
Upgrade scala-library from 2.13.1 to 2.13.9 fixing Remote Code Execution (RCE) vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Upgrade kafkaclients from 3.1.0 to 3.1.2 fixing Out-of-Memory vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Upgrade httpclient from 4.0.1 to 4.5.13 fixing Man-in-the-Middle (MitM):
https://nvd.nist.gov/vuln/detail/CVE-2014-3577

Remove unused jaxrs-code-generator dependency. Only these indirect dependencies are needed and added as direct dependencies: httpclient, mockito-core.