### PR TITLE
MODSOURCE-647 Bulk endpoint to fetch parsed records. Timeout exception

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -233,7 +233,8 @@ public class RecordDaoImpl implements RecordDao {
   public Future<StrippedParsedRecordCollection> getStrippedParsedRecords(List<String> externalIds, IdType idType, RecordType recordType, String tenantId) {
     Name cte = name(CTE);
     Name prt = name(recordType.getTableName());
-    Condition condition = RecordDaoUtil.getExternalIdsCondition(externalIds, idType);
+    Condition condition = RecordDaoUtil.getExternalIdsCondition(externalIds, idType)
+      .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL));
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
       .with(cte.as(dsl.selectCount()
         .from(RECORDS_LB)


### PR DESCRIPTION
## Purpose
The timeout exception appears after trying to catch edited record

## Approach
- Fetch only ACTUAL records
- Add OLD state for `recordState` enum

## Learning
https://issues.folio.org/browse/MODSOURCE-647
