### PR TITLE
MODSOURCE-554: Change registration module in tests

### DIFF
--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -146,7 +146,7 @@ public abstract class AbstractRestVerticleTest {
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, res -> {
       try {
         TenantAttributes tenantAttributes = new TenantAttributes();
-        tenantAttributes.setModuleTo(ModuleName.getModuleName());
+        tenantAttributes.setModuleTo(ModuleName.getModuleName() + "-1.0.0");
         tenantAttributes.setParameters(Collections.singletonList(new Parameter()
           .withKey(LOAD_SAMPLE_PARAMETER)
           .withValue("true")));

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
     <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
According to changes in RMB 35.0.0.0 [RMB-937](https://issues.folio.org/browse/RMB-937) add version "1.0.0" when registering the module in AbstractRestVerticleTest

## Learning
[MODSOURCE-554](https://issues.folio.org/browse/MODSOURCE-554)
