### PR TITLE
MODSOURCE-598: Update postprocessing method to handle DI orders with instances creation

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -31,7 +31,7 @@ public class InstancePostProcessingEventHandler extends AbstractPostProcessingEv
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private final static String POST_PROCESSING_RESULT_EVENT = "POST_PROCESSING_RESULT_EVENT";
+  public final static String POST_PROCESSING_RESULT_EVENT = "POST_PROCESSING_RESULT_EVENT";
 
   private final KafkaConfig kafkaConfig;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -12,6 +12,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.services.RecordService;
 import org.folio.services.caches.MappingParametersSnapshotCache;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,10 @@ import org.folio.services.util.TypeConnection;
 
 @Component
 public class InstancePostProcessingEventHandler extends AbstractPostProcessingEventHandler {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private final static String POST_PROCESSING_RESULT_EVENT = "POST_PROCESSING_RESULT_EVENT";
 
   private final KafkaConfig kafkaConfig;
 
@@ -52,7 +58,13 @@ public class InstancePostProcessingEventHandler extends AbstractPostProcessingEv
 
   @Override
   protected void prepareEventPayload(DataImportEventPayload dataImportEventPayload) {
-    if(dataImportEventPayload.getEventType().equals(DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value())){
+    LOGGER.debug("prepareEventPayload :: eventType: {}, jobExecutionId: {}, POST_PROCESSING_RESULT_EVENT: {}",
+      dataImportEventPayload.getEventType(), dataImportEventPayload.getJobExecutionId(), dataImportEventPayload.getContext().get(POST_PROCESSING_RESULT_EVENT));
+    if (DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value().equals(dataImportEventPayload.getContext().get(POST_PROCESSING_RESULT_EVENT))) {
+      LOGGER.info("Set POST_PROCESSING_INDICATOR to event with eventType: {}, jobExecutionId: {}",
+        dataImportEventPayload.getEventType(), dataImportEventPayload.getJobExecutionId());
+      dataImportEventPayload.setEventType(dataImportEventPayload.getContext().get(POST_PROCESSING_RESULT_EVENT));
+      dataImportEventPayload.getContext().remove(POST_PROCESSING_RESULT_EVENT);
       dataImportEventPayload.getContext().put(POST_PROCESSING_INDICATOR, "true");
     }
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -52,6 +52,7 @@ import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+import static org.folio.services.handlers.InstancePostProcessingEventHandler.POST_PROCESSING_RESULT_EVENT;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 @RunWith(VertxUnitRunner.class)
@@ -734,6 +735,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
     DataImportEventPayload dataImportEventPayload =
       createDataImportEventPayload(payloadContext, DI_ORDER_CREATED_READY_FOR_POST_PROCESSING);
+    dataImportEventPayload.getContext().put(POST_PROCESSING_RESULT_EVENT, DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
 
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
     recordDao.saveRecord(record, TENANT_ID)
@@ -759,7 +761,8 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
         context.assertNotNull(updatedRecord.getParsedRecord());
         context.assertNotNull(updatedRecord.getParsedRecord().getContent());
-        context.assertNull(payload.getContext().get("POST_PROCESSING"));
+        context.assertNull(payload.getContext().get(POST_PROCESSING_RESULT_EVENT));
+        context.assertEquals(Boolean.valueOf(payload.getContext().get("POST_PROCESSING")), true);
         context.assertEquals(payload.getEventType(), DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
 
         JsonObject parsedContent = JsonObject.mapFrom(updatedRecord.getParsedRecord().getContent());

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -759,7 +759,8 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
         context.assertNotNull(updatedRecord.getParsedRecord());
         context.assertNotNull(updatedRecord.getParsedRecord().getContent());
-        context.assertEquals(payload.getContext().get("POST_PROCESSING"),"true");
+        context.assertNull(payload.getContext().get("POST_PROCESSING"));
+        context.assertEquals(payload.getEventType(), DI_ORDER_CREATED_READY_FOR_POST_PROCESSING.value());
 
         JsonObject parsedContent = JsonObject.mapFrom(updatedRecord.getParsedRecord().getContent());
 


### PR DESCRIPTION
## Purpose
Update postprocessing method to handle DI orders with instances creation

## Approach
1. eventType of the message should be set to DI_ORDER_CREATED_READY_FOR_POST_PROCESSING
2. key POST_PROCESSING_RESULT_EVENT should be deleted
3. key POST_PROCESSING_INDICATOR = true should be added to the context 

## Learning
[MODSOURCE-598](https://issues.folio.org/browse/MODSOURCE-598)
