### PR TITLE
MODSOURCE-573 Linked bib update failes because of snapshot absence

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -18,6 +18,7 @@ import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,11 +38,14 @@ import org.folio.kafka.KafkaConfig;
 import org.folio.rest.jaxrs.model.BibAuthorityLinksUpdate;
 import org.folio.rest.jaxrs.model.Link;
 import org.folio.rest.jaxrs.model.MarcBibUpdate;
+import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.rest.jaxrs.model.RecordsBatchResponse;
+import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SubfieldsChange;
 import org.folio.rest.jaxrs.model.UpdateTarget;
 import org.folio.services.RecordService;
+import org.folio.services.SnapshotService;
 import org.marc4j.marc.Subfield;
 import org.marc4j.marc.impl.DataFieldImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
@@ -59,14 +63,17 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
 
   private final RecordService recordService;
   private final KafkaConfig kafkaConfig;
+  private final SnapshotService snapshotService;
   private final KafkaProducer<String, String> producer;
 
   @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
 
-  public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig) {
+  public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig,
+                                        SnapshotService snapshotService) {
     this.recordService = recordService;
     this.kafkaConfig = kafkaConfig;
+    this.snapshotService = snapshotService;
 
     producer = createProducer(SRS_BIB_UPDATE_TOPIC, kafkaConfig);
   }
@@ -74,6 +81,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   @Override
   public Future<String> handle(KafkaConsumerRecord<String, String> consumerRecord) {
     return mapToEvent(consumerRecord)
+      .compose(this::createSnapshot)
       .compose(event -> retrieveRecords(event, event.getTenant())
         .compose(recordCollection -> mapRecordFieldsChanges(event, recordCollection))
         .compose(recordCollection -> recordService.saveRecords(recordCollection, event.getTenant()))
@@ -236,6 +244,20 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
           .withRecord(bibRecord);
       })
       .collect(Collectors.toList());
+  }
+
+  private Future<BibAuthorityLinksUpdate> createSnapshot(BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+    var now = new Date();
+    var snapshot = new Snapshot()
+      .withJobExecutionId(bibAuthorityLinksUpdate.getJobId())
+      .withStatus(Snapshot.Status.COMMITTED)
+      .withProcessingStartedDate(now)
+      .withMetadata(new Metadata()
+        .withCreatedDate(now)
+        .withUpdatedDate(now));
+
+    return snapshotService.saveSnapshot(snapshot, bibAuthorityLinksUpdate.getTenant())
+      .map(result -> bibAuthorityLinksUpdate);
   }
 
   private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents, BibAuthorityLinksUpdate event,

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -79,7 +79,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   private static String updatedParsedRecordContent;
   private static String unlinkedParsedRecordContent;
 
-  private final String authorityJobId = UUID.randomUUID().toString();
+  private final String linkedBibUpdateJobId = UUID.randomUUID().toString();
   private final String recordId = UUID.randomUUID().toString();
   private final String instanceId = UUID.randomUUID().toString();
   private final RawRecord rawRecord = new RawRecord().withId(recordId)
@@ -118,10 +118,6 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
       .withParsedRecord(parsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
 
-    var authoritySnapshot = new Snapshot()
-      .withJobExecutionId(authorityJobId)
-      .withProcessingStartedDate(new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)))
-      .withStatus(Snapshot.Status.COMMITTED);
     var secondParsedRecord = new ParsedRecord().withId(SECOND_RECORD_ID)
       .withContent(new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode());
     secondRecord = new Record()
@@ -136,8 +132,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
 
     SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)
       .compose(savedSnapshot -> recordService.saveRecord(record, TENANT_ID))
-      .compose(savedRecord -> SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), authoritySnapshot))
-      .compose(savedSnapshot -> recordService.saveRecord(secondRecord, TENANT_ID))
+      .compose(savedRecord -> recordService.saveRecord(secondRecord, TENANT_ID))
       .onSuccess(ar -> async.complete())
       .onFailure(context::fail);
   }
@@ -304,7 +299,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
     );
 
     return new BibAuthorityLinksUpdate()
-      .withJobId(authorityJobId)
+      .withJobId(linkedBibUpdateJobId)
       .withAuthorityId(LINKED_AUTHORITY_ID)
       .withTenant(TENANT_ID)
       .withTs("123")


### PR DESCRIPTION
## Purpose
JobId passed in event is generated by mod-entities-links so there's no actual DI job nor srs Snapshot associated with this id and srs needs to create a snapshot for linked bib updates by itself.

## Approach
- create snapshot for linked bib updates before event processing

## Learning
[MODSOURCE-573](https://issues.folio.org/browse/MODSOURCE-573)
