### PR TITLE
MODSOURCE-585 - Data import matching takes incorrect SRS records into consideration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-02-xx v5.6.2-SNAPSHOT
+* [MODSOURCE-585](https://issues.folio.org/browse/MODSOURCE-585) Data import matching takes incorrect SRS records into consideration
+
 ## 2023-02-17 v5.6.0
 * [MODSOURCE-551](https://issues.folio.org/browse/MODSOURCE-551) Link update: Implement mechanism of topic creation
 * [MODSOURCE-557](https://issues.folio.org/browse/MODSOURCE-557) Logging improvement - Configuration

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
@@ -75,6 +75,7 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
 
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
     String tenantId = okapiConnectionParams.getTenantId();
+    String jobExecutionId = extractValueFromHeaders(targetRecord.headers(), JOB_EXECUTION_ID_HEADER);
     String recordId = extractValueFromHeaders(targetRecord.headers(), RECORD_ID_HEADER);
     String chunkId = extractValueFromHeaders(targetRecord.headers(), CHUNK_ID_HEADER);
     String userId = extractValueFromHeaders(targetRecord.headers(), USER_ID_HEADER);
@@ -84,14 +85,14 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
     DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
 
     try {
-      LOGGER.debug("handle:: RecordCollection has been received with event: '{}', chunkId: '{}', starting processing... chunkNumber '{}'-'{}' with recordId: '{}'' ",
-        eventPayload.getEventType(), chunkId, chunkNumber, key, recordId);
+      LOGGER.debug("handle:: RecordCollection has been received with event: '{}', jobExecutionId '{}', chunkId: '{}', starting processing... chunkNumber '{}'-'{}' with recordId: '{}'' ",
+        eventPayload.getEventType(), jobExecutionId, chunkId, chunkNumber, key, recordId);
       setUserMetadata(recordCollection, userId);
       return recordService.saveRecords(recordCollection, tenantId)
         .compose(recordsBatchResponse -> sendBackRecordsBatchResponse(recordsBatchResponse, kafkaHeaders, tenantId, chunkNumber, eventPayload.getEventType(), targetRecord));
     } catch (Exception e) {
-      LOGGER.warn("handle:: RecordCollection processing has failed with errors with event: '{}', chunkId: '{}', chunkNumber '{}'-'{}' with recordId: '{}' ",
-        eventPayload.getEventType(), chunkId, chunkNumber, key, recordId);
+      LOGGER.warn("handle:: RecordCollection processing has failed with errors with event: '{}', jobExecutionId '{}', chunkId: '{}', chunkNumber '{}'-'{}' with recordId: '{}' ",
+        eventPayload.getEventType(), jobExecutionId, chunkId, chunkNumber, key, recordId);
       return Future.failedFuture(e);
     }
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -50,14 +50,15 @@ public interface RecordDao {
   /**
    *  Searches for {@link Record} by {@link MatchField}  with offset and limit
    *
-   * @param matchField  Marc field that needs to be matched
-   * @param recordType  record type
-   * @param offset      starting index in a list of results
-   * @param limit       limit of records for pagination
-   * @param tenantId    tenant id
+   * @param matchField          Marc field that needs to be matched
+   * @param recordType          record type
+   * @param externalIdRequired  specifies whether necessary not to consider records with {@code externalId == null} while searching
+   * @param offset              starting index in a list of results
+   * @param limit               limit of records for pagination
+   * @param tenantId            tenant id
    * @return  {@link Future} of {@link RecordCollection}
    */
-  Future<List<Record>> getMatchedRecords(MatchField matchField, TypeConnection recordType, int offset, int limit, String tenantId);
+  Future<List<Record>> getMatchedRecords(MatchField matchField, TypeConnection recordType, boolean externalIdRequired, int offset, int limit, String tenantId);
 
   /**
    * Streams {@link Record} by {@link Condition} and ordered by collection of {@link OrderField}

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -539,6 +539,10 @@ public final class RecordDaoUtil {
     return DSL.noCondition();
   }
 
+  public static Condition filterRecordByExternalIdNonNull() {
+    return RECORDS_LB.EXTERNAL_ID.isNotNull();
+  }
+
   /**
    * Convert {@link List} of {@link String} to {@link List} or {@link OrderField}
    *

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
   private final DataImportEventTypes matchedEventType;
   private final DataImportEventTypes notMatchedEventType;
 
-  public AbstractMarcMatchEventHandler(TypeConnection typeConnection, RecordDao recordDao, DataImportEventTypes matchedEventType, DataImportEventTypes notMatchedEventType) {
+  protected AbstractMarcMatchEventHandler(TypeConnection typeConnection, RecordDao recordDao, DataImportEventTypes matchedEventType, DataImportEventTypes notMatchedEventType) {
     this.typeConnection = typeConnection;
     this.recordDao = recordDao;
     this.matchedEventType = matchedEventType;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
@@ -86,7 +86,7 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
           .onSuccess(recordCollection -> processSucceededResult(recordCollection.getRecords(), payload, future))
           .onFailure(throwable -> future.completeExceptionally(new MatchingException(throwable)));
       } else {
-        recordDao.getMatchedRecords(matchField, typeConnection, 0, 2, payload.getTenant())
+        recordDao.getMatchedRecords(matchField, typeConnection, isNonNullExternalIdRequired(), 0, 2, payload.getTenant())
           .onSuccess(recordList -> processSucceededResult(recordList, payload, future))
           .onFailure(throwable -> future.completeExceptionally(new MatchingException(throwable)));
       }
@@ -144,6 +144,10 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
    */
   protected String getMatchedMarcKey() {
     return "MATCHED_" + typeConnection.getMarcType();
+  }
+
+  protected boolean isNonNullExternalIdRequired() {
+    return false;
   }
 
   /* Verifies whether the given {@link MatchProfile} is suitable for {@link EventHandler} */

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/MarcBibliographicMatchEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/MarcBibliographicMatchEventHandler.java
@@ -31,4 +31,8 @@ public class MarcBibliographicMatchEventHandler extends AbstractMarcMatchEventHa
     return DI_SRS_MARC_BIB_RECORD_MATCHED_READY_FOR_POST_PROCESSING.value();
   }
 
+  @Override
+  protected boolean isNonNullExternalIdRequired() {
+    return true;
+  }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.Envs;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibliographicMatchEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibliographicMatchEventHandlerTest.java
@@ -379,14 +379,14 @@ public class MarcBibliographicMatchEventHandlerTest extends AbstractLBServiceTes
       .withCurrentNode(new ProfileSnapshotWrapper()
         .withId(UUID.randomUUID().toString())
         .withContentType(MATCH_PROFILE)
-        .withContent(new MatchProfile()
+        .withContent((new MatchProfile()
           .withExistingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
           .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
           .withMatchDetails(singletonList(new MatchDetail()
             .withMatchCriterion(EXACTLY_MATCHES)
             .withExistingMatchExpression(new MatchExpression()
               .withDataValueType(VALUE_FROM_RECORD)
-              .withFields(Lists.newArrayList(
+              .withFields(List.of(
                 new Field().withLabel("field").withValue("035"),
                 new Field().withLabel("indicator1").withValue(" "),
                 new Field().withLabel("indicator2").withValue(" "),
@@ -395,11 +395,12 @@ public class MarcBibliographicMatchEventHandlerTest extends AbstractLBServiceTes
             .withIncomingRecordType(EntityType.MARC_BIBLIOGRAPHIC)
             .withIncomingMatchExpression(new MatchExpression()
               .withDataValueType(VALUE_FROM_RECORD)
-              .withFields(Lists.newArrayList(
+              .withFields(List.of(
                 new Field().withLabel("field").withValue("035"),
-                new Field().withLabel("indicator1").withValue(""),
-                new Field().withLabel("indicator2").withValue(""),
-                new Field().withLabel("recordSubfield").withValue("a"))))))));
+                new Field().withLabel("indicator1").withValue(" "),
+                new Field().withLabel("indicator2").withValue(" "),
+                new Field().withLabel("recordSubfield").withValue("a")))))))
+        ));
 
     recordDao.saveRecord(existingRecord, TENANT_ID)
       .compose(record -> Future.fromCompletionStage(handler.handle(dataImportEventPayload)))


### PR DESCRIPTION
## Purpose
there is a case of creating marc-bib records without instance UUID, but with fields which represent other instance identifiers (035$a field). This in turn causes multiple records matching during matching by arbitrary MARC field (e.g. 035$a field) and taking into consideration incorrect marc-bib records (which aren't associated with instances).


## Approach
* do not consider marc-bib records which have no external id value during records lookup by arbitrary MARC field. Expand RecordsDao#getMatchedRecords() with parameter that indicates whether necessary to avoid records with externalId as null during records lookup.
* add test


## Learning
[MODSOURCE-585](https://issues.folio.org/browse/MODSOURCE-585)
