### PR TITLE
MODSOURCE-609: MarcBibUpdateModifyEventHandler and InstanceLinkClient improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ After setup, it is good to check logs in all related modules for errors. Data im
 * Relevant from the **Orchid** release, module versions from 5.6.0:
   * "_srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum_": 100
   * "_srs.kafka.AuthorityLinkChunkConsumer.loadLimit_": 2
+* Relevant from the **Poppy** release, module versions from 5.7.0:
   * "_srs.linking-rules-cache.expiration.time.hours_": 12
 
 ## Database schemas

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ After setup, it is good to check logs in all related modules for errors. Data im
 * Relevant from the **Orchid** release, module versions from 5.6.0:
   * "_srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum_": 100
   * "_srs.kafka.AuthorityLinkChunkConsumer.loadLimit_": 2
+  * "_srs.linking-rules-cache.expiration.time.hours_": 12
 
 ## Database schemas
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
@@ -2,6 +2,8 @@ package org.folio.client;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.http.HttpStatus;
@@ -10,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.InstanceLinkDtoCollection;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.dataimport.util.RestUtil;
+import org.folio.rest.jaxrs.model.LinkingRuleDto;
 import org.folio.services.exceptions.InstanceLinksException;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +39,31 @@ public class InstanceLinkClient {
           String message = String.format(
             "getLinksByInstanceId:: Error loading InstanceLinkDtoCollection by instanceId: '%s', status code: %s, response message: %s",
             instanceId, httpResponse.getResponse().statusCode(), httpResponse.getBody());
+          LOGGER.warn(message);
+          return CompletableFuture.failedFuture(new InstanceLinksException(message));
+        }
+      });
+  }
+
+  public CompletableFuture<Optional<List<LinkingRuleDto>>> getLinkingRuleList(OkapiConnectionParams params) {
+    LOGGER.trace("Trying to get list of LinkingRule for okapi url: {}, tenantId: {}",
+      params.getOkapiUrl(), params.getTenantId());
+
+    return RestUtil.doRequest(params, "/links/linking-rules/instance-authority", HttpMethod.GET, null)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .thenCompose(httpResponse->{
+        if (HttpStatus.SC_OK == httpResponse.getResponse().statusCode()) {
+          LOGGER.info("getLinkingRuleList:: LinkingRuleDto list was loaded '{}'", httpResponse.getResponse().statusCode());
+          return CompletableFuture.completedFuture(
+            Optional.of(Json.decodeValue(httpResponse.getBody(), List.class)));
+        } else if (httpResponse.getResponse().statusCode() == HttpStatus.SC_NOT_FOUND) {
+          LOGGER.warn("getLinkingRuleList:: no LinkingRuleDto was found '{}'", httpResponse.getResponse().statusCode());
+          return CompletableFuture.completedFuture(Optional.empty());
+        } else {
+          String message = String.format(
+            "getLinkingRuleList:: Error loading LinkingRuleDto list status code: %s, response message: %s",
+            httpResponse.getResponse().statusCode(), httpResponse.getBody());
           LOGGER.warn(message);
           return CompletableFuture.failedFuture(new InstanceLinksException(message));
         }

--- a/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
@@ -2,7 +2,7 @@ package org.folio.client;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
-
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -10,9 +10,9 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.InstanceLinkDtoCollection;
+import org.folio.LinkingRuleDto;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.dataimport.util.RestUtil;
-import org.folio.rest.jaxrs.model.LinkingRuleDto;
 import org.folio.services.exceptions.InstanceLinksException;
 import org.springframework.stereotype.Component;
 
@@ -52,11 +52,11 @@ public class InstanceLinkClient {
     return RestUtil.doRequest(params, "/linking-rules/instance-authority", HttpMethod.GET, null)
       .toCompletionStage()
       .toCompletableFuture()
-      .thenCompose(httpResponse->{
+      .thenCompose(httpResponse -> {
         if (HttpStatus.SC_OK == httpResponse.getResponse().statusCode()) {
           LOGGER.info("getLinkingRuleList:: LinkingRuleDto list was loaded '{}'", httpResponse.getResponse().statusCode());
           return CompletableFuture.completedFuture(
-            Optional.of(Json.decodeValue(httpResponse.getBody(), List.class)));
+            Optional.of(Arrays.asList(Json.decodeValue(httpResponse.getBody(), LinkingRuleDto[].class))));
         } else if (httpResponse.getResponse().statusCode() == HttpStatus.SC_NOT_FOUND) {
           LOGGER.warn("getLinkingRuleList:: no LinkingRuleDto was found '{}'", httpResponse.getResponse().statusCode());
           return CompletableFuture.completedFuture(Optional.empty());

--- a/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/client/InstanceLinkClient.java
@@ -49,7 +49,7 @@ public class InstanceLinkClient {
     LOGGER.trace("Trying to get list of LinkingRule for okapi url: {}, tenantId: {}",
       params.getOkapiUrl(), params.getTenantId());
 
-    return RestUtil.doRequest(params, "/links/linking-rules/instance-authority", HttpMethod.GET, null)
+    return RestUtil.doRequest(params, "/linking-rules/instance-authority", HttpMethod.GET, null)
       .toCompletionStage()
       .toCompletableFuture()
       .thenCompose(httpResponse->{

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/caches/LinkingRulesCache.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/caches/LinkingRulesCache.java
@@ -1,0 +1,46 @@
+package org.folio.services.caches;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.LinkingRuleDto;
+import org.folio.client.InstanceLinkClient;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LinkingRulesCache {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  @Value("${srs.linking-rules-cache.expiration.time.hours:12}")
+  private long cacheExpirationTime;
+
+  private final InstanceLinkClient instanceLinkClient;
+  private final AsyncCache<String, Optional<List<LinkingRuleDto>>> cache;
+
+  @Autowired
+  public LinkingRulesCache(InstanceLinkClient instanceLinkClient, Vertx vertx) {
+    this.instanceLinkClient = instanceLinkClient;
+    cache = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTime, TimeUnit.HOURS)
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync();
+  }
+
+  public Future<Optional<List<LinkingRuleDto>>> get(OkapiConnectionParams params) {
+    try {
+      return Future.fromCompletionStage(cache.get(params.getTenantId(), (key, executor) -> instanceLinkClient.getLinkingRuleList(params)));
+    } catch (Exception e) {
+      LOGGER.warn("get:: Error loading Linking rules", e);
+      return Future.failedFuture(e);
+    }
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
@@ -95,11 +95,9 @@ public class MarcBibUpdateModifyEventHandler extends AbstractUpdateModifyEventHa
     var okapiParams = getOkapiParams(dataImportEventPayload);
 
     return loadLinkingRules(okapiParams)
-      .compose(linkingRuleDtos -> {
-        return loadInstanceLink(matchedRecord, instanceId, okapiParams)
-          .compose(links -> modifyMarcBibRecord(dataImportEventPayload, mappingProfile, mappingParameters, links, linkingRuleDtos))
-          .compose(links -> updateInstanceLinks(instanceId, links, okapiParams));
-      });
+      .compose(linkingRuleDtos -> loadInstanceLink(matchedRecord, instanceId, okapiParams)
+        .compose(links -> modifyMarcBibRecord(dataImportEventPayload, mappingProfile, mappingParameters, links, linkingRuleDtos.orElse(Collections.emptyList())))
+        .compose(links -> updateInstanceLinks(instanceId, links, okapiParams)));
   }
 
   private Future<Optional<InstanceLinkDtoCollection>> loadInstanceLink(Record oldRecord, String instanceId,
@@ -128,7 +126,8 @@ public class MarcBibUpdateModifyEventHandler extends AbstractUpdateModifyEventHa
   private Future<Optional<InstanceLinkDtoCollection>> modifyMarcBibRecord(DataImportEventPayload dataImportEventPayload,
                                                                           MappingProfile mappingProfile,
                                                                           MappingParameters mappingParameters,
-                                                                          Optional<InstanceLinkDtoCollection> links, List<LinkingRuleDto> linkingRules) {
+                                                                          Optional<InstanceLinkDtoCollection> links,
+                                                                          List<LinkingRuleDto> linkingRules) {
     Promise<Optional<InstanceLinkDtoCollection>> promise = Promise.promise();
     try {
       if (links.isPresent()) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/client/AbstractClientTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/client/AbstractClientTest.java
@@ -1,0 +1,34 @@
+package org.folio.client;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public abstract class AbstractClientTest {
+  protected static final String TENANT_ID = "diku";
+  protected static final String TOKEN = "dummy";
+
+  protected static Vertx vertx;
+  public static WireMockServer wireMockServer;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    vertx = Vertx.vertx();
+
+    wireMockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
+    wireMockServer.start();
+  }
+
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      wireMockServer.stop();
+      async.complete();
+    }));
+  }
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/client/LinksClientTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/client/LinksClientTest.java
@@ -1,0 +1,193 @@
+package org.folio.client;
+
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.Collections.singletonList;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.Link;
+import org.folio.LinkingRuleDto;
+import org.folio.SubfieldModification;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.dataimport.util.RestUtil;
+import org.folio.services.exceptions.InstanceLinksException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class LinksClientTest extends AbstractClientTest {
+
+  private static final String LINKING_RULES_URL = "/linking-rules/instance-authority";
+  private static final UrlPathPattern URL_PATH_PATTERN =
+    new UrlPathPattern(new RegexPattern("/links/instances/.*"), true);
+
+  private final OkapiConnectionParams params = new OkapiConnectionParams(Map.of(
+    RestUtil.OKAPI_TENANT_HEADER, TENANT_ID,
+    RestUtil.OKAPI_TOKEN_HEADER, "token",
+    RestUtil.OKAPI_URL_HEADER, wireMockServer.baseUrl()
+  ), vertx);
+
+  private final InstanceLinkClient client = new InstanceLinkClient();
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+
+  @Test
+  public void shouldReturnLinks(TestContext context) {
+    Async async = context.async();
+
+    String instanceId = UUID.randomUUID().toString();
+    List<Link> links = singletonList(new Link()
+      .withId(1)
+      .withInstanceId(UUID.randomUUID().toString())
+      .withAuthorityId(UUID.randomUUID().toString())
+      .withAuthorityNaturalId("test")
+      .withLinkingRuleId(1));
+    InstanceLinkDtoCollection linkDtoCollection = new InstanceLinkDtoCollection()
+      .withLinks(links)
+        .withTotalRecords(1);
+
+    wireMockServer.stubFor(get(URL_PATH_PATTERN)
+      .willReturn(WireMock.ok().withBody(Json.encode(linkDtoCollection))));
+
+    CompletableFuture<Optional<InstanceLinkDtoCollection>> optionalFuture = client.getLinksByInstanceId(instanceId, params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(thr);
+      context.assertTrue(result.isPresent());
+      InstanceLinkDtoCollection actualLinkDtoCollection = result.get();
+      context.assertEquals(linkDtoCollection.getTotalRecords(), actualLinkDtoCollection.getTotalRecords());
+      List<Link> actualLinks = actualLinkDtoCollection.getLinks();
+      context.assertEquals(links.size(), actualLinks.size());
+      context.assertEquals(links.get(0).getId(), actualLinks.get(0).getId());
+      context.assertEquals(links.get(0).getInstanceId(), actualLinks.get(0).getInstanceId());
+      context.assertEquals(links.get(0).getAuthorityId(), actualLinks.get(0).getAuthorityId());
+      context.assertEquals(links.get(0).getAuthorityNaturalId(), actualLinks.get(0).getAuthorityNaturalId());
+      context.assertEquals(links.get(0).getLinkingRuleId(), actualLinks.get(0).getLinkingRuleId());
+
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyLinksOnNotFound(TestContext context) {
+    Async async = context.async();
+
+    String instanceId = UUID.randomUUID().toString();
+
+    wireMockServer.stubFor(get(URL_PATH_PATTERN)
+      .willReturn(WireMock.notFound()));
+
+    CompletableFuture<Optional<InstanceLinkDtoCollection>> optionalFuture = client.getLinksByInstanceId(instanceId, params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(thr);
+      context.assertTrue(result.isEmpty());
+
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldFailLinksOnUnknownCode(TestContext context) {
+    Async async = context.async();
+
+    String instanceId = UUID.randomUUID().toString();
+
+    wireMockServer.stubFor(get(URL_PATH_PATTERN)
+      .willReturn(WireMock.badRequest()));
+
+    CompletableFuture<Optional<InstanceLinkDtoCollection>> optionalFuture = client.getLinksByInstanceId(instanceId, params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(result);
+      context.assertTrue(thr.getCause() instanceof InstanceLinksException);
+      context.assertTrue(thr.getMessage().contains(instanceId));
+
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnLinkingRules(TestContext context) {
+    Async async = context.async();
+
+    List<LinkingRuleDto> linkingRules = singletonList(new LinkingRuleDto()
+      .withId(1)
+      .withBibField("100")
+      .withAuthorityField("100")
+      .withAuthoritySubfields(singletonList("a"))
+      .withSubfieldModifications(singletonList(new SubfieldModification()
+        .withSource("a")
+        .withTarget("b"))));
+
+    wireMockServer.stubFor(get(urlPathEqualTo(LINKING_RULES_URL))
+      .willReturn(WireMock.ok().withBody(Json.encode(linkingRules))));
+
+    CompletableFuture<Optional<List<LinkingRuleDto>>> optionalFuture = client.getLinkingRuleList(params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(thr);
+      context.assertTrue(result.isPresent());
+      List<LinkingRuleDto> actualLinkingRules = result.get();
+      context.assertEquals(linkingRules.size(), actualLinkingRules.size());
+      context.assertEquals(linkingRules.get(0).getId(), actualLinkingRules.get(0).getId());
+      context.assertEquals(linkingRules.get(0).getAuthorityField(), actualLinkingRules.get(0).getAuthorityField());
+      context.assertEquals(linkingRules.get(0).getAuthoritySubfields(), actualLinkingRules.get(0).getAuthoritySubfields());
+      context.assertEquals(linkingRules.get(0).getBibField(), actualLinkingRules.get(0).getBibField());
+      context.assertEquals(linkingRules.get(0).getSubfieldModifications(), actualLinkingRules.get(0).getSubfieldModifications());
+      context.assertEquals(linkingRules.get(0).getValidation(), actualLinkingRules.get(0).getValidation());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyLinkingRulesOnNotFound(TestContext context) {
+    Async async = context.async();
+
+    wireMockServer.stubFor(get(urlPathEqualTo(LINKING_RULES_URL))
+      .willReturn(WireMock.notFound()));
+
+    CompletableFuture<Optional<List<LinkingRuleDto>>> optionalFuture = client.getLinkingRuleList(params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(thr);
+      context.assertTrue(result.isEmpty());
+
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldFailLinkingRulesOnUnknownCode(TestContext context) {
+    Async async = context.async();
+
+    wireMockServer.stubFor(get(urlPathEqualTo(LINKING_RULES_URL))
+      .willReturn(WireMock.badRequest()));
+
+    CompletableFuture<Optional<List<LinkingRuleDto>>> optionalFuture = client.getLinkingRuleList(params);
+
+    optionalFuture.whenComplete((result, thr) -> {
+      context.assertNull(result);
+      context.assertTrue(thr.getCause() instanceof InstanceLinksException);
+
+      async.complete();
+    });
+  }
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/caches/LinkingRulesCacheTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/caches/LinkingRulesCacheTest.java
@@ -1,0 +1,150 @@
+package org.folio.services.caches;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.folio.LinkingRuleDto;
+import org.folio.client.InstanceLinkClient;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.dataimport.util.RestUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class LinkingRulesCacheTest {
+
+  private static final String TENANT_ID = "diku";
+  private static final String LINKING_RULES_URL = "/linking-rules/instance-authority";
+  private static final List<LinkingRuleDto> linkingRules = singletonList(new LinkingRuleDto()
+    .withId(1)
+    .withBibField("100")
+    .withAuthorityField("100")
+    .withAuthoritySubfields(singletonList("a"))
+    .withSubfieldModifications(emptyList()));
+
+  public static WireMockServer mockServer;
+  private static Vertx vertx = Vertx.vertx();
+  private static OkapiConnectionParams params;
+
+  private final InstanceLinkClient instanceLinkClient = new InstanceLinkClient();
+  private final LinkingRulesCache linkingRulesCache = new LinkingRulesCache(instanceLinkClient, vertx);
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+
+  @BeforeClass
+  public static void setUp() {
+    vertx = Vertx.vertx();
+
+    mockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
+    mockServer.start();
+
+    mockServer.stubFor(get(urlPathEqualTo(LINKING_RULES_URL))
+      .willReturn(WireMock.ok().withBody(Json.encode(linkingRules))));
+
+    params = new OkapiConnectionParams(Map.of(
+      RestUtil.OKAPI_TENANT_HEADER, TENANT_ID,
+      RestUtil.OKAPI_TOKEN_HEADER, "token",
+      RestUtil.OKAPI_URL_HEADER, mockServer.baseUrl()
+    ), vertx);
+  }
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    Async async = context.async();
+    vertx.close(context.asyncAssertSuccess(res -> {
+      mockServer.stop();
+      async.complete();
+    }));
+  }
+
+  @After
+  public void tearDown() {
+    mockServer.resetRequests();
+  }
+
+  @Test
+  public void shouldReturnLinkingRules(TestContext context) {
+    Async async = context.async();
+
+    Future<Optional<List<LinkingRuleDto>>> optionalFuture = linkingRulesCache.get(params);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isPresent());
+      List<LinkingRuleDto> actualLinkingRules = ar.result().get();
+      context.assertEquals(linkingRules.get(0).getId(), actualLinkingRules.get(0).getId());
+      context.assertEquals(linkingRules.get(0).getAuthorityField(), actualLinkingRules.get(0).getAuthorityField());
+      context.assertEquals(linkingRules.get(0).getAuthoritySubfields(), actualLinkingRules.get(0).getAuthoritySubfields());
+      context.assertEquals(linkingRules.get(0).getBibField(), actualLinkingRules.get(0).getBibField());
+      context.assertEquals(linkingRules.get(0).getSubfieldModifications(), actualLinkingRules.get(0).getSubfieldModifications());
+      context.assertEquals(linkingRules.get(0).getValidation(), actualLinkingRules.get(0).getValidation());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnLinkingRulesFromCache(TestContext context) throws IllegalAccessException {
+    Async async = context.async();
+    FieldUtils.writeField(linkingRulesCache, "cache", Caffeine.newBuilder()
+      .expireAfterWrite(2, TimeUnit.SECONDS)
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync(), true);
+
+    Future<Optional<List<LinkingRuleDto>>> optionalFuture = linkingRulesCache.get(params);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isPresent());
+
+      Future<Optional<List<LinkingRuleDto>>> optionalFuture1 = linkingRulesCache.get(params);
+
+      optionalFuture1.onComplete(ar1 -> {
+        context.assertTrue(ar1.succeeded());
+        context.assertTrue(ar1.result().isPresent());
+
+        List<LinkingRuleDto> actualLinkingRules = ar1.result().get();
+
+        context.assertEquals(linkingRules.get(0).getId(), actualLinkingRules.get(0).getId());
+        context.assertEquals(linkingRules.get(0).getAuthorityField(), actualLinkingRules.get(0).getAuthorityField());
+        context.assertEquals(linkingRules.get(0).getAuthoritySubfields(), actualLinkingRules.get(0).getAuthoritySubfields());
+        context.assertEquals(linkingRules.get(0).getBibField(), actualLinkingRules.get(0).getBibField());
+        context.assertEquals(linkingRules.get(0).getSubfieldModifications(), actualLinkingRules.get(0).getSubfieldModifications());
+        context.assertEquals(linkingRules.get(0).getValidation(), actualLinkingRules.get(0).getValidation());
+
+        try {
+          mockServer.verify(1, getRequestedFor(urlPathEqualTo(LINKING_RULES_URL)));
+        } catch (VerificationException e) {
+          context.fail(e);
+        }
+
+        async.complete();
+      });
+    });
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/caches/LinkingRulesCacheTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/caches/LinkingRulesCacheTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -13,6 +14,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
 import io.vertx.core.json.Json;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -144,6 +146,22 @@ public class LinkingRulesCacheTest {
 
         async.complete();
       });
+    });
+  }
+
+  @Test
+  public void shouldFailOnException(TestContext context) {
+    Async async = context.async();
+
+    OkapiConnectionParams params = new OkapiConnectionParams(emptyMap(), vertx);
+
+    Future<Optional<List<LinkingRuleDto>>> optionalFuture = linkingRulesCache.get(params);
+
+    optionalFuture.onComplete(ar -> {
+      context.assertTrue(ar.failed());
+      context.assertTrue(ar.cause().getCause() instanceof VertxException);
+
+      async.complete();
     });
   }
 


### PR DESCRIPTION
## Purpose
Update links interactions according to 'instance-authority-links' interface change to 2.0

## Approach
Add api `/linking-rules/instance-authority` to `InstanceLinkClient`
Add created api call into `MarcBibUpdateModifyEventHandler` (it would be good to cache rules for a few hours, with configurable time, because they are not meant to be changed between releases)
Pass linking rules to `MarcBibRecordModifier`

## Learning
[MODSOURCE-609](https://issues.folio.org/browse/MODSOURCE-609)
