### PR TITLE
MODSOURCE-648: Upgrade mod-source-record-storage to Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk17:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE mod-source-record-storage-server-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   doKubeDeploy = true
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 
   doDocker = {
     buildJavaDocker {

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-xo-xo v5.7.0-SNAPSHOT
+* [MODSOURCE-648](https://issues.folio.org/browse/MODSOURCE-648) Upgrade mod-source-record-storage to Java 17
 * [MODSOURCE-601](https://issues.folio.org/browse/MODSOURCE-601) Optimize Insert & Update of marc_records_lb table
 * [MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635) Delete marc_indexers records associated with "OLD" source records
 * [MODSOURCE-636](https://issues.folio.org/browse/MODSOURCE-636) Implement async migration service

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>1.6.0</version>
+      <version>1.7.0-SNAPSHOT</version>
       <type>jar</type>
       <exclusions>
         <exclusion>
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.7.0</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
@@ -237,6 +237,7 @@
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jooq.version>3.16.19</jooq.version>
     <vertx-jooq.version>6.5.5</vertx-jooq.version>
+    <aspectj.version>1.9.19</aspectj.version>
     <postgres.version>42.5.1</postgres.version>
     <postgres.image>postgres:12-alpine</postgres.image>
     <lombok.version>1.18.24</lombok.version>
@@ -269,7 +270,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
           <annotationProcessors>
             <annotationProcessor>lombok.launch.AnnotationProcessorHider$AnnotationProcessor</annotationProcessor>
@@ -476,13 +477,13 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
+        <version>1.13.1</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>11</complianceLevel>
+          <release>17</release>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
           <forceAjcCompile>true</forceAjcCompile>
@@ -504,12 +505,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.6</version>
+            <version>${aspectj.version}</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.6</version>
+            <version>${aspectj.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>35.0.1</raml-module-builder.version>
+    <raml-module-builder.version>35.0.6</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
     <vertx.version>4.3.7</vertx.version>
     <junit.version>4.13.2</junit.version>
@@ -67,7 +67,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Purpose
_Upgrade mod-source-record-storage to Java 17._

## Approach
_Incorporates **updating folio-liquibase-util** and **folio-kafka-wrapper** version already migrated to Java 17_.
