### PR TITLE
MODSOURCE-636 - Implement async migration service

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 ## 2023-xo-xo v5.7.0-SNAPSHOT
 * [MODSOURCE-601](https://issues.folio.org/browse/MODSOURCE-601) Optimize Insert & Update of marc_records_lb table
 * [MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635) Delete marc_indexers records associated with "OLD" source records
+* [MODSOURCE-636](https://issues.folio.org/browse/MODSOURCE-636) Implement async migration service
+
+### Asynchronous migration job API
+| METHOD | URL                                     | DESCRIPTION                                     |
+|--------|-----------------------------------------|-------------------------------------------------|
+| POST   | /source-storage/migrations/jobs         | Initialize asynchronous migration job           |
+| GET    | /source-storage/migrations/jobs/{jobId} | Get asynchronous migration job entity by its id |
 
 ## 2023-03-xx v5.6.3-SNAPSHOT
 * [MODSOURCE-615](https://issues.folio.org/browse/MODSOURCE-615) Importing 10,000 MARC authority records > Completes with errors due to timeout - Indices added.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -236,6 +236,22 @@
       ]
     },
     {
+      "id": "source-storage-async-migrations",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["POST"],
+          "pathPattern": "/source-storage/migrations/jobs",
+          "permissionsRequired": ["source-storage.migrations.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/source-storage/migrations/jobs/{id}",
+          "permissionsRequired": ["source-storage.migrations.get"]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "2.0",
       "interfaceType": "system",
@@ -340,6 +356,16 @@
       "description": "Return marc bib ids, which doesn't exist in the system"
     },
     {
+      "permissionName": "source-storage.migrations.post",
+      "displayName": "Source Storage - initiate migration job",
+      "description": "Initiate asynchronous migration job"
+    },
+    {
+      "permissionName": "source-storage.migrations.get",
+      "displayName": "Source Storage - get migration job(s)",
+      "description": "Get migration job(s)"
+    },
+    {
       "permissionName": "source-storage.all",
       "displayName": "Source Record Storage - all permissions",
       "description": "Entire set of permissions needed to manage snapshots and records",
@@ -356,7 +382,9 @@
         "source-storage.records.delete",
         "source-storage.records.update",
         "source-storage.sourceRecords.get",
-        "source-storage.verified.records"
+        "source-storage.verified.records",
+        "source-storage.migrations.post",
+        "source-storage.migrations.get"
       ],
       "visible": false
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDao.java
@@ -5,7 +5,7 @@ import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 
 import java.util.Optional;
 
-public interface MigrationJobDao {
+public interface AsyncMigrationJobDao {
 
   Future<String> save(AsyncMigrationJob migrationJob, String tenantId);
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDao.java
@@ -5,13 +5,45 @@ import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 
 import java.util.Optional;
 
+/**
+ * Data access object for {@link AsyncMigrationJob} entity
+ *
+ * @see AsyncMigrationJob
+ */
 public interface AsyncMigrationJobDao {
 
-  Future<String> save(AsyncMigrationJob migrationJob, String tenantId);
+  /**
+   * Saves {@link AsyncMigrationJob}
+   *
+   * @param migrationJob asynchronous migration job to save
+   * @param tenantId     tenant id
+   * @return future of Void
+   */
+  Future<Void> save(AsyncMigrationJob migrationJob, String tenantId);
 
+  /**
+   * Searches for {@link AsyncMigrationJob} by id
+   *
+   * @param id        asyncMigrationJob migration job id
+   * @param tenantId  tenant id
+   * @return future with Optional of {@link AsyncMigrationJob}
+   */
   Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
 
+  /**
+   * Updates {@link AsyncMigrationJob}
+   *
+   * @param migrationJob  asyncMigrationJob to update
+   * @param tenantId      tenant id
+   * @return future with updated asyncMigrationJob
+   */
   Future<AsyncMigrationJob> update(AsyncMigrationJob migrationJob, String tenantId);
 
+  /**
+   * Searches for {@link AsyncMigrationJob} with status IN_PROGRESS
+   *
+   * @param tenantId tenant id
+   * @return future with Optional of {@link AsyncMigrationJob}
+   */
   Future<Optional<AsyncMigrationJob>> getJobInProgress(String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
@@ -37,12 +37,12 @@ public class AsyncMigrationJobDaoImpl implements AsyncMigrationJobDao {
   }
 
   @Override
-  public Future<String> save(AsyncMigrationJob migrationJob, String tenantId) {
+  public Future<Void> save(AsyncMigrationJob migrationJob, String tenantId) {
     LOG.trace("save:: Saving async migration job with id {} for tenant {}", migrationJob.getId(), tenantId);
     return getQueryExecutor(tenantId).executeAny(dslContext -> dslContext
         .insertInto(ASYNC_MIGRATION_JOBS)
         .set(mapToDatabaseRecord(migrationJob)))
-      .map(migrationJob.getId());
+      .mapEmpty();
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
@@ -24,7 +24,7 @@ import static java.lang.String.format;
 import static org.folio.rest.jooq.Tables.ASYNC_MIGRATION_JOBS;
 
 @Repository
-public class MigrationJobDaoImpl implements MigrationJobDao {
+public class AsyncMigrationJobDaoImpl implements AsyncMigrationJobDao {
 
   private static final Logger LOG = LogManager.getLogger();
   public static final String JOB_NOT_FOUND_MSG = "Async migration job was not found by id: '%s'";
@@ -32,7 +32,7 @@ public class MigrationJobDaoImpl implements MigrationJobDao {
   private PostgresClientFactory postgresClientFactory;
 
   @Autowired
-  public MigrationJobDaoImpl(PostgresClientFactory postgresClientFactory) {
+  public AsyncMigrationJobDaoImpl(PostgresClientFactory postgresClientFactory) {
     this.postgresClientFactory = postgresClientFactory;
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/AsyncMigrationJobDaoImpl.java
@@ -27,7 +27,7 @@ import static org.folio.rest.jooq.Tables.ASYNC_MIGRATION_JOBS;
 public class AsyncMigrationJobDaoImpl implements AsyncMigrationJobDao {
 
   private static final Logger LOG = LogManager.getLogger();
-  public static final String JOB_NOT_FOUND_MSG = "Async migration job was not found by id: '%s'";
+  private static final String JOB_NOT_FOUND_MSG = "Async migration job was not found by id: '%s'";
 
   private PostgresClientFactory postgresClientFactory;
 
@@ -106,7 +106,6 @@ public class AsyncMigrationJobDaoImpl implements AsyncMigrationJobDao {
     AsyncMigrationJobs pojo = RowMappers.getAsyncMigrationJobsMapper().apply(row);
     AsyncMigrationJob asyncMigrationJob = new AsyncMigrationJob()
       .withId(pojo.getId().toString())
-//      .withMigrations(Arrays.asList(pojo.getMigrations()))
       .withMigrations(Arrays.asList(row.getArrayOfStrings(ASYNC_MIGRATION_JOBS.MIGRATIONS.getName())))
       .withStatus(AsyncMigrationJob.Status.fromValue(pojo.getStatus().toString()))
       .withErrorMessage(pojo.getError());

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDao.java
@@ -10,4 +10,8 @@ public interface MigrationJobDao {
   Future<String> save(AsyncMigrationJob migrationJob, String tenantId);
 
   Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
+
+  Future<AsyncMigrationJob> update(AsyncMigrationJob migrationJob, String tenantId);
+
+  Future<Optional<AsyncMigrationJob>> getJobInProgress(String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDao.java
@@ -1,0 +1,13 @@
+package org.folio.dao;
+
+import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+
+import java.util.Optional;
+
+public interface MigrationJobDao {
+
+  Future<String> save(AsyncMigrationJob migrationJob, String tenantId);
+
+  Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDaoImpl.java
@@ -1,0 +1,98 @@
+package org.folio.dao;
+
+import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+import org.folio.rest.jooq.enums.MigrationJobStatus;
+import org.folio.rest.jooq.tables.mappers.RowMappers;
+import org.folio.rest.jooq.tables.pojos.AsyncMigrationJobs;
+import org.folio.rest.jooq.tables.records.AsyncMigrationJobsRecord;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.folio.rest.jooq.Tables.ASYNC_MIGRATION_JOBS;
+
+@Repository
+public class MigrationJobDaoImpl implements MigrationJobDao {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private PostgresClientFactory postgresClientFactory;
+
+  @Autowired
+  public MigrationJobDaoImpl(PostgresClientFactory postgresClientFactory) {
+    this.postgresClientFactory = postgresClientFactory;
+  }
+
+  @Override
+  public Future<String> save(AsyncMigrationJob migrationJob, String tenantId) {
+    LOG.trace("save:: Saving async migration job with id {} for tenant {}", migrationJob.getId(), tenantId);
+    return getQueryExecutor(tenantId).executeAny(dslContext -> dslContext
+        .insertInto(ASYNC_MIGRATION_JOBS)
+        .set(mapToDatabaseRecord(migrationJob)))
+      .map(migrationJob.getId());
+  }
+
+  @Override
+  public Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId) {
+    LOG.trace("getById:: Finding async migration job by id {} for tenant {}", id, tenantId);
+    return getQueryExecutor(tenantId).findOneRow(dslContext -> dslContext
+        .selectFrom(ASYNC_MIGRATION_JOBS)
+        .where(ASYNC_MIGRATION_JOBS.ID.eq(UUID.fromString(id))))
+      .map(row -> row != null ? Optional.of(mapRowToAsyncMigrationJob(row)) : Optional.empty());
+  }
+
+  private ReactiveClassicGenericQueryExecutor getQueryExecutor(String tenantId) {
+    return postgresClientFactory.getQueryExecutor(tenantId);
+  }
+
+  private AsyncMigrationJobsRecord mapToDatabaseRecord(AsyncMigrationJob migrationJob) {
+    AsyncMigrationJobsRecord asyncMigrationJobsDbRecord = new AsyncMigrationJobsRecord();
+    asyncMigrationJobsDbRecord.setMigrations(migrationJob.getMigrations().toArray(new String[0]));
+
+    if (migrationJob.getId() != null) {
+      asyncMigrationJobsDbRecord.setId(UUID.fromString(migrationJob.getId()));
+    }
+    if (migrationJob.getStatus() != null) {
+      asyncMigrationJobsDbRecord.setStatus(MigrationJobStatus.valueOf(migrationJob.getStatus().toString()));
+    }
+    if (migrationJob.getStartedDate() != null) {
+      asyncMigrationJobsDbRecord.setStartedDate(migrationJob.getStartedDate().toInstant().atOffset(ZoneOffset.UTC));
+    }
+    if (migrationJob.getCompletedDate() != null) {
+      asyncMigrationJobsDbRecord.setCompletedDate(migrationJob.getCompletedDate().toInstant().atOffset(ZoneOffset.UTC));
+    }
+    if (migrationJob.getErrorMessage() != null) {
+      asyncMigrationJobsDbRecord.setError(migrationJob.getErrorMessage());
+    }
+    return asyncMigrationJobsDbRecord;
+  }
+
+  private AsyncMigrationJob mapRowToAsyncMigrationJob(Row row) {
+    AsyncMigrationJobs pojo = RowMappers.getAsyncMigrationJobsMapper().apply(row);
+    AsyncMigrationJob asyncMigrationJob = new AsyncMigrationJob()
+      .withId(pojo.getId().toString())
+      .withMigrations(Arrays.asList(pojo.getMigrations()))
+      .withStatus(AsyncMigrationJob.Status.fromValue(pojo.getStatus().toString()))
+      .withErrorMessage(pojo.getError());
+
+    if (pojo.getStartedDate() != null) {
+      asyncMigrationJob.withStartedDate(Date.from(pojo.getStartedDate().toInstant()));
+    }
+    if (pojo.getCompletedDate() != null) {
+      asyncMigrationJob.withCompletedDate(Date.from(pojo.getCompletedDate().toInstant()));
+    }
+    return asyncMigrationJob;
+  }
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/MigrationJobDaoImpl.java
@@ -47,7 +47,7 @@ public class MigrationJobDaoImpl implements MigrationJobDao {
 
   @Override
   public Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId) {
-    LOG.trace("getById:: Finding async migration job by id {} for tenant {}", id, tenantId);
+    LOG.trace("getById:: Searching async migration job by id {} for tenant {}", id, tenantId);
     return getQueryExecutor(tenantId).findOneRow(dslContext -> dslContext
         .selectFrom(ASYNC_MIGRATION_JOBS)
         .where(ASYNC_MIGRATION_JOBS.ID.eq(UUID.fromString(id))))
@@ -106,7 +106,8 @@ public class MigrationJobDaoImpl implements MigrationJobDao {
     AsyncMigrationJobs pojo = RowMappers.getAsyncMigrationJobsMapper().apply(row);
     AsyncMigrationJob asyncMigrationJob = new AsyncMigrationJob()
       .withId(pojo.getId().toString())
-      .withMigrations(Arrays.asList(pojo.getMigrations()))
+//      .withMigrations(Arrays.asList(pojo.getMigrations()))
+      .withMigrations(Arrays.asList(row.getArrayOfStrings(ASYNC_MIGRATION_JOBS.MIGRATIONS.getName())))
       .withStatus(AsyncMigrationJob.Status.fromValue(pojo.getStatus().toString()))
       .withErrorMessage(pojo.getError());
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -102,7 +102,7 @@ public class PostgresClientFactory {
    * @param tenantId tenant id
    * @return pooled database client
    */
-  PgPool getCachedPool(String tenantId) {
+  public PgPool getCachedPool(String tenantId) {
     return getCachedPool(this.vertx, tenantId);
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -40,7 +40,8 @@ public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJ
   }
 
   @Override
-  public void getSourceStorageMigrationsJobsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getSourceStorageMigrationsJobsById(String id, Map<String, String> okapiHeaders,
+                                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     asyncMigrationJobService.getById(id, tenantId)
       .map(migrationJobOptional -> migrationJobOptional
         .map(GetSourceStorageMigrationsJobsByIdResponse::respond200WithApplicationJson)

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -18,11 +18,12 @@ import static java.lang.String.format;
 
 public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJobs {
 
-  public static final String NOT_FOUND_MSG = "Async migration job with id '%s' was not found";
-  @Autowired
-  private AsyncMigrationJobService asyncMigrationJobService;
+  private static final String NOT_FOUND_MSG = "Async migration job with id '%s' was not found";
 
   private final String tenantId;
+
+  @Autowired
+  private AsyncMigrationJobService asyncMigrationJobService;
 
   public SourceStorageMigrationsJobsImpl(Vertx vertx, String tenantId) {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -1,0 +1,24 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
+import org.folio.rest.jaxrs.resource.SourceStorageMigrationsJobs;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJobs {
+
+
+  @Override
+  public void postSourceStorageMigrationsJobs(AsyncMigrationJobInitRq entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+  }
+
+  @Override
+  public void getSourceStorageMigrationsJobsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -32,7 +32,11 @@ public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJ
   @Override
   public void postSourceStorageMigrationsJobs(AsyncMigrationJobInitRq entity, Map<String, String> okapiHeaders,
                                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-
+    asyncMigrationJobService.runAsyncMigration(entity, tenantId)
+      .map(PostSourceStorageMigrationsJobsResponse::respond202WithApplicationJson)
+      .map(Response.class::cast)
+      .otherwise(ExceptionHelper::mapExceptionToResponse)
+      .onComplete(asyncResultHandler);
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -25,7 +25,7 @@ public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJ
   @Autowired
   private AsyncMigrationJobService asyncMigrationJobService;
 
-  public SourceStorageMigrationsJobsImpl(Vertx vertx, String tenantId) {
+  public SourceStorageMigrationsJobsImpl(Vertx vertx, String tenantId) { //NOSONAR
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
     this.tenantId = tenantId;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageMigrationsJobsImpl.java
@@ -3,22 +3,46 @@ package org.folio.rest.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.folio.dataimport.util.ExceptionHelper;
 import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
 import org.folio.rest.jaxrs.resource.SourceStorageMigrationsJobs;
+import org.folio.services.migrations.AsyncMigrationJobService;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import static java.lang.String.format;
+
 public class SourceStorageMigrationsJobsImpl implements SourceStorageMigrationsJobs {
 
+  public static final String NOT_FOUND_MSG = "Async migration job with id '%s' was not found";
+  @Autowired
+  private AsyncMigrationJobService asyncMigrationJobService;
+
+  private final String tenantId;
+
+  public SourceStorageMigrationsJobsImpl(Vertx vertx, String tenantId) {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+    this.tenantId = tenantId;
+  }
 
   @Override
-  public void postSourceStorageMigrationsJobs(AsyncMigrationJobInitRq entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postSourceStorageMigrationsJobs(AsyncMigrationJobInitRq entity, Map<String, String> okapiHeaders,
+                                              Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
   }
 
   @Override
   public void getSourceStorageMigrationsJobsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-
+    asyncMigrationJobService.getById(id, tenantId)
+      .map(migrationJobOptional -> migrationJobOptional
+        .map(GetSourceStorageMigrationsJobsByIdResponse::respond200WithApplicationJson)
+        .orElseGet(() -> GetSourceStorageMigrationsJobsByIdResponse.respond404WithTextPlain(format(NOT_FOUND_MSG, id))))
+      .map(Response.class::cast)
+      .otherwise(ExceptionHelper::mapExceptionToResponse)
+      .onComplete(asyncResultHandler);
   }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobRunner.java
@@ -1,0 +1,11 @@
+package org.folio.services.migrations;
+
+import io.vertx.core.Future;
+
+public interface AsyncMigrationJobRunner {
+
+  Future<Void> runMigration(String tenantId);
+
+  String getMigrationName();
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
@@ -1,0 +1,15 @@
+package org.folio.services.migrations;
+
+import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
+
+import java.util.Optional;
+
+public interface AsyncMigrationJobService {
+
+  Future<Void> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId);
+
+  Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
@@ -6,10 +6,29 @@ import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
 
 import java.util.Optional;
 
+/**
+ * AsyncMigrationJob service interface
+ */
 public interface AsyncMigrationJobService {
 
+  /**
+   * Executes asynchronous migration according to specified {@code migrations} in {@link AsyncMigrationJobInitRq}.
+   * Returns future with {@code AsyncMigrationJob} that reflects state of asynchronous migration execution.
+   * The method completes returned future before asynchronous migration execution is finished.
+   *
+   * @param migrationJobInitRq  request DTO to initiate asynchronous migration job execution
+   * @param tenantId            tenant id
+   * @return future of {@link AsyncMigrationJob} that reflects state of asynchronous migration execution
+   */
   Future<AsyncMigrationJob> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId);
 
+  /**
+   * Searches for {@link AsyncMigrationJob} by id
+   *
+   * @param id        asyncMigrationJob migration job id
+   * @param tenantId  tenant id
+   * @return future with Optional of {@link AsyncMigrationJob}
+   */
   Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface AsyncMigrationJobService {
 
-  Future<Void> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId);
+  Future<AsyncMigrationJob> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId);
 
   Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId);
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
@@ -25,10 +25,10 @@ public class AsyncMigrationJobServiceImpl implements AsyncMigrationJobService {
   public static final String MIGRATION_IN_PROGRESS_MSG = "Failed to initiate migration job, because migration job with id '%s' already in progress";
 
   private MigrationJobDao migrationJobDao;
-  private List<AsyncMigrationJobRunner> jobRunners;
+  private List<AsyncMigrationTaskRunner> jobRunners;
 
   @Autowired
-  public AsyncMigrationJobServiceImpl(MigrationJobDao migrationJobDao, List<AsyncMigrationJobRunner> jobRunners) {
+  public AsyncMigrationJobServiceImpl(MigrationJobDao migrationJobDao, List<AsyncMigrationTaskRunner> jobRunners) {
     this.migrationJobDao = migrationJobDao;
     this.jobRunners = jobRunners;
   }
@@ -70,12 +70,12 @@ public class AsyncMigrationJobServiceImpl implements AsyncMigrationJobService {
   }
 
   private Future<Void> runMigrations(AsyncMigrationJob asyncMigrationJob, String tenantId) {
-    List<AsyncMigrationJobRunner> runners = asyncMigrationJob.getMigrations().stream()
+    List<AsyncMigrationTaskRunner> runners = asyncMigrationJob.getMigrations().stream()
       .flatMap(migrationName -> jobRunners.stream().filter(runner -> migrationName.equals(runner.getMigrationName())))
       .collect(Collectors.toList());
 
     Future<Void> future = Future.succeededFuture();
-    for (AsyncMigrationJobRunner runner : runners) {
+    for (AsyncMigrationTaskRunner runner : runners) {
       future = future.compose(v -> runner.runMigration(tenantId));
     }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
@@ -1,0 +1,41 @@
+package org.folio.services.migrations;
+
+import io.vertx.core.Future;
+import org.folio.dao.MigrationJobDao;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class AsyncMigrationJobServiceImpl implements AsyncMigrationJobService {
+
+  private MigrationJobDao migrationJobDao;
+
+  @Autowired
+  public AsyncMigrationJobServiceImpl(MigrationJobDao migrationJobDao) {
+    this.migrationJobDao = migrationJobDao;
+  }
+
+  @Override
+  public Future<Void> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId) {
+    AsyncMigrationJob asyncMigrationJob = new AsyncMigrationJob()
+      .withId(UUID.randomUUID().toString())
+      .withMigrations(migrationJobInitRq.getMigrations())
+      .withStatus(AsyncMigrationJob.Status.IN_PROGRESS)
+      .withStartedDate(new Date());
+
+    return migrationJobDao.save(asyncMigrationJob, tenantId)
+      .mapEmpty();
+  }
+
+  @Override
+  public Future<Optional<AsyncMigrationJob>> getById(String id, String tenantId) {
+    return migrationJobDao.getById(id, tenantId);
+  }
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationJobServiceImpl.java
@@ -1,36 +1,104 @@
 package org.folio.services.migrations;
 
 import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.dao.MigrationJobDao;
+import org.folio.dataimport.util.exception.ConflictException;
 import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.ws.rs.BadRequestException;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class AsyncMigrationJobServiceImpl implements AsyncMigrationJobService {
 
+  private static final Logger LOG = LogManager.getLogger();
+  public static final String INVALID_MIGRATIONS_MSG = "Specified migrations are not supported. Migrations: %s";
+  public static final String MIGRATION_IN_PROGRESS_MSG = "Failed to initiate migration job, because migration job with id '%s' already in progress";
+
   private MigrationJobDao migrationJobDao;
+  private List<AsyncMigrationJobRunner> jobRunners;
 
   @Autowired
-  public AsyncMigrationJobServiceImpl(MigrationJobDao migrationJobDao) {
+  public AsyncMigrationJobServiceImpl(MigrationJobDao migrationJobDao, List<AsyncMigrationJobRunner> jobRunners) {
     this.migrationJobDao = migrationJobDao;
+    this.jobRunners = jobRunners;
   }
 
   @Override
-  public Future<Void> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId) {
+  public Future<AsyncMigrationJob> runAsyncMigration(AsyncMigrationJobInitRq migrationJobInitRq, String tenantId) {
+    List<String> invalidMigrations = getUnsupportedMigrations(migrationJobInitRq);
+    if (!invalidMigrations.isEmpty()) {
+      return Future.failedFuture(new BadRequestException(String.format(INVALID_MIGRATIONS_MSG, invalidMigrations)));
+    }
+
     AsyncMigrationJob asyncMigrationJob = new AsyncMigrationJob()
       .withId(UUID.randomUUID().toString())
       .withMigrations(migrationJobInitRq.getMigrations())
       .withStatus(AsyncMigrationJob.Status.IN_PROGRESS)
       .withStartedDate(new Date());
 
-    return migrationJobDao.save(asyncMigrationJob, tenantId)
-      .mapEmpty();
+    return migrationJobDao.getJobInProgress(tenantId)
+      .compose(jobOptional -> jobOptional
+        .map(migrationJob -> Future.<String>failedFuture(new ConflictException(String.format(MIGRATION_IN_PROGRESS_MSG, migrationJob.getId()))))
+        .orElseGet(() -> migrationJobDao.save(asyncMigrationJob, tenantId)))
+      .map(res -> {
+        runMigrations(asyncMigrationJob, tenantId)
+          .onSuccess(v -> logProcessedMigration(asyncMigrationJob, tenantId))
+          .onFailure(e -> logFailedMigration(asyncMigrationJob, tenantId, e));
+        return asyncMigrationJob;
+      });
+  }
+
+  private List<String> getUnsupportedMigrations(AsyncMigrationJobInitRq migrationJobInitRq) {
+    List<String> migrations = migrationJobInitRq.getMigrations();
+    return migrations.stream()
+      .filter(migrationName -> jobRunners.stream().noneMatch(jobRunner -> jobRunner.getMigrationName().equals(migrationName)))
+      .collect(Collectors.toList());
+  }
+
+  private Future<Optional<AsyncMigrationJob>> checkMigrationsInProgress(String tenantId) {
+    return migrationJobDao.getJobInProgress(tenantId);
+  }
+
+  private Future<Void> runMigrations(AsyncMigrationJob asyncMigrationJob, String tenantId) {
+    List<AsyncMigrationJobRunner> runners = asyncMigrationJob.getMigrations().stream()
+      .flatMap(migrationName -> jobRunners.stream().filter(runner -> migrationName.equals(runner.getMigrationName())))
+      .collect(Collectors.toList());
+
+    Future<Void> future = Future.succeededFuture();
+    for (AsyncMigrationJobRunner runner : runners) {
+      future = future.compose(v -> runner.runMigration(tenantId));
+    }
+
+    return future;
+  }
+
+  private void logProcessedMigration(AsyncMigrationJob asyncMigrationJob, String tenantId) {
+    LOG.info("Async migration job with id: '{}' and migrations: '{}' was completed successfully",
+      asyncMigrationJob.getId(), asyncMigrationJob.getMigrations());
+
+    asyncMigrationJob.withCompletedDate(new Date())
+      .withStatus(AsyncMigrationJob.Status.COMPLETED);
+    migrationJobDao.update(asyncMigrationJob, tenantId);
+  }
+
+  private void logFailedMigration(AsyncMigrationJob asyncMigrationJob, String tenantId, Throwable throwable) {
+    LOG.error("Async migration job with id: '{}' and migrations: '{}' failed",
+      asyncMigrationJob.getId(), asyncMigrationJob.getMigrations(), throwable);
+
+    asyncMigrationJob.withCompletedDate(new Date())
+      .withStatus(AsyncMigrationJob.Status.ERROR)
+      .withErrorMessage(throwable.getMessage());
+    migrationJobDao.update(asyncMigrationJob, tenantId);
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
@@ -5,8 +5,20 @@ import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 
 public interface AsyncMigrationTaskRunner {
 
+  /**
+   * Performs migration operations
+   *
+   * @param asyncMigrationJob asyncMigrationJob entity
+   * @param tenantId          tenant id
+   * @return future of Void
+   */
   Future<Void> runMigration(AsyncMigrationJob asyncMigrationJob, String tenantId);
 
+  /**
+   * Returns migration task name
+   *
+   * @return migration task name
+   */
   String getMigrationName();
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
@@ -1,10 +1,11 @@
 package org.folio.services.migrations;
 
 import io.vertx.core.Future;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 
 public interface AsyncMigrationTaskRunner {
 
-  Future<Void> runMigration(String tenantId);
+  Future<Void> runMigration(AsyncMigrationJob asyncMigrationJob, String tenantId);
 
   String getMigrationName();
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/AsyncMigrationTaskRunner.java
@@ -2,7 +2,7 @@ package org.folio.services.migrations;
 
 import io.vertx.core.Future;
 
-public interface AsyncMigrationJobRunner {
+public interface AsyncMigrationTaskRunner {
 
   Future<Void> runMigration(String tenantId);
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
@@ -19,7 +19,7 @@ public class MarcIndexersVersionMigrationTaskRunner implements AsyncMigrationTas
 
   private static final Logger LOG = LogManager.getLogger();
   private static final String MIGRATION_NAME = "marcIndexersVersionMigration";
-  private static final String SCRIPT_PATH = "async_migration/update-fill-in-trigger.sql";
+  private static final String SCRIPT_PATH = "async_migration/set-marc-indexers-version.sql";
 
   private final PostgresClientFactory postgresClientFactory;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
@@ -1,0 +1,57 @@
+package org.folio.services.migrations;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dao.PostgresClientFactory;
+import org.folio.rest.impl.TenantAPI;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class MarcIndexersVersionMigrationTaskRunner implements AsyncMigrationTaskRunner {
+
+  private static final Logger LOG = LogManager.getLogger();
+  private static final String MIGRATION_NAME = "marcIndexersVersionMigration";
+  private static final String SCRIPT_PATH = "async_migration/update-fill-in-trigger.sql";
+
+  private final PostgresClientFactory postgresClientFactory;
+
+  @Autowired
+  public MarcIndexersVersionMigrationTaskRunner(PostgresClientFactory postgresClientFactory) {
+    this.postgresClientFactory = postgresClientFactory;
+  }
+
+  @Override
+  public Future<Void> runMigration(String tenantId) {
+    try {
+      InputStream scriptInputStream = TenantAPI.class.getClassLoader().getResourceAsStream(SCRIPT_PATH);
+      String script = IOUtils.toString(scriptInputStream, StandardCharsets.UTF_8);
+      Promise<Void> promise = Promise.promise();
+
+      postgresClientFactory.getCachedPool(tenantId).query(script).execute(rowsAr -> {
+        if (rowsAr.succeeded()) {
+          LOG.info("runMigration:: Migration '{}' successfully executed", MIGRATION_NAME);
+          promise.complete();
+        } else {
+          LOG.error("runMigration:: Failed to execute migration '{}', cause: ", MIGRATION_NAME, rowsAr.cause());
+          promise.fail(rowsAr.cause());
+        }
+      });
+      return promise.future();
+    } catch (IOException e) {
+      return Future.failedFuture(e);
+    }
+  }
+
+  @Override
+  public String getMigrationName() {
+    return MIGRATION_NAME;
+  }
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/migrations/MarcIndexersVersionMigrationTaskRunner.java
@@ -11,7 +11,6 @@ import org.folio.rest.jaxrs.model.AsyncMigrationJob;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -20,7 +19,8 @@ public class MarcIndexersVersionMigrationTaskRunner implements AsyncMigrationTas
 
   private static final Logger LOG = LogManager.getLogger();
   private static final String MIGRATION_NAME = "marcIndexersVersionMigration";
-  private static final String SCRIPT_PATH = "async_migration/set-marc-indexers-version.sql";
+  private static final String DELETE_OLD_INDEXERS_SCRIPT_PATH = "async_migration/delete-old-records-marc-indexers.sql";
+  private static final String SET_MARC_INDEXERS_VERSION_SCRIPT_PATH = "async_migration/set-marc-indexers-version.sql";
 
   private final PostgresClientFactory postgresClientFactory;
 
@@ -31,24 +31,33 @@ public class MarcIndexersVersionMigrationTaskRunner implements AsyncMigrationTas
 
   @Override
   public Future<Void> runMigration(AsyncMigrationJob asyncMigrationJob, String tenantId) {
+    return executeScript(DELETE_OLD_INDEXERS_SCRIPT_PATH, tenantId, asyncMigrationJob)
+      .compose(v -> executeScript(SET_MARC_INDEXERS_VERSION_SCRIPT_PATH, tenantId, asyncMigrationJob))
+      .onSuccess(v -> LOG.info("runMigration:: Migration '{}' successfully executed, migration jobId: '{}'", MIGRATION_NAME, asyncMigrationJob.getId()))
+      .onFailure(e -> LOG.error("runMigration:: Failed to execute migration '{}', migration jobId: '{}', cause: ",
+        MIGRATION_NAME, asyncMigrationJob.getId(), e));
+  }
+
+  private Future<Void> executeScript(String scriptPath, String tenantId, AsyncMigrationJob asyncMigrationJob) {
     try {
-      InputStream scriptInputStream = TenantAPI.class.getClassLoader().getResourceAsStream(SCRIPT_PATH);
+      LOG.trace("executeScript:: Trying to execute script: '{}', migration jobId: '{}'", scriptPath, asyncMigrationJob.getId());
+      InputStream scriptInputStream = TenantAPI.class.getClassLoader().getResourceAsStream(scriptPath);
       String script = IOUtils.toString(scriptInputStream, StandardCharsets.UTF_8);
       Promise<Void> promise = Promise.promise();
 
       postgresClientFactory.getCachedPool(tenantId).query(script).execute(rowsAr -> {
         if (rowsAr.succeeded()) {
-          LOG.info("runMigration:: Migration '{}' successfully executed, migration jobId: '{}'", MIGRATION_NAME, asyncMigrationJob.getId());
+          LOG.info("executeScript:: The script: '{}' successfully executed, migration jobId: '{}'", scriptPath, asyncMigrationJob.getId());
           promise.complete();
         } else {
-          LOG.error("runMigration:: Failed to execute migration '{}', migration jobId: '{}', cause: ",
-            MIGRATION_NAME, asyncMigrationJob.getId(), rowsAr.cause());
+          LOG.error("executeScript:: Failed to execute script: '{}', migration jobId: '{}', cause: ",
+            scriptPath, asyncMigrationJob.getId(), rowsAr.cause());
           promise.fail(rowsAr.cause());
         }
       });
       return promise.future();
-    } catch (IOException e) {
-      LOG.error("runMigration:: Failed to run migration '{}', migration jobId: '{}' cause: ", MIGRATION_NAME, asyncMigrationJob.getId(), e);
+    } catch (Exception e) {
+      LOG.error("executeScript:: Failed to run script '{}', migration jobId: '{}', cause: ", scriptPath, asyncMigrationJob.getId(), e);
       return Future.failedFuture(e);
     }
   }

--- a/mod-source-record-storage-server/src/main/resources/async_migration/delete-old-records-marc-indexers.sql
+++ b/mod-source-record-storage-server/src/main/resources/async_migration/delete-old-records-marc-indexers.sql
@@ -1,0 +1,8 @@
+-- delete marc_indexers related to OLD records
+DELETE FROM marc_indexers
+WHERE exists(
+  SELECT 1
+  FROM records_lb
+  WHERE records_lb.id = marc_indexers.marc_id
+    AND records_lb.state = 'OLD'
+);

--- a/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
+++ b/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
@@ -13,8 +13,12 @@ do $$
     index integer;
     suffix text;
   begin
-    execute 'update marc_indexers set version = 0;';
-    execute 'insert into marc_records_tracking select id, 0, false from marc_records_lb;';
+    execute 'update marc_indexers set version = 0 where version IS NULL;';
+    execute 'insert into marc_records_tracking ' ||
+            'select id, 0, false ' ||
+            'from marc_records_lb ' ||
+            'left join marc_records_tracking ON marc_records_tracking.marc_id = marc_records_lb.id ' ||
+            'where marc_records_tracking.marc_id IS NULL;';
     for index in 0 .. 999 loop
       suffix = lpad(index::text, 3, '0');
       execute 'drop index if exists idx_marc_indexers_marc_id_' || suffix || ';';

--- a/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
+++ b/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
@@ -1,12 +1,3 @@
--- delete marc_indexers related to OLD records
-DELETE FROM marc_indexers
-WHERE exists(
-  SELECT 1
-  FROM records_lb
-  WHERE records_lb.id = marc_indexers.marc_id
-    AND records_lb.state = 'OLD'
-);
-
 -- set marc_indexers version, populate marc_records_tracking table and create indexes on marc_indexers table
 do $$
   declare
@@ -29,4 +20,3 @@ $$;
 
 ALTER TABLE marc_indexers ALTER COLUMN version SET NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_marc_records_tracking_dirty ON marc_records_tracking USING btree (is_dirty);
-

--- a/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
+++ b/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
@@ -1,0 +1,27 @@
+-- delete marc_indexers related to OLD records
+DELETE FROM marc_indexers
+WHERE exists(
+  SELECT 1
+  FROM records_lb
+  WHERE records_lb.id = marc_indexers.marc_id
+    AND records_lb.state = 'OLD'
+);
+
+-- set marc_indexers version, populate marc_records_tracking table and create indexes on marc_indexers table
+do $$
+  declare
+    index integer;
+    suffix text;
+  begin
+    execute 'update marc_indexers set version = 0;';
+    execute 'insert into marc_records_tracking select id, 0, false from marc_records_lb;';
+    for index in 0 .. 999 loop
+      suffix = lpad(index::text, 3, '0');
+      execute 'drop index if exists idx_marc_indexers_marc_id_' || suffix || ';';
+      execute 'create index idx_marc_indexers_marc_id_version_' || suffix || ' on marc_indexers_' || suffix || '(marc_id, version);';
+    end loop;
+  end;
+$$;
+
+ALTER TABLE marc_indexers ALTER COLUMN version SET NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_marc_records_tracking_dirty ON marc_records_tracking USING btree (is_dirty);

--- a/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
+++ b/mod-source-record-storage-server/src/main/resources/async_migration/set-marc-indexers-version.sql
@@ -22,7 +22,7 @@ do $$
     for index in 0 .. 999 loop
       suffix = lpad(index::text, 3, '0');
       execute 'drop index if exists idx_marc_indexers_marc_id_' || suffix || ';';
-      execute 'create index idx_marc_indexers_marc_id_version_' || suffix || ' on marc_indexers_' || suffix || '(marc_id, version);';
+      execute 'create index if not exists idx_marc_indexers_marc_id_version_' || suffix || ' on marc_indexers_' || suffix || '(marc_id, version);';
     end loop;
   end;
 $$;

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -67,5 +67,6 @@
 
   <include file="scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -66,5 +66,6 @@
   <include file="scripts/v-5.6.3/2023-03-24--16-00-create-marc-indexers-035-value-index.xml" relativeToChangelogFile="true"/>
 
   <include file="scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml
@@ -21,29 +21,6 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="2023-04-13--16-00-create-index_on_marc_indexers.xml" author="okolawole">
-    <sql splitStatements="false">
-      do $$ declare
-      index integer;
-        suffix text;
-      begin
-      execute 'update ${database.defaultSchemaName}.marc_indexers set version = 0;';
-      execute 'insert into ${database.defaultSchemaName}.marc_records_tracking select id, 0, false from ${database.defaultSchemaName}.marc_records_lb;';
-      for index in 0 .. 999
-          loop
-            suffix = lpad(index::text, 3, '0');
-      execute 'drop index if exists ${database.defaultSchemaName}.idx_marc_indexers_marc_id_' || suffix || ';';
-      execute 'create index idx_marc_indexers_marc_id_version_' || suffix || ' on ${database.defaultSchemaName}.marc_indexers_' || suffix || '(marc_id, version);';
-      end loop;
-      end;
-      $$;
-    </sql>
-    <addNotNullConstraint columnName="version" tableName="marc_indexers"/>
-    <createIndex indexName="idx_marc_records_tracking_dirty" tableName="marc_records_tracking">
-      <column name="is_dirty"/>
-    </createIndex>
-  </changeSet>
-
   <changeSet id="2023-04-13--16-00-update-function-fill_in_marc_indexers" author="okolawole">
     <sql splitStatements="false">
       create or replace function ${database.defaultSchemaName}.fill_in_marc_indexers(p_marc_id uuid, p_marc_content jsonb, p_version integer)

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml
@@ -4,17 +4,6 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
 
-  <changeSet id="2023-05-22--16-00-delete-old-records-marc-indexers" author="RuslanLavrov">
-    <sql splitStatements="false">
-      DELETE FROM ${database.defaultSchemaName}.marc_indexers
-      WHERE exists(
-        SELECT 1
-        FROM ${database.defaultSchemaName}.records_lb
-        WHERE records_lb.id = marc_indexers.marc_id
-          AND records_lb.state = 'OLD');
-    </sql>
-  </changeSet>
-
   <changeSet id="2023-05-22--16-00-create-records-state-index" author="RuslanLavrov">
     <createIndex indexName="idx_records_state" tableName="records_lb">
       <column name="state"/>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml
@@ -1,0 +1,36 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+  <changeSet id="2023-05-31--16-00-create-async-migration-jobs-status" author="RuslanLavrov">
+    <sql>
+      CREATE TYPE ${database.defaultSchemaName}.migration_job_status AS ENUM (
+        'IN_PROGRESS',
+        'COMPLETED',
+        'ERROR'
+      );
+    </sql>
+  </changeSet>
+
+  <changeSet id="2023-05-31--16-00-create-async-migration-jobs-table" author="RuslanLavrov">
+    <createTable tableName="async_migration_jobs">
+      <column name="id" type="uuid">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="migrations" type="text[]">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="status" type="${database.defaultSchemaName}.migration_job_status">
+        <constraints nullable="false"/>
+      </column>
+      <column name="started_date" type="timestamptz">
+      </column>
+      <column name="completed_date" type="timestamptz">
+      </column>
+      <column name="error" type="text"></column>
+    </createTable>
+  </changeSet>
+
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml
@@ -20,7 +20,7 @@
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="migrations" type="text[]">
-        <constraints primaryKey="true" nullable="false"/>
+        <constraints nullable="false"/>
       </column>
       <column name="status" type="${database.defaultSchemaName}.migration_job_status">
         <constraints nullable="false"/>

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/MigrationsJobsApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/MigrationsJobsApiTest.java
@@ -1,0 +1,129 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import net.mguenther.kafka.junit.Wait;
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
+import org.folio.rest.jooq.Tables;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@RunWith(VertxUnitRunner.class)
+public class MigrationsJobsApiTest extends AbstractRestVerticleTest {
+
+  static final String MIGRATIONS_JOBS_PATH = "/source-storage/migrations/jobs/";
+
+  @Before
+  public void setUp(TestContext context) {
+    super.setUp();
+    clearTable(context);
+  }
+
+  @Test
+  public void shouldExecuteAsyncMigration() throws InterruptedException {
+    AsyncMigrationJobInitRq migrationInitDto = new AsyncMigrationJobInitRq()
+      .withMigrations(List.of("marcIndexersVersionMigration"));
+
+    AsyncMigrationJob migrationJob = RestAssured.given()
+      .spec(spec)
+      .body(migrationInitDto)
+      .when()
+      .post(MIGRATIONS_JOBS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_ACCEPTED)
+      .body("id", notNullValue())
+      .body("migrations", contains(migrationInitDto.getMigrations().toArray()))
+      .body("status", is(AsyncMigrationJob.Status.IN_PROGRESS.value()))
+      .body("startedDate", notNullValue())
+      .extract().body().as(AsyncMigrationJob.class);
+
+    Wait.delay(3);
+
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(MIGRATIONS_JOBS_PATH + migrationJob.getId())
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("id", is(migrationJob.getId()))
+      .body("status", is(AsyncMigrationJob.Status.COMPLETED.value()))
+      .body("completedDate", notNullValue());
+  }
+
+  @Test
+  public void shouldReturnNotFoundOnGetByIdIfJobDoesNotExist() {
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(MIGRATIONS_JOBS_PATH + UUID.randomUUID())
+      .then()
+      .statusCode(HttpStatus.SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturnBadRequestOnPostIfSpecifiedMigrationIsNotSupported() {
+    AsyncMigrationJobInitRq migrationInitDto = new AsyncMigrationJobInitRq()
+      .withMigrations(List.of("unsupportedMigrationName"));
+
+    RestAssured.given()
+      .spec(spec)
+      .body(migrationInitDto)
+      .when()
+      .post(MIGRATIONS_JOBS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_BAD_REQUEST)
+      .body(is(format("Specified migrations are not supported. Migrations: %s", migrationInitDto.getMigrations())));
+  }
+
+  @Test
+  public void shouldReturnBadRequestOnPostIfOtherMigrationJobInProgress() {
+    AsyncMigrationJobInitRq migrationInitDto = new AsyncMigrationJobInitRq()
+      .withMigrations(List.of("marcIndexersVersionMigration"));
+
+    String runningJobId = RestAssured.given()
+      .spec(spec)
+      .body(migrationInitDto)
+      .when()
+      .post(MIGRATIONS_JOBS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_ACCEPTED)
+      .body("status", is(AsyncMigrationJob.Status.IN_PROGRESS.value()))
+      .extract().body().as(AsyncMigrationJob.class).getId();
+
+    RestAssured.given()
+      .spec(spec)
+      .body(migrationInitDto)
+      .when()
+      .post(MIGRATIONS_JOBS_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_CONFLICT)
+      .body(is(format("Failed to initiate migration job, because migration job with id '%s' already in progress", runningJobId)));
+  }
+
+  private void clearTable(TestContext context) {
+    Async async = context.async();
+    PostgresClient pgClient = PostgresClient.getInstance(vertx.getDelegate(), TENANT_ID);
+    pgClient.delete(Tables.ASYNC_MIGRATION_JOBS.getName(), new Criterion(), ar -> {
+      if (ar.failed()) {
+        context.fail(ar.cause());
+      }
+      async.complete();
+    });
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/migrations/AsyncMigrationJobServiceImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/migrations/AsyncMigrationJobServiceImplTest.java
@@ -1,0 +1,57 @@
+package org.folio.services.migrations;
+
+import io.vertx.core.Future;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.dao.AsyncMigrationJobDaoImpl;
+import org.folio.rest.jaxrs.model.AsyncMigrationJob;
+import org.folio.rest.jaxrs.model.AsyncMigrationJobInitRq;
+import org.folio.services.AbstractLBServiceTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.folio.rest.jaxrs.model.AsyncMigrationJob.Status.ERROR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class AsyncMigrationJobServiceImplTest extends AbstractLBServiceTest {
+
+  private AsyncMigrationJobService asyncMigrationJobService;
+  private AsyncMigrationTaskRunner asyncMigrationTaskRunnerMock;
+
+  @Before
+  public void setUp() {
+    asyncMigrationTaskRunnerMock = Mockito.mock(AsyncMigrationTaskRunner.class);
+    asyncMigrationJobService = new AsyncMigrationJobServiceImpl(new AsyncMigrationJobDaoImpl(postgresClientFactory), List.of(asyncMigrationTaskRunnerMock));
+  }
+
+  @Test
+  public void shouldSetAsyncMigrationJobStatusToErrorIfErrorOccursDuringMigrationExecution(TestContext context) {
+    Async async = context.async();
+    String migrationName = "Test-migration";
+    AsyncMigrationJobInitRq migrationJobInitRequest = new AsyncMigrationJobInitRq().withMigrations(List.of(migrationName));
+    when(asyncMigrationTaskRunnerMock.getMigrationName()).thenReturn(migrationName);
+    when(asyncMigrationTaskRunnerMock.runMigration(any(AsyncMigrationJob.class), eq(TENANT_ID)))
+      .thenReturn(Future.failedFuture("migration error"));
+
+    Future<Optional<AsyncMigrationJob>> future = asyncMigrationJobService.runAsyncMigration(migrationJobInitRequest, TENANT_ID)
+      .compose(migrationJob -> asyncMigrationJobService.getById(migrationJob.getId(), TENANT_ID));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      Optional<AsyncMigrationJob> migrationJobOptional = ar.result();
+      context.assertTrue(migrationJobOptional.isPresent());
+      context.assertEquals(migrationJobOptional.get().getStatus(), ERROR);
+      async.complete();
+    });
+  }
+
+}

--- a/ramls/source-record-storage-migrations-jobs.raml
+++ b/ramls/source-record-storage-migrations-jobs.raml
@@ -21,12 +21,14 @@ types:
     body:
       application/json:
         type: asyncMigrationJobInitRq
+        example: !include raml-storage/examples/mod-source-record-storage/asyncMigrationJobInitRqDto.sample
     responses:
       202:
         description: Migration job has been submitted
         body:
           application/json:
             type: asyncMigrationJob
+            example: !include raml-storage/examples/mod-source-record-storage/asyncMigrationJob.sample
       500:
         description: Internal server error
         body:
@@ -41,6 +43,7 @@ types:
           body:
             application/json:
               type: asyncMigrationJob
+              example: !include raml-storage/examples/mod-source-record-storage/asyncMigrationJob.sample
         404:
           description: "Not found"
           body:

--- a/ramls/source-record-storage-migrations-jobs.raml
+++ b/ramls/source-record-storage-migrations-jobs.raml
@@ -1,0 +1,48 @@
+#%RAML 1.0
+
+title: Source Record Storage Async Migrations API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost
+
+documentation:
+  - title: Source Record Storage Migration Jobs API
+    content: API for managing asynchronous migration jobs
+
+types:
+  asyncMigrationJobInitRq: !include raml-storage/schemas/mod-source-record-storage/asyncMigrationJobInitRq.json
+  asyncMigrationJob: !include raml-storage/schemas/mod-source-record-storage/asyncMigrationJob.json
+
+/source-storage/migrations/jobs:
+  displayName: Async migrations
+  description: API for managing async migration jobs
+  post:
+    description: Initiate a migration job
+    body:
+      application/json:
+        type: asyncMigrationJobInitRq
+    responses:
+      202:
+        description: Migration job has been submitted
+        body:
+          application/json:
+            type: asyncMigrationJob
+      500:
+        description: Internal server error
+        body:
+          text/plain:
+            example: Internal server error
+  /{id}:
+    get:
+      description: Get a migration job
+      responses:
+        200:
+          description: Migration job has been returned
+          body:
+            application/json:
+              type: asyncMigrationJob
+        404:
+          description: "Not found"
+          body:
+            text/plain:
+              example: "Not found"

--- a/ramls/source-record-storage-migrations-jobs.raml
+++ b/ramls/source-record-storage-migrations-jobs.raml
@@ -10,7 +10,7 @@ documentation:
     content: API for managing asynchronous migration jobs
 
 types:
-  asyncMigrationJobInitRq: !include raml-storage/schemas/mod-source-record-storage/asyncMigrationJobInitRq.json
+  asyncMigrationJobInitRq: !include raml-storage/schemas/mod-source-record-storage/asyncMigrationJobInitRqDto.json
   asyncMigrationJob: !include raml-storage/schemas/mod-source-record-storage/asyncMigrationJob.json
 
 /source-storage/migrations/jobs:


### PR DESCRIPTION
## Purpose
Migration script to populate marc_records_tracking table and version for marc_indexers table should be run asynchronously (not at the module deployment time) through REST API call. 
It's necessary to provide API for the management of asynchronous migrations to run migration scripts, which take a long time to complete, manually and separately from the module deployment time.

## Approach
* implement asynchronous endpoint `POST /source-storage/migrations/jobs` to initiate asynchronous migration job and appropriate scripts run.
  The endpoint allows only one migration job to be in progress. If during the endpoint call another migration job is still being IN_PROGRESS, then the endpoint will respond 409 Conflict in response.
* implement endpoint `GET /source-storage/migrations/jobs/{jobId}` to check the status of migration job execution by its id.
* move scripts to populate "marc_records_tracking" table and to update version for "marc_indexers" table to async-migration scripts (`/async_migration` folder) to be run through API.
* add tests


## Learning
[MODSOURCE-636](https://issues.folio.org/browse/MODSOURCE-636)

Requires: PR https://github.com/folio-org/data-import-raml-storage/pull/285

The PR build will be fixed after https://github.com/folio-org/data-import-raml-storage/pull/285 PR is merged