### PR TITLE
MODSOURCE-587 Cleanup kafka headers for marc.bib event

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dao.util.IdType;
@@ -349,6 +350,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     var topicName = topic.fullTopicName(kafkaConfig, tenant);
     var key = String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum);
     var kafkaRecord = KafkaProducerRecord.create(topicName, key, Json.encode(marcRecord));
+    kafkaHeaders.removeIf(kafkaHeader -> !StringUtils.startsWithIgnoreCase(kafkaHeader.key(), "x-okapi-"));
     kafkaRecord.addHeaders(kafkaHeaders);
 
     return kafkaRecord;

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AuthorityLinkChunkKafkaHandlerTest.java
@@ -65,7 +65,7 @@ public class AuthorityLinkChunkKafkaHandlerTest extends AbstractLBServiceTest {
   private static final String PARSED_MARC_RECORD_LINKED_UPDATED_PATH = "src/test/resources/parsedMarcRecordLinkedUpdated.json";
   private static final String PARSED_MARC_RECORD_UNLINKED = "src/test/resources/parsedMarcRecordUnlinked.json";
   private static final String KAFKA_KEY_NAME = "test-key";
-  private static final String KAFKA_TEST_HEADER = "test";
+  private static final String KAFKA_TEST_HEADER = "x-okapi-test";
   private static final String KAFKA_CONSUMER_TOPIC = getTopicName(INSTANCE_AUTHORITY);
   private static final String KAFKA_SRS_BIB_PRODUCER_TOPIC = getTopicName(MARC_BIB);
   private static final String KAFKA_LINK_STATS_PRODUCER_TOPIC = getTopicName(LINKS_STATS);


### PR DESCRIPTION
## Purpose
Cleanup kafka headers for marc.bib event to have only x-okapi-* headers