### PR TITLE
MODSOURCE-550 Link update: Update MARC bibs according to links.instance-authority event

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srs.cleanup.last.updated.days_": 7
   * "_srs.cleanup.limit_": 100
   * "_srs.cleanup.cron.expression_": 0 0 0 * * ?
+* Relevant from the **Orchid** release, module versions from 5.6.0:
+  * "_srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum_": 100
+  * "_srs.kafka.AuthorityLinkChunkConsumer.loadLimit_": 2
 
 ## Database schemas
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -1,0 +1,334 @@
+package org.folio.consumers;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.folio.RecordStorageKafkaTopic.MARC_BIB;
+import static org.folio.dao.util.ParsedRecordDaoUtil.normalize;
+import static org.folio.services.util.EventHandlingUtil.createProducer;
+import static org.folio.services.util.EventHandlingUtil.createTopicName;
+
+import com.google.common.collect.Maps;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dao.util.IdType;
+import org.folio.dao.util.RecordDaoUtil;
+import org.folio.dao.util.RecordType;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaConfig;
+import org.folio.rest.jaxrs.model.BibAuthorityLinksUpdate;
+import org.folio.rest.jaxrs.model.Link;
+import org.folio.rest.jaxrs.model.MarcBibUpdate;
+import org.folio.rest.jaxrs.model.RecordCollection;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.rest.jaxrs.model.SubfieldsChange;
+import org.folio.rest.jaxrs.model.UpdateTarget;
+import org.folio.services.RecordService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String, String> {
+
+  public static final String SRS_BIB_UPDATE_TOPIC = MARC_BIB.moduleName() + "." + MARC_BIB.topicName();
+
+  private static final Logger log = LogManager.getLogger();
+  private static final String PARSED_RECORD_FIELDS_KEY = "fields";
+  private static final String PARSED_RECORD_SUBFIELDS_KEY = "subfields";
+  private static final String AUTHORITY_ID_SUBFIELD = "9";
+  private static final AtomicLong INDEXER = new AtomicLong();
+
+  private final RecordService recordService;
+  private final KafkaConfig kafkaConfig;
+  private final KafkaProducer<String, String> producer;
+
+  @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
+  private int maxDistributionNum;
+
+  public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig) {
+    this.recordService = recordService;
+    this.kafkaConfig = kafkaConfig;
+
+    producer = createProducer(SRS_BIB_UPDATE_TOPIC, kafkaConfig);
+  }
+
+  @Override
+  public Future<String> handle(KafkaConsumerRecord<String, String> consumerRecord) {
+    return mapToEvent(consumerRecord)
+      .compose(event -> retrieveRecords(event, event.getTenant())
+        .compose(recordCollection -> mapRecordFieldsChanges(event, recordCollection))
+        .compose(recordCollection -> recordService.saveRecords(recordCollection, event.getTenant()))
+        .map(recordsBatchResponse -> mapRecordsToBibUpdateEvents(recordsBatchResponse, event))
+        .compose(marcBibUpdates -> sendEvents(marcBibUpdates, event, consumerRecord))
+      ).recover(th -> {
+          log.error("Failed to handle {} event", SRS_BIB_UPDATE_TOPIC, th);
+          return Future.failedFuture(th);
+        }
+      );
+  }
+
+  private Future<BibAuthorityLinksUpdate> mapToEvent(KafkaConsumerRecord<String, String> consumerRecord) {
+    try {
+      var event = Json.decodeValue(consumerRecord.value(), BibAuthorityLinksUpdate.class);
+      log.info("Decoded {} event for authorityId {}", BibAuthorityLinksUpdate.class, event.getAuthorityId());
+      return Future.succeededFuture(event);
+    } catch (Exception e) {
+      log.error("Failed to decode event with key {}", consumerRecord.key());
+      return Future.failedFuture(e);
+    }
+  }
+
+  private Future<RecordCollection> retrieveRecords(BibAuthorityLinksUpdate bibAuthorityLinksUpdate, String tenantId) {
+    log.trace("Retrieving bibs for authorityId {}", bibAuthorityLinksUpdate.getAuthorityId());
+    var instanceIds = bibAuthorityLinksUpdate.getUpdateTargets().stream()
+      .flatMap(updateTarget -> updateTarget.getLinks().stream()
+        .map(Link::getInstanceId))
+      .distinct()
+      .collect(Collectors.toList());
+
+    var condition = RecordDaoUtil.getExternalIdsCondition(instanceIds, IdType.INSTANCE)
+      .and(RecordDaoUtil.filterRecordByDeleted(false));
+    return recordService.getRecords(condition, RecordType.MARC_BIB, emptyList(), 0, instanceIds.size(), tenantId);
+  }
+
+  private Future<RecordCollection> mapRecordFieldsChanges(BibAuthorityLinksUpdate bibAuthorityLinksUpdate,
+                                                          RecordCollection recordCollection) {
+    log.debug("Retrieved {} records for authorityId {}.",
+      recordCollection.getTotalRecords(), bibAuthorityLinksUpdate.getAuthorityId());
+
+    return getSubfieldProcessorForEvent(bibAuthorityLinksUpdate).map(subfieldProcessor -> {
+      recordCollection.getRecords().forEach(bibRecord -> {
+        var newRecordId = UUID.randomUUID().toString();
+        var instanceId = bibRecord.getExternalIdsHolder().getInstanceId();
+        var parsedRecord = bibRecord.getParsedRecord();
+        var parsedRecordContent = normalize(parsedRecord.getContent());
+        var fieldsArray = parsedRecordContent.getJsonArray(PARSED_RECORD_FIELDS_KEY);
+
+
+        var updateTargetFieldCodes = extractUpdateTargetFieldCodesForInstance(bibAuthorityLinksUpdate, instanceId);
+        var subfieldChanges = bibAuthorityLinksUpdate.getSubfieldsChanges().stream()
+          .filter(subfieldsChange -> updateTargetFieldCodes.contains(subfieldsChange.getField()))
+          .collect(Collectors.toList());
+
+        var fieldsList = fieldsArray.stream()
+          .map(JsonObject::mapFrom)
+          .map(fieldJson -> fieldJson.getMap().entrySet().stream().findFirst().orElse(null))
+          .filter(Objects::nonNull)
+          .map(field -> {
+            var fieldCode = field.getKey();
+            if (!updateTargetFieldCodes.contains(fieldCode)) {
+              return field;
+            }
+
+            var fieldValueJson = JsonObject.mapFrom(field.getValue());
+            var subfieldsJson = fieldValueJson.getJsonArray(PARSED_RECORD_SUBFIELDS_KEY);
+            if (subfieldsJson == null) {
+              return field;
+            }
+            var subfields = extractSubfields(subfieldsJson);
+
+            var authorityId = extractAuthorityId(subfields);
+            if (authorityId.isEmpty() || !bibAuthorityLinksUpdate.getAuthorityId().equals(authorityId.get())) {
+              return field;
+            }
+
+            var newSubfields = subfieldProcessor.process(fieldCode, subfieldChanges, subfields);
+            log.trace("AuthorityId {}, instanceId {}, field {}, old subfields: {}, new subfields: {}",
+              bibAuthorityLinksUpdate.getAuthorityId(), instanceId, fieldCode, subfieldsJson, newSubfields);
+
+            fieldValueJson.put(PARSED_RECORD_SUBFIELDS_KEY, newSubfields);
+            field.setValue(fieldValueJson);
+            return field;
+          })
+          .collect(Collectors.toList());
+
+        parsedRecordContent.put(PARSED_RECORD_FIELDS_KEY, fieldsList);
+        parsedRecord.setContent(parsedRecordContent.encode());
+        parsedRecord.setFormattedContent(EMPTY);
+        parsedRecord.setId(newRecordId);
+        bibRecord.setId(newRecordId);
+        bibRecord.getRawRecord().setId(newRecordId);
+        bibRecord.setSnapshotId(bibAuthorityLinksUpdate.getJobId());
+      });
+
+      return recordCollection;
+    });
+  }
+
+  private Future<SubfieldProcessor> getSubfieldProcessorForEvent(BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+
+    var eventType = bibAuthorityLinksUpdate.getType();
+    switch (eventType) {
+      case DELETE: {
+        log.debug("Precessing DELETE event for authorityId {}", bibAuthorityLinksUpdate.getAuthorityId());
+        return Future.succeededFuture(deleteSubfieldProcessor());
+      }
+      case UPDATE: {
+        log.debug("Precessing UPDATE event for authorityId {}", bibAuthorityLinksUpdate.getAuthorityId());
+        return Future.succeededFuture(updateSubfieldProcessor());
+      }
+      default: {
+        return Future.failedFuture(new IllegalArgumentException(
+          "Unsupported event type: " + eventType + " for authorityId " + bibAuthorityLinksUpdate.getAuthorityId()));
+      }
+    }
+  }
+
+  private List<String> extractUpdateTargetFieldCodesForInstance(BibAuthorityLinksUpdate bibAuthorityLinksUpdate, String instanceId) {
+    return bibAuthorityLinksUpdate.getUpdateTargets().stream()
+      .filter(updateTarget -> updateTarget.getLinks().stream()
+        .anyMatch(link -> link.getInstanceId().equals(instanceId)))
+      .map(UpdateTarget::getField)
+      .collect(Collectors.toList());
+  }
+
+  private List<Map.Entry<String, Object>> extractSubfields(JsonArray subfields) {
+    return subfields.stream()
+      .map(JsonObject::mapFrom)
+      .map(subfieldJson -> subfieldJson.getMap().entrySet().stream().findFirst().orElse(null))
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+
+  private Optional<Object> extractAuthorityId(List<Map.Entry<String, Object>> subfields) {
+    return subfields.stream()
+      .filter(entry -> entry.getKey().equals(AUTHORITY_ID_SUBFIELD))
+      .map(Map.Entry::getValue)
+      .findFirst();
+  }
+
+  private List<MarcBibUpdate> mapRecordsToBibUpdateEvents(RecordsBatchResponse batchResponse, BibAuthorityLinksUpdate event) {
+    log.debug("Updated {} bibs for authorityId {}", batchResponse.getTotalRecords(), event.getAuthorityId());
+
+    var errors = batchResponse.getErrorMessages();
+    if (!errors.isEmpty()) {
+      log.error("Unable to batch update some of linked bib records for authority: {}."
+          + " Total number of records: {}, successful: {}, failures: {}",
+        event.getAuthorityId(), batchResponse.getTotalRecords(), batchResponse.getRecords().size(), errors);
+    }
+
+    return toMarcBibUpdateEvents(batchResponse, event);
+  }
+
+  private List<MarcBibUpdate> toMarcBibUpdateEvents(RecordsBatchResponse batchResponse,
+                                                    BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+    var instanceIdToLinkIds = bibAuthorityLinksUpdate.getUpdateTargets().stream()
+      .flatMap(updateTarget -> updateTarget.getLinks().stream())
+      .collect(Collectors.groupingBy(Link::getInstanceId, Collectors.mapping(Link::getLinkId, Collectors.toList())));
+    return batchResponse.getRecords().stream()
+      .map(bibRecord -> {
+        var instanceId = bibRecord.getExternalIdsHolder().getInstanceId();
+        return new MarcBibUpdate()
+          .withJobId(bibAuthorityLinksUpdate.getJobId())
+          .withLinkIds(instanceIdToLinkIds.get(instanceId))
+          .withTenant(bibAuthorityLinksUpdate.getTenant())
+          .withType(MarcBibUpdate.Type.UPDATE)
+          .withTs(bibAuthorityLinksUpdate.getTs())
+          .withRecord(bibRecord);
+      })
+      .collect(Collectors.toList());
+  }
+
+  private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents, BibAuthorityLinksUpdate event,
+                                    KafkaConsumerRecord<String, String> consumerRecord) {
+    log.info("Sending {} bib update events for authorityId {}", marcBibUpdateEvents.size(), event.getAuthorityId());
+    return Future.fromCompletionStage(
+      CompletableFuture.allOf(
+        marcBibUpdateEvents.stream()
+          .map(marcBibUpdate -> sendEventToKafka(marcBibUpdate, consumerRecord.headers())
+            .onFailure(th -> log.error("Failed to send {} event", SRS_BIB_UPDATE_TOPIC, th)))
+          .map(Future::toCompletionStage)
+          .map(CompletionStage::toCompletableFuture)
+          .toArray(CompletableFuture[]::new)
+      ).minimalCompletionStage()
+    ).map(unused -> consumerRecord.key());
+  }
+
+  private Future<Boolean> sendEventToKafka(MarcBibUpdate marcBibUpdate, List<KafkaHeader> kafkaHeaders) {
+    var promise = Promise.<Boolean>promise();
+    try {
+      var kafkaRecord = createKafkaProducerRecord(marcBibUpdate, kafkaHeaders);
+      producer.write(kafkaRecord, war -> {
+        if (war.succeeded()) {
+          log.debug("Event with type {} was sent to kafka", SRS_BIB_UPDATE_TOPIC);
+          promise.complete(true);
+        } else {
+          var cause = war.cause();
+          log.error("Failed to sent event {}, cause: {}", SRS_BIB_UPDATE_TOPIC, cause);
+          promise.fail(cause);
+        }
+      });
+    } catch (Exception e) {
+      log.error("Failed to send an event for eventType {}, cause {}", SRS_BIB_UPDATE_TOPIC, e);
+      return Future.failedFuture(e);
+    }
+    return promise.future();
+  }
+
+  private KafkaProducerRecord<String, String> createKafkaProducerRecord(MarcBibUpdate marcBibUpdate,
+                                                                        List<KafkaHeader> kafkaHeaders) {
+    var topicName = createTopicName(SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getTenant(), kafkaConfig);
+    var key = String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum);
+    var kafkaRecord = KafkaProducerRecord.create(topicName, key,Json.encode(marcBibUpdate));
+    kafkaRecord.addHeaders(kafkaHeaders);
+
+    return kafkaRecord;
+  }
+
+  private SubfieldProcessor updateSubfieldProcessor() {
+    return (fieldCode, subfieldsChanges, oldSubfields) -> {
+      var newSubfields = new HashMap<String, Map.Entry<String, Object>>();
+
+      //add subfields from incoming event
+      subfieldsChanges.stream()
+        .filter(updateFieldValue -> updateFieldValue.getField().equals(fieldCode))
+        .flatMap(subfieldsChange -> subfieldsChange.getSubfields().stream())
+        .forEach(subfield -> newSubfields.put(subfield.getCode(),
+          Maps.immutableEntry(subfield.getCode(), subfield.getValue())));
+
+      //add old subfields which codes are absent in incoming event
+      oldSubfields.stream()
+        .filter(subfield -> !newSubfields.containsKey(subfield.getKey()))
+        .forEach(subfield -> newSubfields.put(subfield.getKey(), subfield));
+
+      return newSubfields.values();
+    };
+  }
+
+  private SubfieldProcessor deleteSubfieldProcessor() {
+    return (fieldCode, subfieldsChanges, oldSubfields) -> {
+      var newSubfields = new LinkedList<>(oldSubfields);
+
+      newSubfields.removeIf(subfield -> subfield.getKey().equals(AUTHORITY_ID_SUBFIELD));
+
+      return newSubfields;
+    };
+  }
+
+  private interface SubfieldProcessor {
+    Collection<Map.Entry<String, Object>> process(String fieldCode,
+                                                  List<SubfieldsChange> subfieldsChanges,
+                                                  List<Map.Entry<String, Object>> oldSubfields);
+  }
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/RecordMappingUtils.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/RecordMappingUtils.java
@@ -1,0 +1,53 @@
+package org.folio.consumers;
+
+import io.vertx.core.json.JsonObject;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.jaxrs.model.Record;
+import org.marc4j.MarcJsonReader;
+import org.marc4j.MarcJsonWriter;
+import org.marc4j.MarcReader;
+import org.marc4j.MarcStreamWriter;
+
+//todo: replace after this methods become public in mod-data-import-processing-core.
+// Maybe not possible because same dto is built in different packages (org.folio.rest.jaxrs.model.Record, org.folio.Record).
+// In such case this should be replaces after resolving issue with having same dtos built by multiple modules
+public final class RecordMappingUtils {
+
+  private static final String ERROR_RECORD_PARSING_MSG = "Failed to parse record from payload";
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private RecordMappingUtils() {}
+
+  public static org.marc4j.marc.Record readParsedContentToObjectRepresentation(Record srsRecord) {
+    var existingRecordReader = buildMarcReader(srsRecord);
+    if (existingRecordReader.hasNext()) {
+      return existingRecordReader.next();
+    } else {
+      LOGGER.error(ERROR_RECORD_PARSING_MSG);
+      throw new IllegalArgumentException(ERROR_RECORD_PARSING_MSG);
+    }
+  }
+
+  public static String mapObjectRepresentationToParsedContentJsonString(org.marc4j.marc.Record marcRecord) {
+    var os = new ByteArrayOutputStream();
+    var streamWriter = new MarcStreamWriter(new ByteArrayOutputStream());
+    var jsonWriter = new MarcJsonWriter(os);
+    streamWriter.write(marcRecord);
+    jsonWriter.write(marcRecord);
+    return os.toString().trim();
+  }
+
+  private static MarcReader buildMarcReader(Record srsRecord) {
+    var parsedContent = srsRecord.getParsedRecord().getContent() instanceof String
+      ? new JsonObject(srsRecord.getParsedRecord().getContent().toString())
+      : JsonObject.mapFrom(srsRecord.getParsedRecord().getContent());
+
+    return new MarcJsonReader(new ByteArrayInputStream(parsedContent
+      .toString()
+      .getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -221,17 +221,17 @@ public final class ParsedRecordDaoUtil {
   /**
    * Convinience method to get {@link RecordType} from {@link Record}
    *
-   * @param record record
+   * @param r record
    * @return record type defaulting to MARC
    */
-  public static RecordType toRecordType(Record record) {
-    if (Objects.nonNull(record.getRecordType())) {
-      return RecordType.valueOf(record.getRecordType().toString());
+  public static RecordType toRecordType(Record r) {
+    if (Objects.nonNull(r.getRecordType())) {
+      return RecordType.valueOf(r.getRecordType().toString());
     }
     return RecordType.MARC_BIB;
   }
 
-  private static JsonObject normalize(Object content) {
+  public static JsonObject normalize(Object content) {
     return (content instanceof String)
       ? new JsonObject((String) content)
       : JsonObject.mapFrom(content);

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
@@ -1,0 +1,72 @@
+package org.folio.verticle.consumers;
+
+import static org.folio.services.util.EventHandlingUtil.constructModuleName;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.folio.consumers.AuthorityLinkChunkKafkaHandler;
+import org.folio.kafka.GlobalLoadSensor;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaConsumerWrapper;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.SubscriptionDefinition;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.support.AbstractApplicationContext;
+
+public class AuthorityLinkChunkConsumersVerticle extends AbstractVerticle {
+  private static AbstractApplicationContext springGlobalContext;
+
+  private static final GlobalLoadSensor globalLoadSensor = new GlobalLoadSensor();
+  public static final String AUTHORITY_INSTANCE_LINKS_TOPIC = "links.instance-authority";
+
+  @Autowired
+  private AuthorityLinkChunkKafkaHandler kafkaHandler;
+
+  @Autowired
+  private KafkaConfig kafkaConfig;
+
+  @Value("${srs.kafka.AuthorityLinkChunkConsumer.loadLimit:2}")
+  private int loadLimit;
+
+  private KafkaConsumerWrapper<String, String> consumer;
+
+  /**
+   * @deprecated need to be replaced with spring global context
+   * */
+  @Deprecated(forRemoval = false)
+  public static void setSpringGlobalContext(AbstractApplicationContext springGlobalContext) {
+    AuthorityLinkChunkConsumersVerticle.springGlobalContext = springGlobalContext;
+  }
+
+  @Override
+  public void start(Promise<Void> startPromise) {
+    context.put("springContext", springGlobalContext);
+
+    SpringContextUtil.autowireDependencies(this, context);
+
+    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper
+      .createSubscriptionDefinition(kafkaConfig.getEnvId(),
+        KafkaTopicNameHelper.getDefaultNameSpace(),
+        AUTHORITY_INSTANCE_LINKS_TOPIC);
+
+    consumer = KafkaConsumerWrapper.<String, String>builder()
+      .context(context)
+      .vertx(vertx)
+      .kafkaConfig(kafkaConfig)
+      .loadLimit(loadLimit)
+      .globalLoadSensor(globalLoadSensor)
+      .subscriptionDefinition(subscriptionDefinition)
+      .build();
+
+    consumer.start(kafkaHandler, constructModuleName() + "_" + getClass().getSimpleName())
+      .onComplete(ar -> startPromise.complete());
+  }
+
+  @Override
+  public void stop(Promise<Void> stopPromise) {
+    consumer.stop().onComplete(ar -> stopPromise.complete());
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -297,7 +297,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
         .withSubfields(List.of(
           new Subfield().withCode("a").withValue("The fundamentals of typography updated"),//update
           new Subfield().withCode("b").withValue("new subfield"),//add new
-          new Subfield().withCode("h").withValue("[electronic resource] / updated"))),//update
+          new Subfield().withCode("h").withValue(""))),//remove subfield on update (for empty subfields)
       new SubfieldsChange().withField("100")//controlled by different authority, should remain as is
         .withSubfields(singletonList(new Subfield().withCode("a").withValue("Ambrose, Gavin. updated"))),
       new SubfieldsChange().withField("123")//doesn't exist, should be ignored

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -1,0 +1,373 @@
+package org.folio.services;
+
+import static java.util.Collections.singletonList;
+import static org.folio.consumers.AuthorityLinkChunkKafkaHandler.SRS_BIB_UPDATE_TOPIC;
+import static org.folio.kafka.KafkaTopicNameHelper.formatTopicName;
+import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
+import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+import static org.folio.verticle.consumers.AuthorityLinkChunkConsumersVerticle.AUTHORITY_INSTANCE_LINKS_TOPIC;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.ReadKeyValues;
+import net.mguenther.kafka.junit.SendKeyValues;
+import org.apache.commons.lang3.RandomUtils;
+import org.folio.TestUtil;
+import org.folio.dao.RecordDao;
+import org.folio.dao.RecordDaoImpl;
+import org.folio.dao.util.ParsedRecordDaoUtil;
+import org.folio.dao.util.SnapshotDaoUtil;
+import org.folio.rest.jaxrs.model.BibAuthorityLinksUpdate;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.Link;
+import org.folio.rest.jaxrs.model.MarcBibUpdate;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.RawRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.Record.State;
+import org.folio.rest.jaxrs.model.Snapshot;
+import org.folio.rest.jaxrs.model.Subfield;
+import org.folio.rest.jaxrs.model.SubfieldsChange;
+import org.folio.rest.jaxrs.model.UpdateTarget;
+import org.folio.rest.util.OkapiConnectionParams;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@RunWith(VertxUnitRunner.class)
+public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
+
+  private static final String PARSED_MARC_RECORD_LINKED_PATH = "src/test/resources/parsedMarcRecordLinked.json";
+  private static final String PARSED_MARC_RECORD_LINKED_UPDATED_PATH = "src/test/resources/parsedMarcRecordLinkedUpdated.json";
+  private static final String PARSED_MARC_RECORD_UNLINKED = "src/test/resources/parsedMarcRecordUnlinked.json";
+  private static final String KAFKA_KEY_NAME = "test-key";
+  private static final String KAFKA_TEST_HEADER = "test";
+  private static final String KAFKA_CONSUMER_TOPIC = getTopicName(AUTHORITY_INSTANCE_LINKS_TOPIC);
+  private static final String KAFKA_PRODUCER_TOPIC = getTopicName(SRS_BIB_UPDATE_TOPIC);
+  private static final String LINKED_AUTHORITY_ID = "6d19a8e8-2b71-482e-bfda-2b97f8722a2f";
+  private static final String SECOND_RECORD_ID = UUID.randomUUID().toString();
+  private static final String SECOND_INSTANCE_ID = UUID.randomUUID().toString();
+  private static final Integer LINK_ID = RandomUtils.nextInt();
+  private static final Map<String, String> OKAPI_HEADERS = Map.of(
+    OkapiConnectionParams.OKAPI_URL_HEADER, OKAPI_URL,
+    OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID,
+    OkapiConnectionParams.OKAPI_TOKEN_HEADER, TOKEN);
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private static String updatedParsedRecordContent;
+  private static String unlinkedParsedRecordContent;
+
+  private final String authorityJobId = UUID.randomUUID().toString();
+  private final String recordId = UUID.randomUUID().toString();
+  private final String instanceId = UUID.randomUUID().toString();
+  private final RawRecord rawRecord = new RawRecord().withId(recordId)
+    .withContent("test content");
+
+  private RecordDao recordDao;
+  private RecordService recordService;
+  private Record record;
+  private Record secondRecord;
+
+  @BeforeClass
+  public static void setUpClass() throws IOException {
+    updatedParsedRecordContent = new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_UPDATED_PATH)).encode();
+    unlinkedParsedRecordContent = new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_UNLINKED)).encode();
+  }
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    recordDao = new RecordDaoImpl(postgresClientFactory);
+    recordService = new RecordServiceImpl(recordDao);
+
+    var async = context.async();
+    var snapshot = new Snapshot()
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withProcessingStartedDate(new Date())
+      .withStatus(Snapshot.Status.COMMITTED);
+    var parsedRecord = new ParsedRecord().withId(recordId)
+      .withContent(new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode());
+    record = new Record()
+      .withId(recordId)
+      .withSnapshotId(snapshot.getJobExecutionId())
+      .withGeneration(0)
+      .withMatchedId(recordId)
+      .withRecordType(MARC_BIB)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(parsedRecord)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
+
+    var authoritySnapshot = new Snapshot()
+      .withJobExecutionId(authorityJobId)
+      .withProcessingStartedDate(new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)))
+      .withStatus(Snapshot.Status.COMMITTED);
+    var secondParsedRecord = new ParsedRecord().withId(SECOND_RECORD_ID)
+      .withContent(new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode());
+    secondRecord = new Record()
+      .withId(SECOND_RECORD_ID)
+      .withSnapshotId(snapshot.getJobExecutionId())
+      .withGeneration(0)
+      .withMatchedId(SECOND_RECORD_ID)
+      .withRecordType(MARC_BIB)
+      .withRawRecord(rawRecord)
+      .withParsedRecord(secondParsedRecord)
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(SECOND_INSTANCE_ID));
+
+    SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)
+      .compose(savedSnapshot -> recordService.saveRecord(record, TENANT_ID))
+      .compose(savedRecord -> SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), authoritySnapshot))
+      .compose(savedSnapshot -> recordService.saveRecord(secondRecord, TENANT_ID))
+      .onSuccess(ar -> async.complete())
+      .onFailure(context::fail);
+  }
+
+  @After
+  public void cleanUp(TestContext context) {
+    var async = context.async();
+    SnapshotDaoUtil.deleteAll(postgresClientFactory.getQueryExecutor(TENANT_ID)).onComplete(delete -> {
+      if (delete.failed()) {
+        context.fail(delete.cause());
+      }
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldUpdateBibRecordAndSendRecordUpdatedEvent(TestContext context)
+    throws InterruptedException, IOException {
+    var async = context.async();
+
+    var parsedRecord = record.getParsedRecord();
+    var updateTargets = buildUpdateTargets();
+    var event = buildLinkEventForUpdate(updateTargets);
+
+    var traceHeader = UUID.randomUUID().toString();
+    cluster.send(createRequest(event, traceHeader));
+    var keyValues = cluster.read(ReadKeyValues.from(KAFKA_PRODUCER_TOPIC)
+      .withMaxTotalPollTime(60, TimeUnit.SECONDS)
+      .filterOnHeaders(headers -> Arrays.equals(headers.lastHeader(KAFKA_TEST_HEADER).value(),
+        traceHeader.getBytes(StandardCharsets.UTF_8)))
+      .withLimit(1)
+      .build());
+    context.assertEquals(1, keyValues.size());
+    var actualHeaders = keyValues.get(0).getHeaders();
+    OKAPI_HEADERS.forEach((key, value) ->
+      context.assertTrue(Arrays.equals(value.getBytes(StandardCharsets.UTF_8), actualHeaders.lastHeader(key).value())));
+    var actualOutgoingEvent = objectMapper.readValue(keyValues.get(0).getValue(), MarcBibUpdate.class);
+
+    recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(getNew -> {
+      if (getNew.failed()) {
+        context.fail(getNew.cause());
+      }
+      context.assertTrue(getNew.result().isPresent());
+      var updatedRecord = getNew.result().get();
+
+      assertNewDatabaseRecord(context, updatedRecord, parsedRecord, updatedParsedRecordContent);
+      assertOutgoingEvent(context, event, actualOutgoingEvent, updatedRecord, updateTargets);
+
+      recordDao.getRecordById(record.getId(), TENANT_ID)
+        .onComplete(assertOldDatabaseRecord(context, async, parsedRecord));
+    });
+  }
+
+  @Test
+  public void shouldUpdateMultipleRecordsAndSendMultipleRecordUpdatedEvents(TestContext context)
+    throws InterruptedException {
+    var updateTargets = buildUpdateTargets(instanceId, UUID.randomUUID().toString(), SECOND_INSTANCE_ID);
+    var event = buildLinkEventForUpdate(updateTargets);
+
+    var traceHeader = UUID.randomUUID().toString();
+    cluster.send(createRequest(event, traceHeader));
+    var values = readValuesFromKafka(traceHeader, 2);
+    context.assertEquals(2, values.size());
+
+    var eventsInstanceIds = values.stream()
+      .map(value -> {
+        try {
+          return objectMapper.readValue(value, MarcBibUpdate.class).getRecord().getExternalIdsHolder().getInstanceId();
+        } catch (IOException e) {
+          return null;
+        }})
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+
+    context.assertTrue(List.of(instanceId, SECOND_INSTANCE_ID).containsAll(eventsInstanceIds));
+  }
+
+  /**
+   * Only $9 subfield should be removed and only in case it matches authorityId from event
+   * */
+  @Test
+  public void shouldUpdateBibRecordForDeleteEventAndSendRecordUpdatedEvent(TestContext context)
+    throws InterruptedException, IOException {
+    var async = context.async();
+
+    var parsedRecord = record.getParsedRecord();
+    var updateTargets = buildUpdateTargets();
+    var event = buildLinkEvent(updateTargets, BibAuthorityLinksUpdate.Type.DELETE);
+
+    var traceHeader = UUID.randomUUID().toString();
+    cluster.send(createRequest(event, traceHeader));
+    var values = readValuesFromKafka(traceHeader, 1);
+    context.assertEquals(1, values.size());
+    var actualOutgoingEvent = objectMapper.readValue(values.get(0), MarcBibUpdate.class);
+
+    recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(getNew -> {
+      if (getNew.failed()) {
+        context.fail(getNew.cause());
+      }
+      context.assertTrue(getNew.result().isPresent());
+      var updatedRecord = getNew.result().get();
+
+      assertNewDatabaseRecord(context, updatedRecord, parsedRecord, unlinkedParsedRecordContent);
+      assertOutgoingEvent(context, event, actualOutgoingEvent, updatedRecord, updateTargets);
+
+      recordDao.getRecordById(record.getId(), TENANT_ID)
+        .onComplete(assertOldDatabaseRecord(context, async, parsedRecord));
+    });
+  }
+
+  private SendKeyValues<String, String> createRequest(Object payload, String traceValue) {
+    var eventRecord = new KeyValue<>(KAFKA_KEY_NAME, Json.encode(payload));
+    OKAPI_HEADERS.forEach((key, value) -> {
+      eventRecord.addHeader(key, value, Charset.defaultCharset());
+      eventRecord.addHeader(key, value, Charset.defaultCharset());
+      eventRecord.addHeader(key, value, Charset.defaultCharset());
+    });
+    eventRecord.addHeader(KAFKA_TEST_HEADER, traceValue, Charset.defaultCharset());
+    return SendKeyValues.to(KAFKA_CONSUMER_TOPIC, singletonList(eventRecord)).useDefaults();
+  }
+
+  private static String getTopicName(String name) {
+    return formatTopicName(kafkaConfig.getEnvId(), getDefaultNameSpace(), TENANT_ID, name);
+  }
+
+  private List<String> readValuesFromKafka(String traceHeader, int limit) throws InterruptedException {
+    return cluster.readValues(ReadKeyValues.from(KAFKA_PRODUCER_TOPIC)
+      .withMaxTotalPollTime(60, TimeUnit.SECONDS)
+      .filterOnHeaders(headers -> Arrays.equals(headers.lastHeader(KAFKA_TEST_HEADER).value(),
+        traceHeader.getBytes(StandardCharsets.UTF_8)))
+      .withLimit(limit)
+      .build());
+  }
+
+  private int getLinksCount(List<UpdateTarget> updateTargets) {
+    return (int) updateTargets.stream()
+      .flatMap(updateTarget -> updateTarget.getLinks().stream())
+      .filter(link -> link.getInstanceId().equals(instanceId))
+      .count();
+  }
+
+  private List<Link> buildLinks(String... instanceIds) {
+    return Stream.of(instanceIds)
+      .map(instanceId -> new Link()
+        .withInstanceId(instanceId)
+        .withLinkId(LINK_ID))
+      .collect(Collectors.toList());
+  }
+
+  private BibAuthorityLinksUpdate buildLinkEvent(List<UpdateTarget> updateTargets, BibAuthorityLinksUpdate.Type type) {
+
+    var subfieldChanges = List.of(
+      new SubfieldsChange().withField("020")//repeatable, should update only one | $9 should be removed on DELETE
+        .withSubfields(singletonList(new Subfield().withCode("a").withValue("2940447241 (electronic bk. updated)"))),
+      new SubfieldsChange().withField("245")//should update/add subfields | $9 should be removed on DELETE
+        .withSubfields(List.of(
+          new Subfield().withCode("a").withValue("The fundamentals of typography updated"),//update
+          new Subfield().withCode("b").withValue("new subfield"),//add new
+          new Subfield().withCode("h").withValue("[electronic resource] / updated"))),//update
+      new SubfieldsChange().withField("100")//controlled by different authority, should remain as is
+        .withSubfields(singletonList(new Subfield().withCode("a").withValue("Ambrose, Gavin. updated"))),
+      new SubfieldsChange().withField("123")//doesn't exist, should be ignored
+        .withSubfields(singletonList(new Subfield().withCode("a").withValue("absent")))
+    );
+
+    return new BibAuthorityLinksUpdate()
+      .withJobId(authorityJobId)
+      .withAuthorityId(LINKED_AUTHORITY_ID)
+      .withTenant(TENANT_ID)
+      .withTs("123")
+      .withType(type)
+      .withUpdateTargets(updateTargets)
+      .withSubfieldsChanges(subfieldChanges);
+  }
+
+  private List<UpdateTarget> buildUpdateTargets() {
+    return buildUpdateTargets(instanceId, UUID.randomUUID().toString());
+  }
+
+  private List<UpdateTarget> buildUpdateTargets(String... instanceIds) {
+    return List.of(
+      new UpdateTarget().withField("020").withLinks(buildLinks(instanceIds)),
+      new UpdateTarget().withField("245").withLinks(buildLinks(instanceIds)),
+      new UpdateTarget().withField("100").withLinks(buildLinks(instanceIds)),
+      new UpdateTarget().withField("222").withLinks(buildLinks(UUID.randomUUID().toString())),
+      new UpdateTarget().withField("123").withLinks(buildLinks(instanceIds)));
+  }
+
+  private BibAuthorityLinksUpdate buildLinkEventForUpdate(List<UpdateTarget> updateTargets) {
+    return buildLinkEvent(updateTargets, BibAuthorityLinksUpdate.Type.UPDATE);
+  }
+
+  private void assertOutgoingEvent(TestContext context, BibAuthorityLinksUpdate event, MarcBibUpdate actualOutgoingEvent,
+                                   Record updatedRecord, List<UpdateTarget> updateTargets) {
+    context.assertEquals(event.getJobId(), actualOutgoingEvent.getJobId());
+    context.assertEquals(getLinksCount(updateTargets), actualOutgoingEvent.getLinkIds().size());
+    context.assertEquals(LINK_ID, actualOutgoingEvent.getLinkIds().get(0));
+    context.assertEquals(event.getTenant(), actualOutgoingEvent.getTenant());
+    context.assertEquals(event.getTs(), actualOutgoingEvent.getTs());
+    context.assertEquals(MarcBibUpdate.Type.UPDATE, actualOutgoingEvent.getType());
+    context.assertEquals(updatedRecord.getId(), actualOutgoingEvent.getRecord().getId());
+  }
+
+  private Handler<AsyncResult<Optional<Record>>> assertOldDatabaseRecord(TestContext context, Async async,
+                                                                         ParsedRecord parsedRecord) {
+    return getOldFuture -> {
+      if (getOldFuture.failed()) {
+        context.fail(getOldFuture.cause());
+      }
+
+      context.assertTrue(getOldFuture.result().isPresent());
+      var existingRecord = getOldFuture.result().get();
+
+      context.assertEquals(State.OLD, existingRecord.getState());
+      context.assertEquals(0, existingRecord.getGeneration());
+      context.assertEquals(parsedRecord.getId(), existingRecord.getParsedRecord().getId());
+      context.assertEquals(parsedRecord.getContent(), existingRecord.getParsedRecord().getContent());
+      context.assertEquals(record.getSnapshotId(), existingRecord.getSnapshotId());
+
+      async.complete();
+    };
+  }
+
+  private void assertNewDatabaseRecord(TestContext context, Record updatedRecord,
+                                       ParsedRecord parsedRecord, String expectedParsedRecordContent) {
+    context.assertNotEquals(parsedRecord.getId(), updatedRecord.getParsedRecord().getId());
+    context.assertNotEquals(record.getSnapshotId(), updatedRecord.getSnapshotId());
+    context.assertEquals(record.getGeneration() + 1, updatedRecord.getGeneration());
+    context.assertEquals(expectedParsedRecordContent,
+      ParsedRecordDaoUtil.normalize(updatedRecord.getParsedRecord().getContent()).toString());
+  }
+}

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinked.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinked.json
@@ -1,0 +1,117 @@
+{
+  "leader": "01314nam  22003851a 4500",
+  "fields": [
+    {
+      "001": "ybp7406411"
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk.)"
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "9782940447244 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "040": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "NhCcYBP"
+          },
+          {
+            "c": "NhCcYBP"
+          }
+        ]
+      }
+    },
+    {
+      "050": {
+        "ind1": " ",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "Z246"
+          },
+          {
+            "b": ".A43 2011"
+          }
+        ]
+      }
+    },
+    {
+      "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Ambrose, Gavin."
+          },
+          {
+            "9": "40e95923-9e8c-48dd-8081-761ed1a57292"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography"
+          },
+          {
+            "h": "[electronic resource] /"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "500": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Previous ed.: 2006."
+          }
+        ]
+      }
+    },
+    {
+      "504": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Includes bibliographical references (p. [200]) and index."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
@@ -1,0 +1,120 @@
+{
+  "fields": [
+    {
+      "001": "ybp7406411"
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk. updated)"
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "9782940447244 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "040": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "NhCcYBP"
+          },
+          {
+            "c": "NhCcYBP"
+          }
+        ]
+      }
+    },
+    {
+      "050": {
+        "ind1": " ",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "Z246"
+          },
+          {
+            "b": ".A43 2011"
+          }
+        ]
+      }
+    },
+    {
+      "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Ambrose, Gavin."
+          },
+          {
+            "9": "40e95923-9e8c-48dd-8081-761ed1a57292"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography updated"
+          },
+          {
+            "b": "new subfield"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          },
+          {
+            "h": "[electronic resource] / updated"
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "500": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Previous ed.: 2006."
+          }
+        ]
+      }
+    },
+    {
+      "504": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Includes bibliographical references (p. [200]) and index."
+          }
+        ]
+      }
+    }
+  ],
+  "leader": "01314nam  22003851a 4500"
+}

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
@@ -85,9 +85,6 @@
             "c": "Gavin Ambrose, Paul Harris."
           },
           {
-            "h": "[electronic resource] / updated"
-          },
-          {
             "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
           }
         ]

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
@@ -9,20 +9,6 @@
         "ind2": " ",
         "subfields": [
           {
-            "a": "2940447241 (electronic bk. updated)"
-          },
-          {
-            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
-          }
-        ]
-      }
-    },
-    {
-      "020": {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [
-          {
             "a": "9782940447244 (electronic bk.)"
           }
         ]
@@ -71,26 +57,6 @@
       }
     },
     {
-      "245": {
-        "ind1": "1",
-        "ind2": "4",
-        "subfields": [
-          {
-            "a": "The fundamentals of typography updated"
-          },
-          {
-            "b": "new subfield"
-          },
-          {
-            "c": "Gavin Ambrose, Paul Harris."
-          },
-          {
-            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
-          }
-        ]
-      }
-    },
-    {
       "500": {
         "ind1": " ",
         "ind2": " ",
@@ -111,7 +77,41 @@
           }
         ]
       }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk. updated)"
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography updated"
+          },
+          {
+            "b": "new subfield"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
     }
   ],
-  "leader": "01314nam  22003851a 4500"
+  "leader": "00567nam  22001331a 4500"
 }

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
@@ -9,17 +9,6 @@
         "ind2": " ",
         "subfields": [
           {
-            "a": "2940447241 (electronic bk.)"
-          }
-        ]
-      }
-    },
-    {
-      "020": {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [
-          {
             "a": "9782940447244 (electronic bk.)"
           }
         ]
@@ -68,23 +57,6 @@
       }
     },
     {
-      "245": {
-        "ind1": "1",
-        "ind2": "4",
-        "subfields": [
-          {
-            "a": "The fundamentals of typography"
-          },
-          {
-            "h": "[electronic resource] /"
-          },
-          {
-            "c": "Gavin Ambrose, Paul Harris."
-          }
-        ]
-      }
-    },
-    {
       "500": {
         "ind1": " ",
         "ind2": " ",
@@ -105,7 +77,35 @@
           }
         ]
       }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography"
+          },
+          {
+            "h": "[electronic resource] /"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          }
+        ]
+      }
     }
   ],
-  "leader": "01314nam  22003851a 4500"
+  "leader": "00486nam  22001331a 4500"
 }

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
@@ -1,0 +1,111 @@
+{
+  "fields": [
+    {
+      "001": "ybp7406411"
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "2940447241 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "9782940447244 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "040": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "NhCcYBP"
+          },
+          {
+            "c": "NhCcYBP"
+          }
+        ]
+      }
+    },
+    {
+      "050": {
+        "ind1": " ",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "Z246"
+          },
+          {
+            "b": ".A43 2011"
+          }
+        ]
+      }
+    },
+    {
+      "100": {
+        "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Ambrose, Gavin."
+          },
+          {
+            "9": "40e95923-9e8c-48dd-8081-761ed1a57292"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography"
+          },
+          {
+            "h": "[electronic resource] /"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          }
+        ]
+      }
+    },
+    {
+      "500": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Previous ed.: 2006."
+          }
+        ]
+      }
+    },
+    {
+      "504": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "a": "Includes bibliographical references (p. [200]) and index."
+          }
+        ]
+      }
+    }
+  ],
+  "leader": "01314nam  22003851a 4500"
+}

--- a/ramls/source-record-storage-records.raml
+++ b/ramls/source-record-storage-records.raml
@@ -24,6 +24,8 @@ types:
   marcData: !include raml-storage/schemas/mod-data-import-converter-storage/mapping-profile-detail/marcData.json
   errors: !include raml-storage/raml-util/schemas/errors.schema
   mappingMetadataDto: !include raml-storage/schemas/dto/mappingMetadataDto.json
+  bibAuthorityLinksUpdate: !include raml-storage/schemas/mod-entities-links/bibAuthorityLinksUpdate.json
+  marcBibUpdate: !include raml-storage/schemas/mod-source-record-storage/marcBibUpdate.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml


### PR DESCRIPTION
## Purpose
When the authority record in mod-inventory-storage is updated - mod-entities-links triggers an update of linked MARC Bib and Instance records. For this purpose, the module has to subscribe to an event generated by mod-entities-links, then update MARC bib records and publish the event to make corresponding changes to related instance records in mod-inventory-storage

## Approach
- Subscribe to `links.instance-authority`
- Update MARC bib records based on consumed
- Publish events to `srs.marc-bib` topic

## Learning
[MODSOURCE-550](https://issues.folio.org/browse/MODSOURCE-550)
