### PR TITLE
 MODSOURCE-641: Close Transactions After Exceptions Are Thrown

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -235,8 +235,8 @@
     <testcontainers.version>1.15.3</testcontainers.version>
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
-    <jooq.version>3.13.6</jooq.version>
-    <vertx-jooq.version>6.1.1</vertx-jooq.version>
+    <jooq.version>3.16.19</jooq.version>
+    <vertx-jooq.version>6.5.5</vertx-jooq.version>
     <postgres.version>42.5.1</postgres.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <lombok.version>1.18.24</lombok.version>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -589,7 +589,7 @@ public class RecordDaoImpl implements RecordDao {
               }
               return record;
             }).collect(Collectors.toList()))
-            .fieldsFromSource()
+            .fieldsCorresponding()
             .execute()
             .errors();
 
@@ -608,7 +608,7 @@ public class RecordDaoImpl implements RecordDao {
             .onDuplicateKeyUpdate()
             .onErrorAbort()
             .loadRecords(dbRawRecords)
-            .fieldsFromSource()
+            .fieldsCorresponding()
             .execute();
 
           // batch insert parsed records
@@ -618,7 +618,7 @@ public class RecordDaoImpl implements RecordDao {
             .onDuplicateKeyUpdate()
             .onErrorAbort()
             .loadRecords(dbParsedRecords)
-            .fieldsFromSource()
+            .fieldsCorresponding()
             .execute();
 
           if (!dbErrorRecords.isEmpty()) {
@@ -629,7 +629,7 @@ public class RecordDaoImpl implements RecordDao {
               .onDuplicateKeyUpdate()
               .onErrorAbort()
               .loadRecords(dbErrorRecords)
-              .fieldsFromSource()
+              .fieldsCorresponding()
               .execute();
           }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -643,7 +643,7 @@ public class RecordDaoImpl implements RecordDao {
         promise.fail(e);
       } catch (SQLException | DataAccessException e) {
         LOG.warn("saveRecords:: Failed to save records", e);
-        promise.fail(e);
+        promise.fail(e.getCause());
       }
     },
     false,

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticleTest.java
@@ -174,7 +174,7 @@ public class ParsedRecordChunkConsumersVerticleTest extends AbstractLBServiceTes
 
     sendRecordsToKafka(jobExecutionId, records);
 
-    check_DI_ERROR_eventsSent(jobExecutionId, records, "SQL [null]; ERROR: insert or update on table \"raw_records_lb\" violates foreign key constraint \"fk_raw_records_records\"" );
+    check_DI_ERROR_eventsSent(jobExecutionId, records, "ERROR: insert or update on table \"raw_records_lb\" violates foreign key constraint \"fk_raw_records_records\"" );
   }
 
   @Test


### PR DESCRIPTION
## Purpose
There is an issue with lingering transactions when exceptions occur within lambda on some code paths. This is caused by a bug captured by the offending library used in SRS, https://github.com/jklingsporn/vertx-jooq/issues/197. 

A symptom of this issue is that database connections are in a "idle in transaction" state for some time after an exception has occurred. Transactions are open but no SQL statements are sent through. The database is left waiting for any interaction before the connection is closed. Top suspect is that the connection is closed when the query executor, which holds a reference to the transaction object, is garbage collected. This also means that for the duration of the connection being held hostage other processes within SRS can't use the connection. In a Data Import job with lots of errors, the total duration of the job could increase considerably.

## Approach
Upgrade vertx-jooq-classic-reactive to at least version 6.5.5

## Learning
[MODSOURCE-641](https://issues.folio.org/browse/MODSOURCE-641)
