### PR TITLE
MODDATAIMP-722 - MARC-to-MARC Holdings update stacked

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -23,6 +23,7 @@ import org.folio.services.handlers.match.MarcAuthorityMatchEventHandler;
 import org.folio.services.handlers.match.MarcBibliographicMatchEventHandler;
 import org.folio.services.handlers.actions.MarcAuthorityUpdateModifyEventHandler;
 import org.folio.services.handlers.actions.MarcBibUpdateModifyEventHandler;
+import org.folio.services.handlers.match.MarcHoldingsMatchEventHandler;
 import org.folio.spring.SpringContextUtil;
 import org.folio.verticle.consumers.DataImportConsumersVerticle;
 import org.folio.verticle.consumers.ParsedRecordChunkConsumersVerticle;
@@ -58,6 +59,9 @@ public class InitAPIImpl implements InitAPI {
 
   @Autowired
   private MarcAuthorityDeleteEventHandler marcAuthorityDeleteEventHandler;
+
+  @Autowired
+  private MarcHoldingsMatchEventHandler marcHoldingsMatchEventHandler;
 
   @Value("${srs.kafka.ParsedMarcChunkConsumer.instancesNumber:1}")
   private int parsedMarcChunkConsumerInstancesNumber;
@@ -96,6 +100,7 @@ public class InitAPIImpl implements InitAPI {
     EventManager.registerEventHandler(marcBibliographicMatchEventHandler);
     EventManager.registerEventHandler(marcAuthorityMatchEventHandler);
     EventManager.registerEventHandler(marcAuthorityDeleteEventHandler);
+    EventManager.registerEventHandler(marcHoldingsMatchEventHandler);
   }
 
   private Future<?> deployConsumerVerticles(Vertx vertx) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -19,6 +19,7 @@ import org.folio.services.handlers.AuthorityPostProcessingEventHandler;
 import org.folio.services.handlers.HoldingsPostProcessingEventHandler;
 import org.folio.services.handlers.InstancePostProcessingEventHandler;
 import org.folio.services.handlers.actions.MarcAuthorityDeleteEventHandler;
+import org.folio.services.handlers.actions.MarcHoldingsUpdateModifyEventHandler;
 import org.folio.services.handlers.match.MarcAuthorityMatchEventHandler;
 import org.folio.services.handlers.match.MarcBibliographicMatchEventHandler;
 import org.folio.services.handlers.actions.MarcAuthorityUpdateModifyEventHandler;
@@ -63,6 +64,9 @@ public class InitAPIImpl implements InitAPI {
   @Autowired
   private MarcHoldingsMatchEventHandler marcHoldingsMatchEventHandler;
 
+  @Autowired
+  private MarcHoldingsUpdateModifyEventHandler marcHoldingsUpdateModifyEventHandler;
+
   @Value("${srs.kafka.ParsedMarcChunkConsumer.instancesNumber:1}")
   private int parsedMarcChunkConsumerInstancesNumber;
 
@@ -100,7 +104,8 @@ public class InitAPIImpl implements InitAPI {
     EventManager.registerEventHandler(marcBibliographicMatchEventHandler);
     EventManager.registerEventHandler(marcAuthorityMatchEventHandler);
     EventManager.registerEventHandler(marcAuthorityDeleteEventHandler);
-    EventManager.registerEventHandler(marcHoldingsMatchEventHandler);
+    EventManager.registerEventHandler(marcHoldingsMatchEventHandler) ;
+    EventManager.registerEventHandler(marcHoldingsUpdateModifyEventHandler);
   }
 
   private Future<?> deployConsumerVerticles(Vertx vertx) {


### PR DESCRIPTION
## Purpose
_MARC-to-MARC Holdings update stacked_

## Approach

- Create job profile to update MARC Holdings with match profile MARC-MARC matching (available only via API)
- Import some Holdings records
- Try to update these holdings with created job profile

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
https://issues.folio.org/browse/MODDATAIMP-722