### PR TITLE
[MODSOURCE-540]Upgrade to RMB v35.0.0

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/TenantUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/TenantUtil.java
@@ -22,7 +22,7 @@ public class TenantUtil {
     PostgresClient pgClient = PostgresClient.getInstance(vertx);
     Promise<RowSet<Row>> promise = Promise.promise();
     String tenantQuery = "select nspname from pg_catalog.pg_namespace where nspname LIKE '%_mod_source_record_storage';";
-    pgClient.select(tenantQuery, promise);
+    pgClient.selectRead(tenantQuery, 60000, promise);
     return promise.future()
       .map(rowSet -> StreamSupport.stream(rowSet.spliterator(), false)
         .map(TenantUtil::mapToTenant)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>34.1.0</raml-module-builder.version>
+    <raml-module-builder.version>35.0.0</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
     <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURCE-540
[RMB-348](https://issues.folio.org/browse/RMB-348) introduces the ability to direct the read and write calls to the respective database node, the reader or writer (if the database is configured in such a way). The separation of read and write queries brings performance improvements and scalability as the write node is freed up to do more writing while the read node is busy making retrievals.   Most of the read-only code in RMB has already been updated to communicate to the Read node directly. However, there are many other public RMB APIs that are used for both reading and writing by RMB's clients that have not been updated to exclusively talk to the read node.  To take advantage of the read/write split, mod-source-record-storage should replace any readonly code that calls the existing RMB "read" methods (which unfortunately could handle both read and writes) with one of the new RMB read-only methods that exclusively communicates to the read node. The table below shows the current RMB "read" methods that could handle reading and writing, and the new methods to replace them.