### PR TITLE
MODSOURCE-567 Link update report: send event if update failed

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/EntityLinksKafkaTopic.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/EntityLinksKafkaTopic.java
@@ -1,19 +1,21 @@
 package org.folio;
 
+
 import org.folio.kafka.services.KafkaTopic;
 
-public enum RecordStorageKafkaTopic implements KafkaTopic {
-  MARC_BIB("marc-bib");
+public enum EntityLinksKafkaTopic implements KafkaTopic {
+  LINKS_STATS("instance-authority-stats"),
+  INSTANCE_AUTHORITY("instance-authority");
 
   private final String topic;
 
-  RecordStorageKafkaTopic(String topic) {
+  EntityLinksKafkaTopic(String topic) {
     this.topic = topic;
   }
 
   @Override
   public String moduleName() {
-    return "srs";
+    return "links";
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/EntityLinksKafkaTopic.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/EntityLinksKafkaTopic.java
@@ -22,8 +22,4 @@ public enum EntityLinksKafkaTopic implements KafkaTopic {
   public String topicName() {
     return topic;
   }
-
-  public String moduleTopicName() {
-    return moduleName() + '.' + topicName();
-  }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/RecordStorageKafkaTopic.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/RecordStorageKafkaTopic.java
@@ -20,8 +20,4 @@ public enum RecordStorageKafkaTopic implements KafkaTopic {
   public String topicName() {
     return topic;
   }
-
-  public String moduleTopicName() {
-    return moduleName() + '.' + topicName();
-  }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -55,7 +55,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String, String> {
 
-  public static final String SRS_BIB_UPDATE_TOPIC = MARC_BIB.moduleName() + "." + MARC_BIB.topicName();
+  public static final String SRS_BIB_UPDATE_TOPIC = MARC_BIB.moduleTopicName();
 
   private static final char AUTHORITY_ID_SUBFIELD = '9';
   private static final AtomicLong INDEXER = new AtomicLong();
@@ -222,6 +222,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
           + " Total number of records: {}, successful: {}, failures: {}",
         event.getJobId(), event.getAuthorityId(),
         batchResponse.getTotalRecords(), batchResponse.getRecords().size(), errors);
+      // send report
     }
 
     return toMarcBibUpdateEvents(batchResponse, event);

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -4,11 +4,13 @@ import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.EntityLinksKafkaTopic.LINKS_STATS;
 import static org.folio.RecordStorageKafkaTopic.MARC_BIB;
 import static org.folio.consumers.RecordMappingUtils.mapObjectRepresentationToParsedContentJsonString;
 import static org.folio.consumers.RecordMappingUtils.readParsedContentToObjectRepresentation;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.FAIL;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
 import static org.folio.services.util.EventHandlingUtil.createProducer;
-import static org.folio.services.util.EventHandlingUtil.createTopicNameNoNamespace;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -17,17 +19,6 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.util.IdType;
@@ -35,8 +26,10 @@ import org.folio.dao.util.RecordDaoUtil;
 import org.folio.dao.util.RecordType;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.services.KafkaTopic;
 import org.folio.rest.jaxrs.model.BibAuthorityLinksUpdate;
 import org.folio.rest.jaxrs.model.Link;
+import org.folio.rest.jaxrs.model.LinkUpdateReport;
 import org.folio.rest.jaxrs.model.MarcBibUpdate;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.RecordCollection;
@@ -52,19 +45,30 @@ import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
 @Component
 public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String, String> {
 
   public static final String SRS_BIB_UPDATE_TOPIC = MARC_BIB.moduleTopicName();
-
+  public static final String LINKS_STATS_TOPIC = LINKS_STATS.moduleTopicName();
   private static final char AUTHORITY_ID_SUBFIELD = '9';
   private static final AtomicLong INDEXER = new AtomicLong();
   private static final Logger LOGGER = LogManager.getLogger();
-
+  private final Map<KafkaTopic, KafkaProducer<String, String>> producers = new HashMap<>();
   private final RecordService recordService;
-  private final KafkaConfig kafkaConfig;
   private final SnapshotService snapshotService;
-  private final KafkaProducer<String, String> producer;
 
   @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
@@ -72,10 +76,10 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig,
                                         SnapshotService snapshotService) {
     this.recordService = recordService;
-    this.kafkaConfig = kafkaConfig;
     this.snapshotService = snapshotService;
 
-    producer = createProducer(SRS_BIB_UPDATE_TOPIC, kafkaConfig);
+    producers.put(MARC_BIB, createProducer(SRS_BIB_UPDATE_TOPIC, kafkaConfig));
+    producers.put(LINKS_STATS, createProducer(LINKS_STATS_TOPIC, kafkaConfig));
   }
 
   @Override
@@ -85,6 +89,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .compose(event -> retrieveRecords(event, event.getTenant())
         .compose(recordCollection -> mapRecordFieldsChanges(event, recordCollection))
         .compose(recordCollection -> recordService.saveRecords(recordCollection, event.getTenant()))
+        .map(recordsBatchResponse -> sendReports(recordsBatchResponse, event, consumerRecord.headers()))
         .map(recordsBatchResponse -> mapRecordsToBibUpdateEvents(recordsBatchResponse, event))
         .compose(marcBibUpdates -> sendEvents(marcBibUpdates, event, consumerRecord))
       ).recover(th -> {
@@ -222,7 +227,6 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
           + " Total number of records: {}, successful: {}, failures: {}",
         event.getJobId(), event.getAuthorityId(),
         batchResponse.getTotalRecords(), batchResponse.getRecords().size(), errors);
-      // send report
     }
 
     return toMarcBibUpdateEvents(batchResponse, event);
@@ -247,6 +251,33 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .collect(Collectors.toList());
   }
 
+  private List<LinkUpdateReport> toLinkUpdateReport(RecordsBatchResponse batchResponse,
+                                                    BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+    var instanceIdToLinkIds = bibAuthorityLinksUpdate.getUpdateTargets().stream()
+      .flatMap(updateTarget -> updateTarget.getLinks().stream())
+      .collect(Collectors.groupingBy(Link::getInstanceId, Collectors.mapping(Link::getLinkId, Collectors.toList())));
+    return batchResponse.getRecords().stream()
+      .map(bibRecord -> {
+        var instanceId = bibRecord.getExternalIdsHolder().getInstanceId();
+        var errorRecord = bibRecord.getErrorRecord();
+        var report = new LinkUpdateReport()
+          .withInstanceId(instanceId)
+          .withJobId(bibAuthorityLinksUpdate.getJobId())
+          .withLinkIds(instanceIdToLinkIds.get(instanceId))
+          .withTenant(bibAuthorityLinksUpdate.getTenant())
+          .withTs(bibAuthorityLinksUpdate.getTs());
+
+        if (errorRecord == null) {
+          report.setStatus(SUCCESS);
+        } else {
+          report.setStatus(FAIL);
+          report.setFailCause(errorRecord.getDescription());
+        }
+        return report;
+      })
+      .collect(Collectors.toList());
+  }
+
   private Future<BibAuthorityLinksUpdate> createSnapshot(BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
     var now = new Date();
     var snapshot = new Snapshot()
@@ -261,16 +292,25 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .map(result -> bibAuthorityLinksUpdate);
   }
 
+  private RecordsBatchResponse sendReports(RecordsBatchResponse batchResponse, BibAuthorityLinksUpdate event, List<KafkaHeader> headers) {
+    LOGGER.info("Sending {} linking reports for jobId {}, authorityId {}",
+      batchResponse.getRecords().size(), event.getJobId(), event.getAuthorityId());
+
+    toLinkUpdateReport(batchResponse, event).forEach(report ->
+      sendEventToKafka(LINKS_STATS, report.getTenant(), report.getJobId(), report, headers));
+
+    return batchResponse;
+  }
+
   private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents, BibAuthorityLinksUpdate event,
                                     KafkaConsumerRecord<String, String> consumerRecord) {
     LOGGER.info("Sending {} bib update events for jobId {}, authorityId {}",
       marcBibUpdateEvents.size(), event.getJobId(), event.getAuthorityId());
+
     return Future.fromCompletionStage(
       CompletableFuture.allOf(
         marcBibUpdateEvents.stream()
-          .map(marcBibUpdate -> sendEventToKafka(marcBibUpdate, consumerRecord.headers())
-            .onFailure(th -> LOGGER.error("Failed to send {} event for jobId {}.",
-              SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getJobId(), th)))
+          .map(marcBibUpdate -> sendEventToKafka(MARC_BIB, marcBibUpdate.getTenant(), marcBibUpdate.getJobId(), marcBibUpdate, consumerRecord.headers()))
           .map(Future::toCompletionStage)
           .map(CompletionStage::toCompletableFuture)
           .toArray(CompletableFuture[]::new)
@@ -278,32 +318,32 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     ).map(unused -> consumerRecord.key());
   }
 
-  private Future<Boolean> sendEventToKafka(MarcBibUpdate marcBibUpdate, List<KafkaHeader> kafkaHeaders) {
+  private Future<Boolean> sendEventToKafka(KafkaTopic topic, String tenant, String jobId, Object record, List<KafkaHeader> kafkaHeaders) {
     var promise = Promise.<Boolean>promise();
     try {
-      var kafkaRecord = createKafkaProducerRecord(marcBibUpdate, kafkaHeaders);
-      producer.write(kafkaRecord, war -> {
-        if (war.succeeded()) {
-          LOGGER.debug("Event with type {}, jobId {} was sent to kafka", SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getJobId());
+      var kafkaRecord = createKafkaProducerRecord(topic, tenant, record, kafkaHeaders);
+      producers.get(topic).write(kafkaRecord, ar -> {
+        if (ar.succeeded()) {
+          LOGGER.debug("Event with type {}, jobId {} was sent to kafka", topic.topicName(), jobId);
           promise.complete(true);
         } else {
-          var cause = war.cause();
-          LOGGER.error("Failed to sent event {} for jobId {}, cause: {}", SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getJobId(), cause);
+          var cause = ar.cause();
+          LOGGER.error("Failed to sent event {} for jobId {}, cause: {}", topic.topicName(), jobId, cause);
           promise.fail(cause);
         }
       });
     } catch (Exception e) {
-      LOGGER.error("Failed to send an event for eventType {}, jobId {}, cause {}", SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getJobId(), e);
+      LOGGER.error("Failed to send an event for eventType {}, jobId {}, cause {}", topic.topicName(), jobId, e);
       return Future.failedFuture(e);
     }
-    return promise.future();
+    return promise.future().onFailure(th -> LOGGER.error("Failed to send {} event for jobId {}.", topic.topicName(), jobId, th));
   }
 
-  private KafkaProducerRecord<String, String> createKafkaProducerRecord(MarcBibUpdate marcBibUpdate,
+  private KafkaProducerRecord<String, String> createKafkaProducerRecord(KafkaTopic topic, String tenant, Object record,
                                                                         List<KafkaHeader> kafkaHeaders) {
-    var topicName = createTopicNameNoNamespace(SRS_BIB_UPDATE_TOPIC, marcBibUpdate.getTenant(), kafkaConfig);
+    var topicName = topic.fullTopicName(tenant);
     var key = String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum);
-    var kafkaRecord = KafkaProducerRecord.create(topicName, key,Json.encode(marcBibUpdate));
+    var kafkaRecord = KafkaProducerRecord.create(topicName, key, Json.encode(record));
     kafkaRecord.addHeaders(kafkaHeaders);
 
     return kafkaRecord;

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.FAIL;
 import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
 import static org.folio.services.util.EventHandlingUtil.createProducer;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
@@ -19,6 +20,18 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.util.IdType;
@@ -44,19 +57,6 @@ import org.marc4j.marc.impl.DataFieldImpl;
 import org.marc4j.marc.impl.SubfieldImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 @Component
 public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String, String> {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -95,10 +95,6 @@ public final class EventHandlingUtil {
       tenantId, eventType);
   }
 
-  public static String createTopicNameNoNamespace(String eventType, String tenantId, KafkaConfig kafkaConfig) {
-    return String.join(".", kafkaConfig.getEnvId(), tenantId, eventType);
-  }
-
   public static String createSubscriptionPattern(String env, String eventType) {
     return String.join("\\.", env, "\\w{1,}", eventType);
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
@@ -1,5 +1,6 @@
 package org.folio.verticle.consumers;
 
+import static org.folio.EntityLinksKafkaTopic.INSTANCE_AUTHORITY;
 import static org.folio.services.util.EventHandlingUtil.constructModuleName;
 import static org.folio.services.util.EventHandlingUtil.createSubscriptionPattern;
 
@@ -19,7 +20,7 @@ public class AuthorityLinkChunkConsumersVerticle extends AbstractVerticle {
   private static AbstractApplicationContext springGlobalContext;
 
   private static final GlobalLoadSensor globalLoadSensor = new GlobalLoadSensor();
-  public static final String AUTHORITY_INSTANCE_LINKS_TOPIC = "links.instance-authority";
+  public static final String AUTHORITY_INSTANCE_LINKS_TOPIC = INSTANCE_AUTHORITY.moduleTopicName();
 
   @Autowired
   private AuthorityLinkChunkKafkaHandler kafkaHandler;

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -66,10 +66,6 @@ public abstract class AbstractLBServiceTest {
     cluster = provisionWith(defaultClusterConfig());
     cluster.start();
     String[] hostAndPort = cluster.getBrokerList().split(":");
-    //Property variables
-    System.setProperty("kafka-host", hostAndPort[0]);
-    System.setProperty("kafka-port", hostAndPort[1]);
-    System.setProperty("env", KAFKA_ENV_ID);
     //Env variables
     System.setProperty(KAFKA_HOST, hostAndPort[0]);
     System.setProperty(KAFKA_PORT, hostAndPort[1]);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -69,6 +69,7 @@ public abstract class AbstractLBServiceTest {
     //Property variables
     System.setProperty("kafka-host", hostAndPort[0]);
     System.setProperty("kafka-port", hostAndPort[1]);
+    System.setProperty("env", KAFKA_ENV_ID);
     //Env variables
     System.setProperty(KAFKA_HOST, hostAndPort[0]);
     System.setProperty(KAFKA_PORT, hostAndPort[1]);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -1,11 +1,5 @@
 package org.folio.services;
 
-import static java.util.Collections.singletonList;
-import static org.folio.EntityLinksKafkaTopic.INSTANCE_AUTHORITY;
-import static org.folio.EntityLinksKafkaTopic.LINKS_STATS;
-import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
-import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
@@ -13,19 +7,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ReadKeyValues;
 import net.mguenther.kafka.junit.SendKeyValues;
@@ -37,6 +18,7 @@ import org.folio.dao.util.ParsedRecordDaoUtil;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.kafka.services.KafkaTopic;
 import org.folio.rest.jaxrs.model.BibAuthorityLinksUpdate;
+import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.Link;
 import org.folio.rest.jaxrs.model.LinkUpdateReport;
@@ -57,6 +39,27 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.folio.EntityLinksKafkaTopic.INSTANCE_AUTHORITY;
+import static org.folio.EntityLinksKafkaTopic.LINKS_STATS;
+import static org.folio.RecordStorageKafkaTopic.MARC_BIB;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.FAIL;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
+
 @RunWith(VertxUnitRunner.class)
 public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
 
@@ -69,29 +72,30 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   private static final String KAFKA_KAFKA_SRS_BIB_PRODUCER_TOPIC = getTopicName(MARC_BIB);
   private static final String KAFKA_LINK_STATS_PRODUCER_TOPIC = getTopicName(LINKS_STATS);
   private static final String LINKED_AUTHORITY_ID = "6d19a8e8-2b71-482e-bfda-2b97f8722a2f";
+  private static final String LINKED_BIB_UPDATE_JOB_ID = UUID.randomUUID().toString();
+  private static final String RECORD_ID = UUID.randomUUID().toString();
+  private static final String INSTANCE_ID = UUID.randomUUID().toString();
   private static final String SECOND_RECORD_ID = UUID.randomUUID().toString();
   private static final String SECOND_INSTANCE_ID = UUID.randomUUID().toString();
+  private static final String ERROR_RECORD_ID = UUID.randomUUID().toString();
+  private static final String ERROR_INSTANCE_ID = UUID.randomUUID().toString();
+  private static final String ERROR_RECORD_DESCRIPTION = "test error";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final Integer LINK_ID = RandomUtils.nextInt();
   private static final Map<String, String> OKAPI_HEADERS = Map.of(
     OkapiConnectionParams.OKAPI_URL_HEADER, OKAPI_URL,
     OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID,
     OkapiConnectionParams.OKAPI_TOKEN_HEADER, TOKEN);
-
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
   private static String updatedParsedRecordContent;
   private static String unlinkedParsedRecordContent;
-
-  private final String linkedBibUpdateJobId = UUID.randomUUID().toString();
-  private final String recordId = UUID.randomUUID().toString();
-  private final String instanceId = UUID.randomUUID().toString();
-  private final RawRecord rawRecord = new RawRecord().withId(recordId)
+  private final RawRecord rawRecord = new RawRecord().withId(RECORD_ID)
     .withContent("test content");
 
   private RecordDao recordDao;
   private RecordService recordService;
   private Record record;
   private Record secondRecord;
+  private Record errorRecord;
 
   @BeforeClass
   public static void setUpClass() throws IOException {
@@ -109,17 +113,17 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
       .withJobExecutionId(UUID.randomUUID().toString())
       .withProcessingStartedDate(new Date())
       .withStatus(Snapshot.Status.COMMITTED);
-    var parsedRecord = new ParsedRecord().withId(recordId)
-      .withContent(new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode());
+    var content = new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode();
+    var parsedRecord = new ParsedRecord().withId(RECORD_ID).withContent(content);
     record = new Record()
-      .withId(recordId)
+      .withId(RECORD_ID)
       .withSnapshotId(snapshot.getJobExecutionId())
       .withGeneration(0)
-      .withMatchedId(recordId)
-      .withRecordType(MARC_BIB)
+      .withMatchedId(RECORD_ID)
+      .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(INSTANCE_ID));
 
     var secondParsedRecord = new ParsedRecord().withId(SECOND_RECORD_ID)
       .withContent(new JsonObject(TestUtil.readFileFromPath(PARSED_MARC_RECORD_LINKED_PATH)).encode());
@@ -128,14 +132,28 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
       .withSnapshotId(snapshot.getJobExecutionId())
       .withGeneration(0)
       .withMatchedId(SECOND_RECORD_ID)
-      .withRecordType(MARC_BIB)
+      .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(secondParsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(SECOND_INSTANCE_ID));
 
+    var errorRecordContent = new ErrorRecord().withId(ERROR_RECORD_ID).withContent(content).withDescription(ERROR_RECORD_DESCRIPTION);
+    var errorParsedRecord = new ParsedRecord().withContent(ERROR_RECORD_ID).withContent(content);
+    errorRecord = new Record()
+      .withId(ERROR_RECORD_ID)
+      .withRawRecord(rawRecord)
+      .withGeneration(0)
+      .withMatchedId(ERROR_RECORD_ID)
+      .withErrorRecord(errorRecordContent)
+      .withParsedRecord(errorParsedRecord)
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withSnapshotId(snapshot.getJobExecutionId())
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(ERROR_INSTANCE_ID));
+
     SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)
       .compose(savedSnapshot -> recordService.saveRecord(record, TENANT_ID))
       .compose(savedRecord -> recordService.saveRecord(secondRecord, TENANT_ID))
+      .compose(savedRecord -> recordService.saveRecord(errorRecord, TENANT_ID))
       .onSuccess(ar -> async.complete())
       .onFailure(context::fail);
   }
@@ -192,7 +210,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   @Test
   public void shouldUpdateMultipleRecordsAndSendMultipleRecordUpdatedEvents(TestContext context)
     throws InterruptedException {
-    var updateTargets = buildUpdateTargets(instanceId, UUID.randomUUID().toString(), SECOND_INSTANCE_ID);
+    var updateTargets = buildUpdateTargets(INSTANCE_ID, UUID.randomUUID().toString(), SECOND_INSTANCE_ID);
     var event = buildLinkEventForUpdate(updateTargets);
 
     var traceHeader = UUID.randomUUID().toString();
@@ -206,16 +224,17 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
           return objectMapper.readValue(value, MarcBibUpdate.class).getRecord().getExternalIdsHolder().getInstanceId();
         } catch (IOException e) {
           return null;
-        }})
+        }
+      })
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
 
-    context.assertTrue(List.of(instanceId, SECOND_INSTANCE_ID).containsAll(eventsInstanceIds));
+    context.assertTrue(List.of(INSTANCE_ID, SECOND_INSTANCE_ID).containsAll(eventsInstanceIds));
   }
 
   /**
    * Only $9 subfield should be removed and only in case it matches authorityId from event
-   * */
+   */
   @Test
   public void shouldUpdateBibRecordForDeleteEventAndSendRecordUpdatedEvent(TestContext context)
     throws InterruptedException, IOException {
@@ -247,8 +266,8 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   @Test
-  public void shouldUpdateMultipleRecordsAndSendLinkUpdateReports(TestContext context) throws InterruptedException {
-    var updateTargets = buildUpdateTargets(instanceId, UUID.randomUUID().toString(), SECOND_INSTANCE_ID);
+  public void shouldUpdateMultipleRecordsAndSendSuccessLinkUpdateReports(TestContext context) throws InterruptedException {
+    var updateTargets = buildUpdateTargets(INSTANCE_ID, UUID.randomUUID().toString(), SECOND_INSTANCE_ID);
     var event = buildLinkEventForUpdate(updateTargets);
 
     var traceHeader = UUID.randomUUID().toString();
@@ -261,14 +280,31 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
         try {
           var report = objectMapper.readValue(value, LinkUpdateReport.class);
           context.assertEquals(SUCCESS, report.getStatus());
+          context.assertNull(report.getFailCause());
           return report.getInstanceId();
         } catch (IOException e) {
           return null;
-        }})
+        }
+      })
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
 
-    context.assertTrue(List.of(instanceId, SECOND_INSTANCE_ID).containsAll(eventsInstanceIds));
+    context.assertTrue(List.of(INSTANCE_ID, SECOND_INSTANCE_ID).containsAll(eventsInstanceIds));
+  }
+
+  @Test
+  public void shouldUpdateRecordAndSendFailedLinkUpdateReport(TestContext context) throws InterruptedException, IOException {
+    var event = buildLinkEventForUpdate(buildUpdateTargets(ERROR_INSTANCE_ID));
+    var traceHeader = UUID.randomUUID().toString();
+
+    cluster.send(createRequest(event, traceHeader));
+    var values = readValuesFromKafka(KAFKA_LINK_STATS_PRODUCER_TOPIC, traceHeader, 1);
+    context.assertEquals(1, values.size());
+
+    var report = objectMapper.readValue(values.get(0), LinkUpdateReport.class);
+    context.assertEquals(FAIL, report.getStatus());
+    context.assertEquals(ERROR_INSTANCE_ID, report.getInstanceId());
+    context.assertEquals(ERROR_RECORD_DESCRIPTION, report.getFailCause());
   }
 
   private SendKeyValues<String, String> createRequest(Object payload, String traceValue) {
@@ -283,7 +319,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   private static String getTopicName(KafkaTopic topic) {
-    return topic.fullTopicName(kafkaConfig, topic);
+    return topic.fullTopicName(kafkaConfig, TENANT_ID);
   }
 
   private List<String> readValuesFromKafka(String topic, String traceHeader, int limit) throws InterruptedException {
@@ -298,7 +334,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   private int getLinksCount(List<UpdateTarget> updateTargets) {
     return (int) updateTargets.stream()
       .flatMap(updateTarget -> updateTarget.getLinks().stream())
-      .filter(link -> link.getInstanceId().equals(instanceId))
+      .filter(link -> link.getInstanceId().equals(INSTANCE_ID))
       .count();
   }
 
@@ -311,7 +347,6 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   private BibAuthorityLinksUpdate buildLinkEvent(List<UpdateTarget> updateTargets, BibAuthorityLinksUpdate.Type type) {
-
     var subfieldChanges = List.of(
       new SubfieldsChange().withField("020")//repeatable, should update only one | $9 should be removed on DELETE
         .withSubfields(singletonList(new Subfield().withCode("a").withValue("2940447241 (electronic bk. updated)"))),
@@ -327,7 +362,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
     );
 
     return new BibAuthorityLinksUpdate()
-      .withJobId(linkedBibUpdateJobId)
+      .withJobId(LINKED_BIB_UPDATE_JOB_ID)
       .withAuthorityId(LINKED_AUTHORITY_ID)
       .withTenant(TENANT_ID)
       .withTs("123")
@@ -337,7 +372,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   }
 
   private List<UpdateTarget> buildUpdateTargets() {
-    return buildUpdateTargets(instanceId, UUID.randomUUID().toString());
+    return buildUpdateTargets(INSTANCE_ID, UUID.randomUUID().toString());
   }
 
   private List<UpdateTarget> buildUpdateTargets(String... instanceIds) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -1,5 +1,12 @@
 package org.folio.services;
 
+import static java.util.Collections.singletonList;
+import static org.folio.EntityLinksKafkaTopic.INSTANCE_AUTHORITY;
+import static org.folio.EntityLinksKafkaTopic.LINKS_STATS;
+import static org.folio.RecordStorageKafkaTopic.MARC_BIB;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.FAIL;
+import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.Json;
@@ -7,6 +14,19 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ReadKeyValues;
 import net.mguenther.kafka.junit.SendKeyValues;
@@ -38,27 +58,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Collections.singletonList;
-import static org.folio.EntityLinksKafkaTopic.INSTANCE_AUTHORITY;
-import static org.folio.EntityLinksKafkaTopic.LINKS_STATS;
-import static org.folio.RecordStorageKafkaTopic.MARC_BIB;
-import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.FAIL;
-import static org.folio.rest.jaxrs.model.LinkUpdateReport.Status.SUCCESS;
 
 @RunWith(VertxUnitRunner.class)
 public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -68,7 +68,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   private static final String KAFKA_KEY_NAME = "test-key";
   private static final String KAFKA_TEST_HEADER = "test";
   private static final String KAFKA_CONSUMER_TOPIC = getTopicName(INSTANCE_AUTHORITY);
-  private static final String KAFKA_KAFKA_SRS_BIB_PRODUCER_TOPIC = getTopicName(MARC_BIB);
+  private static final String KAFKA_SRS_BIB_PRODUCER_TOPIC = getTopicName(MARC_BIB);
   private static final String KAFKA_LINK_STATS_PRODUCER_TOPIC = getTopicName(LINKS_STATS);
   private static final String LINKED_AUTHORITY_ID = "6d19a8e8-2b71-482e-bfda-2b97f8722a2f";
   private static final String LINKED_BIB_UPDATE_JOB_ID = UUID.randomUUID().toString();
@@ -179,7 +179,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
 
     var traceHeader = UUID.randomUUID().toString();
     cluster.send(createRequest(event, traceHeader));
-    var keyValues = cluster.read(ReadKeyValues.from(KAFKA_KAFKA_SRS_BIB_PRODUCER_TOPIC)
+    var keyValues = cluster.read(ReadKeyValues.from(KAFKA_SRS_BIB_PRODUCER_TOPIC)
       .withMaxTotalPollTime(60, TimeUnit.SECONDS)
       .filterOnHeaders(headers -> Arrays.equals(headers.lastHeader(KAFKA_TEST_HEADER).value(),
         traceHeader.getBytes(StandardCharsets.UTF_8)))
@@ -214,7 +214,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
 
     var traceHeader = UUID.randomUUID().toString();
     cluster.send(createRequest(event, traceHeader));
-    var values = readValuesFromKafka(KAFKA_KAFKA_SRS_BIB_PRODUCER_TOPIC, traceHeader, 2);
+    var values = readValuesFromKafka(KAFKA_SRS_BIB_PRODUCER_TOPIC, traceHeader, 2);
     context.assertEquals(2, values.size());
 
     var eventsInstanceIds = values.stream()
@@ -245,7 +245,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
 
     var traceHeader = UUID.randomUUID().toString();
     cluster.send(createRequest(event, traceHeader));
-    var values = readValuesFromKafka(KAFKA_KAFKA_SRS_BIB_PRODUCER_TOPIC, traceHeader, 1);
+    var values = readValuesFromKafka(KAFKA_SRS_BIB_PRODUCER_TOPIC, traceHeader, 1);
     context.assertEquals(1, values.size());
     var actualOutgoingEvent = objectMapper.readValue(values.get(0), MarcBibUpdate.class);
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
@@ -2,7 +2,6 @@ package org.folio.services.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.folio.kafka.KafkaConfig;
 import org.junit.jupiter.api.Test;
 
 class EventHandlingUtilTest {
@@ -10,18 +9,6 @@ class EventHandlingUtilTest {
   private static final String ENV = "env";
   private static final String EVENT = "event";
   private static final String TENANT = "tenant";
-
-  @Test
-  void shouldCreateTopicNameNoNamespace() {
-    var kafkaConfig = KafkaConfig.builder()
-      .envId(ENV)
-      .build();
-
-    var expected = String.format("%s.%s.%s", ENV, TENANT, EVENT);
-    var actual = EventHandlingUtil.createTopicNameNoNamespace(EVENT, TENANT, kafkaConfig);
-
-    assertEquals(expected, actual);
-  }
 
   @Test
   void shouldCreateSubscriptionPattern() {

--- a/ramls/source-record-storage-records.raml
+++ b/ramls/source-record-storage-records.raml
@@ -26,6 +26,7 @@ types:
   mappingMetadataDto: !include raml-storage/schemas/dto/mappingMetadataDto.json
   bibAuthorityLinksUpdate: !include raml-storage/schemas/mod-entities-links/bibAuthorityLinksUpdate.json
   marcBibUpdate: !include raml-storage/schemas/mod-source-record-storage/marcBibUpdate.json
+  linkUpdateReport: !include raml-storage/schemas/mod-source-record-storage/linkUpdateReport.json
 
 traits:
   validate: !include raml-storage/raml-util/traits/validation.raml


### PR DESCRIPTION
When SRS consumes an event from `links.instance-authority` it tries to update related SRS records. If the update failed then send an event to `links.instance-authority-stats` topic.

https://issues.folio.org/browse/MODSOURCE-567