### PR TITLE
MODSOURCE-556: Fix behaviour of the cache in JobProfileSnapshotCache class

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -213,7 +213,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.8.5</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/caches/JobProfileSnapshotCache.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/caches/JobProfileSnapshotCache.java
@@ -48,7 +48,7 @@ public class JobProfileSnapshotCache {
   }
 
   private CompletableFuture<Optional<ProfileSnapshotWrapper>> loadJobProfileSnapshot(String profileSnapshotId, OkapiConnectionParams params) {
-    LOGGER.debug("Trying to load jobProfileSnapshot by id  '{}' for cache, okapi url: {}, tenantId: {}", profileSnapshotId, params.getOkapiUrl(), params.getTenantId());
+    LOGGER.debug("Trying to load jobProfileSnapshot by id '{}' for cache, okapi url: {}, tenantId: {}", profileSnapshotId, params.getOkapiUrl(), params.getTenantId());
 
     return RestUtil.doRequest(params, "/data-import-profiles/jobProfileSnapshots/" + profileSnapshotId, HttpMethod.GET, null)
       .toCompletionStage()


### PR DESCRIPTION
## Purpose
The cache does not return ProfileSnapshot and record-storage calls converter-storage every time. The same class in mod-inventory works as expected.

## Approach
Fixed in caffeine 3.1.1

## Learning
[MODSOURCE-556](https://issues.folio.org/browse/MODSOURCE-556)
