### PR TITLE
MODSOURCE-577: Prevent Instance PostProcessing Handler from sending DI_COMPLETED.

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.5.1</version>
+      <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -71,6 +71,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
   private static final String DISCOVERY_SUPPRESS_FIELD = "discoverySuppress";
   private static final String FAILED_UPDATE_STATE_MSG = "Error during update records state to OLD";
   private static final String ID_FIELD = "id";
+  public static final String POST_PROCESSING_INDICATOR = "POST_PROCESSING";
   private final KafkaConfig kafkaConfig;
   private final MappingParametersSnapshotCache mappingParamsCache;
   private final Vertx vertx;
@@ -130,6 +131,8 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
   protected abstract DataImportEventTypes replyEventType();
 
   protected abstract TypeConnection typeConnection();
+
+  protected abstract void prepareEventPayload(DataImportEventPayload dataImportEventPayload);
 
   protected List<KafkaHeader> getKafkaHeaders(DataImportEventPayload eventPayload) {
     List<KafkaHeader> kafkaHeaders = new ArrayList<>(List.of(
@@ -207,6 +210,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     context.put(getRecordType().value(), Json.encode(record));
     context.put(DATA_IMPORT_IDENTIFIER, Boolean.TRUE.toString());
     context.put(getMarcType().value(), Json.encode(record));
+    prepareEventPayload(dataImportEventPayload);
     return Json.encode(context);
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
@@ -61,6 +61,11 @@ public class AuthorityPostProcessingEventHandler extends AbstractPostProcessingE
   }
 
   @Override
+  protected void prepareEventPayload(DataImportEventPayload dataImportEventPayload) {
+
+  }
+
+  @Override
   protected void setExternalIds(ExternalIdsHolder externalIdsHolder, String externalId, String externalHrid) {
     externalIdsHolder.setAuthorityId(externalId);
     externalIdsHolder.setAuthorityHrid(externalHrid);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/HoldingsPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/HoldingsPostProcessingEventHandler.java
@@ -40,6 +40,11 @@ public class HoldingsPostProcessingEventHandler extends AbstractPostProcessingEv
   }
 
   @Override
+  protected void prepareEventPayload(DataImportEventPayload dataImportEventPayload) {
+
+  }
+
+  @Override
   protected void setExternalIds(ExternalIdsHolder externalIdsHolder, String externalId, String externalHrid) {
     externalIdsHolder.setHoldingsId(externalId);
     externalIdsHolder.setHoldingsHrid(externalHrid);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -1,6 +1,6 @@
 package org.folio.services.handlers;
 
-import static org.folio.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -1,5 +1,6 @@
 package org.folio.services.handlers;
 
+import static org.folio.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
@@ -47,6 +48,13 @@ public class InstancePostProcessingEventHandler extends AbstractPostProcessingEv
   @Override
   protected TypeConnection typeConnection() {
     return TypeConnection.MARC_BIB;
+  }
+
+  @Override
+  protected void prepareEventPayload(DataImportEventPayload dataImportEventPayload) {
+    if(dataImportEventPayload.getEventType().equals(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value())){
+      dataImportEventPayload.getContext().put(POST_PROCESSING_INDICATOR, "true");
+    }
   }
 
   @Override

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -768,6 +768,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
         String actualInstanceId = getInventoryId(fields);
         context.assertEquals(expectedInstanceId, actualInstanceId);
+        async.complete();
       });
     });
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.folio.DataImportEventTypes.DI_ORDER_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
@@ -715,6 +716,101 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
     boolean isEligible = handler.isEligible(dataImportEventPayload);
 
     Assert.assertFalse(isEligible);
+  }
+
+  @Test
+  public void shouldFillEventPayloadWithPostProcessingFlagIfOrderEventExists(TestContext context) {
+    Async async = context.async();
+
+    String expectedInstanceId = UUID.randomUUID().toString();
+    String expectedHrId = UUID.randomUUID().toString();
+
+    JsonObject instance = createExternalEntity(expectedInstanceId, expectedHrId);
+
+    HashMap<String, String> payloadContext = new HashMap<>();
+    payloadContext.put(INSTANCE.value(), instance.encode());
+    payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
+    payloadContext.put("recordId", record.getId());
+
+    DataImportEventPayload dataImportEventPayload =
+      createDataImportEventPayload(payloadContext, DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING);
+
+    CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
+    recordDao.saveRecord(record, TENANT_ID)
+      .onFailure(future::completeExceptionally)
+      .onSuccess(record -> handler.handle(dataImportEventPayload)
+        .thenApply(future::complete)
+        .exceptionally(future::completeExceptionally));
+
+    future.whenComplete((payload, e) -> {
+      if (e != null) {
+        context.fail(e);
+      }
+      recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+        if (getAr.failed()) {
+          context.fail(getAr.cause());
+        }
+
+        context.assertTrue(getAr.result().isPresent());
+        Record updatedRecord = getAr.result().get();
+
+        context.assertNotNull(updatedRecord.getExternalIdsHolder());
+        context.assertEquals(expectedInstanceId, updatedRecord.getExternalIdsHolder().getInstanceId());
+
+        context.assertNotNull(updatedRecord.getParsedRecord());
+        context.assertNotNull(updatedRecord.getParsedRecord().getContent());
+        JsonObject parsedContent = JsonObject.mapFrom(updatedRecord.getParsedRecord().getContent());
+
+        JsonArray fields = parsedContent.getJsonArray("fields");
+        context.assertTrue(!fields.isEmpty());
+
+        String actualInstanceId = getInventoryId(fields);
+        context.assertEquals(expectedInstanceId, actualInstanceId);
+
+        String recordForUdateId = UUID.randomUUID().toString();
+        Record recordForUpdate = JsonObject.mapFrom(record).mapTo(Record.class)
+          .withId(recordForUdateId)
+          .withSnapshotId(snapshotId2)
+          .withRawRecord(record.getRawRecord().withId(recordForUdateId))
+          .withParsedRecord(record.getParsedRecord().withId(recordForUdateId))
+          .withGeneration(1);
+
+        HashMap<String, String> payloadContextForUpdate = new HashMap<>();
+        payloadContextForUpdate.put(INSTANCE.value(), instance.encode());
+        payloadContextForUpdate.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(recordForUpdate));
+
+        DataImportEventPayload dataImportEventPayloadForUpdate =
+          createDataImportEventPayload(payloadContextForUpdate, DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING);
+
+        dataImportEventPayloadForUpdate.setEventType(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
+
+        CompletableFuture<DataImportEventPayload> future2 = new CompletableFuture<>();
+        recordDao.saveRecord(recordForUpdate, TENANT_ID)
+          .onFailure(future2::completeExceptionally)
+          .onSuccess(record -> handler.handle(dataImportEventPayloadForUpdate)
+            .thenApply(future2::complete)
+            .exceptionally(future2::completeExceptionally));
+
+        future2.whenComplete((payload2, ex) -> {
+          if (ex != null) {
+            context.fail(ex);
+          }
+          context.assertEquals(payload2.getContext().get("POST_PROCESSING"),"true");
+          recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(recordAr -> {
+            if (recordAr.failed()) {
+              context.fail(recordAr.cause());
+            }
+            Record rec = recordAr.result().get();
+            context.assertTrue(rec.getState().equals(Record.State.ACTUAL));
+            context.assertNotNull(rec.getExternalIdsHolder());
+            context.assertTrue(expectedInstanceId.equals(rec.getExternalIdsHolder().getInstanceId()));
+            context.assertNotEquals(rec.getId(), record.getId());
+            context.assertTrue(recordAr.result().isPresent());
+            async.complete();
+          });
+        });
+      });
+    });
   }
 
 }


### PR DESCRIPTION
## Purpose
To avoid sending DI_COMPLETED event from di-core lib if there is an "DI_ORDER_CREATED_READY_FOR_POST_PROCESSING"-event in the payload.

## Approach
Added a new abstract method, and implemented only for the Instance-entity (because the logic inside InstancePostProcessingEventHandler is only for sending events for the logs).

## Learning
(https://issues.folio.org/browse/MODSOURCE-577)
