### PR TITLE
MODSOURCE-635 - Delete marc_indexers records associated with old source records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2023-xo-xo v5.7.0-SNAPSHOT
+* [MODSOURCE-601](https://issues.folio.org/browse/MODSOURCE-601) Optimize Insert & Update of marc_records_lb table
+* [MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635) Delete marc_indexers records associated with "OLD" source records
+
 ## 2023-03-xx v5.6.3-SNAPSHOT
 * [MODSOURCE-615](https://issues.folio.org/browse/MODSOURCE-615) Importing 10,000 MARC authority records > Completes with errors due to timeout - Indices added.
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -168,32 +168,30 @@ public class RecordDaoImpl implements RecordDao {
 
   private static final String DELETE_MARC_INDEXERS_TEMP_TABLE = "marc_indexers_deleted_ids";
   private static final String DELETE_OLD_MARC_INDEXERS_SQL =
-    "WITH deleted_rows AS (\n" +
-    "    delete from marc_indexers mi\n" +
-    "    where exists(\n" +
-    "        select 1\n" +
-    "        from " + MARC_RECORDS_TRACKING.getName() + " mrt\n" +
-    "        where mrt.is_dirty = true\n" +
-    "          and mrt.marc_id = mi.marc_id\n" +
-    "          and mrt.version > mi.version\n" +
-    "    )\n" +
-    "    returning mi.marc_id \n" +
-    "),\n" +
-    "deleted_rows2 AS (\n" +
-    "    delete from marc_indexers mi\n" +
-    "    where exists(\n" +
-    "        select 1 \n" +
-    "        from records_lb\n" +
-    "        where records_lb.id = mi.marc_id\n" +
-    "          and records_lb.state = 'OLD'\n" +
-    "    )        \n" +
-    "    returning mi.marc_id\t\n" +
-    ")\n" +
-    "INSERT INTO " + DELETE_MARC_INDEXERS_TEMP_TABLE + "\n" +
-    "SELECT DISTINCT marc_id\n" +
-    "FROM deleted_rows\n" +
-    "UNION \n" +
-    "SELECT marc_id\n" +
+    "WITH deleted_rows AS ( " +
+    "    delete from marc_indexers mi " +
+    "    where exists( " +
+    "        select 1 " +
+    "        from " + MARC_RECORDS_TRACKING.getName() + " mrt " +
+    "        where mrt.is_dirty = true " +
+    "          and mrt.marc_id = mi.marc_id " +
+    "          and mrt.version > mi.version " +
+    "    ) " +
+    "    returning mi.marc_id), " +
+    "deleted_rows2 AS ( " +
+    "    delete from marc_indexers mi " +
+    "    where exists( " +
+    "        select 1 " +
+    "        from records_lb " +
+    "        where records_lb.id = mi.marc_id " +
+    "          and records_lb.state = 'OLD' " +
+    "    ) " +
+    "    returning mi.marc_id) " +
+    "INSERT INTO " + DELETE_MARC_INDEXERS_TEMP_TABLE + " " +
+    "SELECT DISTINCT marc_id " +
+    "FROM deleted_rows " +
+    "UNION " +
+    "SELECT marc_id " +
     "FROM deleted_rows2";
 
   private final PostgresClientFactory postgresClientFactory;

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -66,5 +66,6 @@
   <include file="scripts/v-5.6.3/2023-03-24--16-00-create-marc-indexers-035-value-index.xml" relativeToChangelogFile="true"/>
 
   <include file="scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
@@ -4,6 +4,17 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
 
+  <changeSet id="2023-05-22--16-00-delete-old-records-marc-indexers" author="RuslanLavrov">
+    <sql splitStatements="false">
+      DELETE FROM ${database.defaultSchemaName}.marc_indexers
+      WHERE exists(
+        SELECT 1
+        FROM ${database.defaultSchemaName}.records_lb
+        WHERE records_lb.id = marc_indexers.marc_id
+          AND records_lb.state = 'OLD');
+    </sql>
+  </changeSet>
+
   <changeSet id="2023-05-22--16-00-create-records-state-index" author="RuslanLavrov">
     <createIndex indexName="idx_records_state" tableName="records_lb">
       <column name="state"/>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+  <changeSet id="2023-05-22--16-00-create-records-state-index" author="RuslanLavrov">
+    <createIndex indexName="idx_records_state" tableName="records_lb">
+      <column name="state"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
to clean up "marc_indexers" rows associated with "OLD" source records since they are not accounted during search in the "marc_indexers" table.

## Approach
* modify the existing query for "marc_indexers" table cleanup with condition by "OLD" records state. Add index on the "records_lb"."state" field
* add migration script to clean up rows from "marc_indexers" associated with "OLD" records in "marc_records_lb".
* add test


## Learning
[MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635)
