### PR TITLE
MODSOURCE-639: Update Leader position when authority record is deleted

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -368,8 +368,9 @@ public interface RecordDao {
    *
    * @param matchedId matched id
    * @param recordState record state
+   * @param recordType record type
    * @param tenantId  tenant id
    * @return void future
    */
-  Future<Void> updateRecordsState(String matchedId, RecordState recordState, String tenantId);
+  Future<Void> updateRecordsState(String matchedId, RecordState recordState, RecordType recordType, String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -35,6 +35,7 @@ public final class ParsedRecordDaoUtil {
   private static final String ID = "id";
   private static final String CONTENT = "content";
   private static final String LEADER = "leader";
+  private static final int LEADER_STATUS_SUBFIELD_POSITION = 5;
 
   private static final Field<UUID> ID_FIELD = field(name(ID), UUID.class);
   private static final Field<JsonObject> CONTENT_FIELD = field(name(CONTENT), SQLDataType.JSONB.asConvertedDataType(new JSONBToJsonObjectConverter()));
@@ -179,11 +180,32 @@ public final class ParsedRecordDaoUtil {
     if (Objects.nonNull(parsedRecord)) {
       JsonObject marcJson = normalize(parsedRecord.getContent());
       String leader = marcJson.getString(LEADER);
-      if (Objects.nonNull(leader) && leader.length() > 5) {
-        return String.valueOf(leader.charAt(5));
+      if (Objects.nonNull(leader) && leader.length() > LEADER_STATUS_SUBFIELD_POSITION) {
+        return String.valueOf(leader.charAt(LEADER_STATUS_SUBFIELD_POSITION));
       }
     }
     return null;
+  }
+
+  /**
+   * Update MARC Leader status 05 for the given {@link ParsedRecord} content
+   *
+   * @param parsedRecord parsedRecord parsed record
+   * @param status new MARC Leader status
+   */
+  public static void updateLeaderStatus(ParsedRecord parsedRecord, Character status) {
+    if (Objects.isNull(parsedRecord) || Objects.isNull(parsedRecord.getContent()) || Objects.isNull(status)) {
+      return;
+    }
+
+    JsonObject marcJson = normalize(parsedRecord.getContent());
+    String leader = marcJson.getString(LEADER);
+    if (Objects.nonNull(leader) && leader.length() > LEADER_STATUS_SUBFIELD_POSITION) {
+      StringBuilder builder = new StringBuilder(leader);
+      builder.setCharAt(LEADER_STATUS_SUBFIELD_POSITION, status);
+      marcJson.put(LEADER, builder.toString());
+      parsedRecord.setContent(normalize(marcJson));
+    }
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -229,8 +229,9 @@ public interface RecordService {
    *
    * @param matchedId matched id
    * @param state record state
+   * @param recordType record type
    * @param tenantId  tenant id
    * @return void future
    */
-  Future<Void> updateRecordsState(String matchedId, RecordState state, String tenantId);
+  Future<Void> updateRecordsState(String matchedId, RecordState state, RecordType recordType, String tenantId);
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -246,8 +246,8 @@ public class RecordServiceImpl implements RecordService {
   }
 
   @Override
-  public Future<Void> updateRecordsState(String matchedId, RecordState state, String tenantId) {
-    return recordDao.updateRecordsState(matchedId, state, tenantId);
+  public Future<Void> updateRecordsState(String matchedId, RecordState state, RecordType recordType, String tenantId) {
+    return recordDao.updateRecordsState(matchedId, state, recordType, tenantId);
   }
 
   private Record formatMarcRecord(Record record) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityDeleteEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityDeleteEventHandlerTest.java
@@ -36,6 +36,9 @@ import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
 
 @RunWith(VertxUnitRunner.class)
 public class MarcAuthorityDeleteEventHandlerTest extends AbstractLBServiceTest {
+
+  private static final String PARSED_CONTENT =
+    "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
   private final RecordService recordService = new RecordServiceImpl(new RecordDaoImpl(postgresClientFactory));
   private final EventHandler eventHandler = new MarcAuthorityDeleteEventHandler(recordService);
   private Record record;
@@ -67,6 +70,7 @@ public class MarcAuthorityDeleteEventHandlerTest extends AbstractLBServiceTest {
   public void shouldDeleteRecord(TestContext context) {
     Async async = context.async();
     // given
+    record.setParsedRecord(new ParsedRecord().withId(record.getId()).withContent(PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put("MATCHED_MARC_AUTHORITY", Json.encode(record));
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
@@ -96,6 +100,7 @@ public class MarcAuthorityDeleteEventHandlerTest extends AbstractLBServiceTest {
               context.assertTrue(optionalDeletedRecord.isPresent());
               Record deletedRecord = optionalDeletedRecord.get();
               context.assertTrue(deletedRecord.getDeleted());
+              context.assertEquals(deletedRecord.getLeaderRecordStatus(), "d");
               async.complete();
             });
         })


### PR DESCRIPTION
Update Leader position when authority record is deleted

## Purpose
_Update Leader position when authority record is deleted_

## Approach
_When user deletes an authority record update Parsed Record Leader position 05 to value of 'd'_

## Closes
[_MODSOURCE-639_](https//issues.folio.org/browse/MODSOURCE-639)
