### PR TITLE
MODSOURCE-676 Implement retries for queries with specific exceptions

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -33,6 +33,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
@@ -228,6 +234,11 @@
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
       <version>5.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.14.5</version>
     </dependency>
   </dependencies>
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/QueryExecutorInterceptor.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/QueryExecutorInterceptor.java
@@ -1,0 +1,146 @@
+package org.folio.dao;
+
+import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.NoStackTraceThrowable;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.SuperMethodCall;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * This class provides an interceptor for the `transaction` and `query` methods of
+ * `ReactiveClassicGenericQueryExecutor`. It includes functionality for retrying the
+ * operations based on a configurable number of retries and delay, specifically for
+ * exceptions like `NoStackTraceThrowable` or `ClosedChannelException`.
+ */
+public class QueryExecutorInterceptor {
+  private static final Logger LOGGER = LogManager.getLogger();
+  private static int numRetries = 1;
+  private static long retryDelay = 1000;
+
+  /**
+   * Sets the number of retries for the transaction and query methods.
+   *
+   * @param numberOfRetries the number of retries to set
+   */
+  public static void setNumberOfRetries(int numberOfRetries) {
+    numRetries = numberOfRetries;
+  }
+
+  /**
+   * Sets the delay time between retries in milliseconds.
+   *
+   * @param delay the delay time to set in milliseconds
+   */
+  public static void setRetryDelay(long delay) {
+    if (delay < 0) throw new IllegalArgumentException("delay cannot be less than zero");
+    retryDelay = delay;
+  }
+
+  /**
+   * Generates a subclass of `ReactiveClassicGenericQueryExecutor` with interceptors for the
+   * transaction and query methods.
+   *
+   * @return the generated subclass
+   */
+  public static Class<? extends ReactiveClassicGenericQueryExecutor> generateClass() {
+    return new ByteBuddy()
+      .subclass(ReactiveClassicGenericQueryExecutor.class)
+      .constructor(ElementMatchers.any()) // Match all constructors
+      .intercept(SuperMethodCall.INSTANCE) // Call the original constructor
+      .method(ElementMatchers.named("transaction")) // For transaction method
+      .intercept(MethodDelegation.to(QueryExecutorInterceptor.class))
+      .method(ElementMatchers.named("query")) // For query method
+      .intercept(MethodDelegation.to(QueryExecutorInterceptor.class))
+      .make()
+      .load(QueryExecutorInterceptor.class.getClassLoader())
+      .getLoaded();
+  }
+
+  /**
+   * Interceptor for the query method, with retry functionality.
+   *
+   * @param superCall the original method call
+   * @return the result of the query operation
+   */
+  @SuppressWarnings("unused")
+  public static <U> Future<U> query(
+    @net.bytebuddy.implementation.bind.annotation.SuperCall Callable<Future<U>> superCall
+  ) {
+    LOGGER.trace("query method of ReactiveClassicGenericQueryExecutor proxied");
+    return retryOf(() -> {
+      try {
+        return superCall.call();
+      } catch (Throwable e) {
+        LOGGER.error("Something happened while attempting to make proxied call for query method", e);
+        return Future.failedFuture(e);
+      }
+    }, numRetries);
+  }
+
+  /**
+   * Interceptor for the transaction method, with retry functionality.
+   *
+   * @param superCall the original method call
+   * @return the result of the transaction operation
+   */
+  @SuppressWarnings("unused")
+  public static <U> Future<U> transaction(
+    @net.bytebuddy.implementation.bind.annotation.SuperCall Callable<Future<U>> superCall
+  ) {
+    LOGGER.trace("transaction method of ReactiveClassicGenericQueryExecutor proxied");
+    return retryOf(() -> {
+      try {
+        return superCall.call();
+      } catch (Throwable e) {
+        LOGGER.error("Something happened while attempting to make proxied call for transaction method", e);
+        return Future.failedFuture(e);
+      }
+    }, numRetries);
+  }
+
+  /**
+   * Private helper method for retrying the transaction or query operations. Introduces
+   * a delay and recursively retries in case of specific exceptions.
+   *
+   * @param supplier the operation to retry
+   * @param times    the number of times to retry
+   * @return the result of the operation
+   */
+  private static <U> Future<U> retryOf(Supplier<Future<U>> supplier, int times) {
+    if (times <= 0) {
+      return supplier.get();
+    }
+
+    return supplier.get().recover(err -> {
+      if (err instanceof NoStackTraceThrowable ||
+        err instanceof ClosedChannelException) {
+        Promise<U> promise = Promise.promise();
+        Context currentContext = Vertx.currentContext();
+        if (currentContext == null) { // don't introduce a delay
+          LOGGER.error("Execution error during proxied call. Retrying...", err);
+          return retryOf(supplier, times - 1);
+        } else {
+          Vertx vertx = currentContext.owner();
+          LOGGER.error("Execution error during proxied call. Retry in {}ms...", retryDelay, err);
+          vertx.setTimer(retryDelay, timerId -> { // Introduce a delay
+            retryOf(supplier, times - 1).onComplete(promise); // Recursively call retryOf and pass on the result
+          });
+          return promise.future();
+        }
+      }
+
+      return Future.failedFuture(err);
+    });
+  }
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/PostgresClientFactoryTest.java
@@ -1,23 +1,39 @@
 package org.folio.dao;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.HashMap;
-
-import org.folio.rest.tools.utils.Envs;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.ResetPeer;
+import io.github.jklingsporn.vertx.jooq.shared.internal.QueryResult;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.postgres.testing.PostgresTesterContainer;
+import org.folio.rest.tools.utils.Envs;
+import org.jooq.impl.DSL;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(VertxUnitRunner.class)
 public class PostgresClientFactoryTest {
+  private static final Logger LOGGER = LogManager.getLogger();
 
   static Vertx vertx;
 
@@ -70,6 +86,79 @@ public class PostgresClientFactoryTest {
     PostgresClientFactory.setConfigFilePath("/postgres-conf-local.json");
     assertEquals("/postgres-conf-local.json", PostgresClientFactory.getConfigFilePath());
     PostgresClientFactory.setConfigFilePath(null);
+  }
+
+  @Test
+  public void queryExecutorTransactionShouldRetry(TestContext context) throws IOException, InterruptedException {
+    Function<PostgresClientFactory, Future<QueryResult>> exec =
+      (postgresClientFactory) -> postgresClientFactory.getQueryExecutor("diku")
+              .transaction(qe -> qe.query(dsl -> dsl.select(DSL.inline(1))));
+    queryExecutorShouldRetryInternal(context, exec);
+  }
+
+  @Test
+  public void queryExecutorQueryShouldRetry(TestContext context) throws IOException, InterruptedException {
+    Function<PostgresClientFactory, Future<QueryResult>> exec =
+      (postgresClientFactory) -> postgresClientFactory.getQueryExecutor("diku")
+        .query(dsl -> dsl.select(DSL.inline(1)));
+    queryExecutorShouldRetryInternal(context, exec);
+  }
+
+  private void queryExecutorShouldRetryInternal(TestContext context, Function<PostgresClientFactory, Future<QueryResult>> exec)
+    throws IOException, InterruptedException {
+    Async async = context.async();
+    // Arrange
+    Network network = Network.newNetwork();
+    ToxiproxyContainer toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0")
+      .withNetwork(network).withNetworkAliases("toxiproxy");
+    PostgreSQLContainer<?> postgreSQLContainer =
+      new PostgreSQLContainer<>(PostgresTesterContainer.DEFAULT_IMAGE_NAME)
+        .withNetwork(network).withNetworkAliases("toxipostgres");
+    toxiproxy.start();
+    postgreSQLContainer
+      .waitingFor(new LogMessageWaitStrategy().withRegEx(".*database system is ready to accept connections.*\\n")).start();
+    Runnable closeResources = () -> {
+      toxiproxy.close();
+      postgreSQLContainer.close();
+      PostgresClientFactory.setConfigFilePath(null);
+    };
+    final ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+    final Proxy proxy = toxiproxyClient.createProxy("postgres", "0.0.0.0:8666", "toxipostgres:5432");
+    final String dbHost = toxiproxy.getHost();
+    final int dbPort = toxiproxy.getMappedPort(8666);
+    // break connection after 1 second
+    ResetPeer resetPeer = proxy.toxics().resetPeer("reset-peer", ToxicDirection.DOWNSTREAM, 1000);
+
+    // Act
+    Envs.setEnv(dbHost, dbPort, "test", "test", "test");
+    PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+    postgresClientFactory.setRetryPolicy(0, null);
+    exec.apply(postgresClientFactory)
+      .onComplete(ar1 -> {
+        // expect failure
+        if (!ar1.failed()) {
+          closeResources.run();
+          context.fail("database execution should fail");
+        }
+
+        // set multiple retries.
+        postgresClientFactory.setRetryPolicy(5, null);
+        exec.apply(postgresClientFactory).onComplete(ar2 -> {
+          // expect success
+          context.assertTrue(ar2.succeeded());
+          closeResources.run();
+          async.complete();
+        });
+        // make db connections work eventually in 2 seconds
+        // if executor is set to retry 5 times, then it will take at least 5 seconds for return of an error
+        vertx.setTimer(2000, (l) -> {
+          try {
+            resetPeer.remove();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
+      });
   }
 
   @AfterClass


### PR DESCRIPTION
## Purpose
Retry database queries that fail intermittently with non-actionable exceptions

## Approach
ByteBuddy library is used to generate bytecode that will append `.recover` from Vert.x to the future representing the result of the database query. The retry logic is embedded within the `.recover` composition of the database future. Retry logic is only performed for the `query` and `transaction` methods of ReactiveClassicGenericQueryExecutor from JOOQ-Vertx.
Retry will only occur for two exceptions as of this PR: `io.vertx.core.impl.NoStackTraceThrowable` and `io.netty.channel.StacklessClosedChannelException`


## Learning
https://issues.folio.org/browse/MODSOURCE-676
