### PR TITLE
MODSOURCE-578 MARC bib field moved to the end of the fields lists after user updates controlling MARC authority record

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -161,8 +161,10 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
           var newField = new DataFieldImpl(field.getTag(), field.getIndicator1(), field.getIndicator2());
           newSubfields.forEach(newField::addSubfield);
 
-          parsedRecordContent.removeVariableField(field);
-          parsedRecordContent.addVariableField(newField);
+          var dataFields = parsedRecordContent.getDataFields();
+          var fieldPosition = dataFields.indexOf(field);
+          dataFields.remove(fieldPosition);
+          dataFields.add(fieldPosition, newField);
         });
 
         parsedRecord.setContent(mapObjectRepresentationToParsedContentJsonString(parsedRecordContent));

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordLinkedUpdated.json
@@ -9,6 +9,20 @@
         "ind2": " ",
         "subfields": [
           {
+            "a": "2940447241 (electronic bk. updated)"
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
             "a": "9782940447244 (electronic bk.)"
           }
         ]
@@ -57,6 +71,26 @@
       }
     },
     {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography updated"
+          },
+          {
+            "b": "new subfield"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          },
+          {
+            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
+          }
+        ]
+      }
+    },
+    {
       "500": {
         "ind1": " ",
         "ind2": " ",
@@ -74,40 +108,6 @@
         "subfields": [
           {
             "a": "Includes bibliographical references (p. [200]) and index."
-          }
-        ]
-      }
-    },
-    {
-      "020": {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [
-          {
-            "a": "2940447241 (electronic bk. updated)"
-          },
-          {
-            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
-          }
-        ]
-      }
-    },
-    {
-      "245": {
-        "ind1": "1",
-        "ind2": "4",
-        "subfields": [
-          {
-            "a": "The fundamentals of typography updated"
-          },
-          {
-            "b": "new subfield"
-          },
-          {
-            "c": "Gavin Ambrose, Paul Harris."
-          },
-          {
-            "9": "6d19a8e8-2b71-482e-bfda-2b97f8722a2f"
           }
         ]
       }

--- a/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
+++ b/mod-source-record-storage-server/src/test/resources/parsedMarcRecordUnlinked.json
@@ -9,6 +9,17 @@
         "ind2": " ",
         "subfields": [
           {
+            "a": "2940447241 (electronic bk.)"
+          }
+        ]
+      }
+    },
+    {
+      "020": {
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
             "a": "9782940447244 (electronic bk.)"
           }
         ]
@@ -57,6 +68,23 @@
       }
     },
     {
+      "245": {
+        "ind1": "1",
+        "ind2": "4",
+        "subfields": [
+          {
+            "a": "The fundamentals of typography"
+          },
+          {
+            "h": "[electronic resource] /"
+          },
+          {
+            "c": "Gavin Ambrose, Paul Harris."
+          }
+        ]
+      }
+    },
+    {
       "500": {
         "ind1": " ",
         "ind2": " ",
@@ -74,34 +102,6 @@
         "subfields": [
           {
             "a": "Includes bibliographical references (p. [200]) and index."
-          }
-        ]
-      }
-    },
-    {
-      "020": {
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [
-          {
-            "a": "2940447241 (electronic bk.)"
-          }
-        ]
-      }
-    },
-    {
-      "245": {
-        "ind1": "1",
-        "ind2": "4",
-        "subfields": [
-          {
-            "a": "The fundamentals of typography"
-          },
-          {
-            "h": "[electronic resource] /"
-          },
-          {
-            "c": "Gavin Ambrose, Paul Harris."
           }
         ]
       }


### PR DESCRIPTION
## Purpose
Updated fields should remain on the same position

## Approach
- remove/add field directly by index

## Learning
[MODSOURCE-578](https://issues.folio.org/browse/MODSOURCE-578)
