### PR TITLE
MODSOURCE-671 - Allow DI to function correctly if marc_indexers version value is not set

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -205,6 +205,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>2.13.10</version>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -192,7 +192,8 @@ public class PostgresClientFactory {
       .setPassword(postgresConfig.getString(PASSWORD))
       .setIdleTimeout(postgresConfig.getInteger(IDLE_TIMEOUT, 60000))
       .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
-      .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId));
+      .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId))
+      .addProperty("application_name", "srs-pgpool");
   }
 
   private static DataSource getDataSource(String tenantId) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -192,8 +192,7 @@ public class PostgresClientFactory {
       .setPassword(postgresConfig.getString(PASSWORD))
       .setIdleTimeout(postgresConfig.getInteger(IDLE_TIMEOUT, 60000))
       .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
-      .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId))
-      .addProperty("application_name", "srs-pgpool");
+      .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId));
   }
 
   private static DataSource getDataSource(String tenantId) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -257,7 +257,7 @@ public class RecordDaoImpl implements RecordDao {
   @Override
   public Future<List<Record>> getMatchedRecords(MatchField matchedField, TypeConnection typeConnection, boolean externalIdRequired, int offset, int limit, String tenantId) {
     Name prt = name(typeConnection.getDbType().getTableName());
-    Table marcIndexersPartitionTable = table(name(MARC_INDEXERS_PARTITION_PREFIX + matchedField.getTag()));
+    Table<org.jooq.Record> marcIndexersPartitionTable = table(name(MARC_INDEXERS_PARTITION_PREFIX + matchedField.getTag()));
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl ->
       {
         SelectOnConditionStep<org.jooq.Record> query = dsl
@@ -407,12 +407,12 @@ public class RecordDaoImpl implements RecordDao {
 
   private void appendJoin(SelectJoinStep selectJoinStep, ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult) {
     if (parseLeaderResult.isEnabled()) {
-      Table marcIndexersLeader = table(name("marc_indexers_leader"));
+      Table<org.jooq.Record> marcIndexersLeader = table(name("marc_indexers_leader"));
       selectJoinStep.innerJoin(marcIndexersLeader).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexersLeader, name(MARC_ID))));
     }
     if (parseFieldsResult.isEnabled()) {
       parseFieldsResult.getFieldsToJoin().forEach(fieldToJoin -> {
-        Table marcIndexers = table(name(MARC_INDEXERS_PARTITION_PREFIX + fieldToJoin)).as("i" + fieldToJoin);
+        Table<org.jooq.Record> marcIndexers = table(name(MARC_INDEXERS_PARTITION_PREFIX + fieldToJoin)).as("i" + fieldToJoin);
         Field<UUID> marcIndexersMarcIdField = field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexers, name(MARC_ID));
         Field<Integer> marcIndexersVersionField = field(TABLE_FIELD_TEMPLATE, Integer.class, marcIndexers, name(VERSION));
         selectJoinStep.innerJoin(marcIndexers).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexers, name(MARC_ID))))

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -447,7 +447,6 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   private String getAlternativeQuery(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters) {
-    /* Building a search query */
     SelectJoinStep searchQuery = DSL.selectDistinct(RECORDS_LB.EXTERNAL_ID).from(RECORDS_LB);
     appendJoinAlternative(searchQuery, parseLeaderResult, parseFieldsResult);
     appendWhere(searchQuery, parseLeaderResult, parseFieldsResult, searchParameters);
@@ -457,7 +456,7 @@ public class RecordDaoImpl implements RecordDao {
     if (searchParameters.getLimit() != null) {
       searchQuery.limit(searchParameters.getLimit());
     }
-    /* Building a count query */
+
     SelectJoinStep countQuery = DSL.select(countDistinct(RECORDS_LB.EXTERNAL_ID)).from(RECORDS_LB);
     appendJoinAlternative(countQuery, parseLeaderResult, parseFieldsResult);
     appendWhere(countQuery, parseLeaderResult, parseFieldsResult, searchParameters);

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -9,6 +9,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.reactivex.pgclient.PgPool;
+import io.vertx.reactivex.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Row;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
@@ -200,6 +201,9 @@ public class RecordDaoImpl implements RecordDao {
 
   private final PostgresClientFactory postgresClientFactory;
 
+  @org.springframework.beans.factory.annotation.Value("${srs.record.matching.fallback-query.enable:false}")
+  private boolean enableFallbackQuery;
+
   @Autowired
   public RecordDaoImpl(final PostgresClientFactory postgresClientFactory) {
     this.postgresClientFactory = postgresClientFactory;
@@ -280,6 +284,35 @@ public class RecordDaoImpl implements RecordDao {
           .offset(offset)
           .limit(limit > 0 ? limit : DEFAULT_LIMIT_FOR_GET_RECORDS);
       }
+    )).compose(queryResult -> handleMatchedRecordsSearchResult(queryResult, matchedField, typeConnection, externalIdRequired, offset, limit, tenantId));
+  }
+
+  private Future<List<Record>> handleMatchedRecordsSearchResult(QueryResult queryResult, MatchField matchedField, TypeConnection typeConnection,
+                                                                boolean externalIdRequired, int offset, int limit, String tenantId) {
+    if (enableFallbackQuery && !queryResult.hasResults()) {
+      return getMatchedRecordsWithoutTrackingTable(matchedField, typeConnection, externalIdRequired, offset, limit, tenantId);
+    }
+    return Future.succeededFuture(queryResult.stream().map(res -> asRow(res.unwrap())).map(this::toRecord).collect(Collectors.toList()));
+  }
+
+  public Future<List<Record>> getMatchedRecordsWithoutTrackingTable(MatchField matchedField, TypeConnection typeConnection, boolean externalIdRequired, int offset, int limit, String tenantId) {
+    Name prt = name(typeConnection.getDbType().getTableName());
+    Table marcIndexersPartitionTable = table(name("marc_indexers_" + matchedField.getTag()));
+    return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
+      .select(getAllRecordFields(prt))
+      .from(RECORDS_LB)
+      .leftJoin(table(prt)).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, prt, name(ID))))
+      .leftJoin(RAW_RECORDS_LB).on(RECORDS_LB.ID.eq(RAW_RECORDS_LB.ID))
+      .leftJoin(ERROR_RECORDS_LB).on(RECORDS_LB.ID.eq(ERROR_RECORDS_LB.ID))
+      .innerJoin(marcIndexersPartitionTable).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexersPartitionTable, name(MARC_ID))))
+      .where(
+        filterRecordByType(typeConnection.getRecordType().value())
+          .and(filterRecordByState(Record.State.ACTUAL.value()))
+          .and(externalIdRequired ? filterRecordByExternalIdNonNull() : DSL.noCondition())
+          .and(getMatchedFieldCondition(matchedField, marcIndexersPartitionTable.getName()))
+      )
+      .offset(offset)
+      .limit(limit > 0 ? limit : DEFAULT_LIMIT_FOR_GET_RECORDS)
     )).map(queryResult -> queryResult.stream().map(res -> asRow(res.unwrap())).map(this::toRecord).collect(Collectors.toList()));
   }
 
@@ -363,7 +396,10 @@ public class RecordDaoImpl implements RecordDao {
       .flatMapPublisher(conn -> conn.rxBegin()
         .flatMapPublisher(tx -> conn.rxPrepare(sql)
           .flatMapPublisher(pq -> pq.createStream(10000)
-            .toFlowable().map(this::toRow))
+            .toFlowable()
+            .filter(row -> !enableFallbackQuery || row.getInteger(COUNT) != 0)
+            .switchIfEmpty(streamMarcRecordIdsWithoutTracking(conn, parseLeaderResult, parseFieldsResult, searchParameters))
+            .map(this::toRow))
           .doAfterTerminate(tx::commit)));
   }
 
@@ -401,6 +437,44 @@ public class RecordDaoImpl implements RecordDao {
       .and(suppressedFromDiscoveryCondition)
       .and(recordTypeCondition)
       .and(RECORDS_LB.EXTERNAL_ID.isNotNull());
+  }
+
+  private Flowable<io.vertx.reactivex.sqlclient.Row> streamMarcRecordIdsWithoutTracking(SqlConnection conn, ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult,
+                                                                                        RecordSearchParameters searchParameters) {
+    return conn.rxPrepare(getAlternativeQuery(parseLeaderResult, parseFieldsResult, searchParameters))
+      .flatMapPublisher(pq -> pq.createStream(10000).toFlowable());
+  }
+
+  private String getAlternativeQuery(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters) {
+    /* Building a search query */
+    SelectJoinStep searchQuery = DSL.selectDistinct(RECORDS_LB.EXTERNAL_ID).from(RECORDS_LB);
+    appendJoinAlternative(searchQuery, parseLeaderResult, parseFieldsResult);
+    appendWhere(searchQuery, parseLeaderResult, parseFieldsResult, searchParameters);
+    if (searchParameters.getOffset() != null) {
+      searchQuery.offset(searchParameters.getOffset());
+    }
+    if (searchParameters.getLimit() != null) {
+      searchQuery.limit(searchParameters.getLimit());
+    }
+    /* Building a count query */
+    SelectJoinStep countQuery = DSL.select(countDistinct(RECORDS_LB.EXTERNAL_ID)).from(RECORDS_LB);
+    appendJoinAlternative(countQuery, parseLeaderResult, parseFieldsResult);
+    appendWhere(countQuery, parseLeaderResult, parseFieldsResult, searchParameters);
+
+    return DSL.select().from(searchQuery).rightJoin(countQuery).on(DSL.trueCondition()).getSQL(ParamType.INLINED);
+  }
+
+  private void appendJoinAlternative(SelectJoinStep selectJoinStep, ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult) {
+    if (parseLeaderResult.isEnabled()) {
+      Table marcIndexersLeader = table(name("marc_indexers_leader"));
+      selectJoinStep.innerJoin(marcIndexersLeader).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexersLeader, name(MARC_ID))));
+    }
+    if (parseFieldsResult.isEnabled()) {
+      parseFieldsResult.getFieldsToJoin().forEach(fieldToJoin -> {
+        Table marcIndexers = table(name("marc_indexers_" + fieldToJoin)).as("i" + fieldToJoin);
+        selectJoinStep.innerJoin(marcIndexers).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexers, name(MARC_ID))));
+      });
+    }
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -300,6 +300,7 @@ public class RecordDaoImpl implements RecordDao {
     Table marcIndexersPartitionTable = table(name("marc_indexers_" + matchedField.getTag()));
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
       .select(getAllRecordFields(prt))
+      .distinctOn(RECORDS_LB.ID)
       .from(RECORDS_LB)
       .leftJoin(table(prt)).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, prt, name(ID))))
       .leftJoin(RAW_RECORDS_LB).on(RECORDS_LB.ID.eq(RAW_RECORDS_LB.ID))

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -118,11 +118,9 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
         })
         .onFailure(throwable -> {
           LOG.warn("handle:: Error while MARC record modifying", throwable);
-          if (throwable instanceof PgException pgException) {
-            if (StringUtils.equals(pgException.getConstraint(), DUPLICATE_CONSTRAINT)) {
-              future.completeExceptionally(new DuplicateRecordException(DUPLICATE_RECORD_MSG));
-              return;
-            }
+          if (throwable instanceof PgException pgException && StringUtils.equals(pgException.getConstraint(), DUPLICATE_CONSTRAINT)) {
+            future.completeExceptionally(new DuplicateRecordException(DUPLICATE_RECORD_MSG));
+            return;
           }
           future.completeExceptionally(throwable);
         });

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -118,14 +118,13 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
         })
         .onFailure(throwable -> {
           LOG.warn("handle:: Error while MARC record modifying", throwable);
-          if (throwable instanceof PgException) {
-            PgException pgException = (PgException) throwable;
+          if (throwable instanceof PgException pgException) {
             if (StringUtils.equals(pgException.getConstraint(), DUPLICATE_CONSTRAINT)) {
               future.completeExceptionally(new DuplicateRecordException(DUPLICATE_RECORD_MSG));
+              return;
             }
-          } else {
-            future.completeExceptionally(throwable);
           }
+          future.completeExceptionally(throwable);
         });
     } catch (Exception e) {
       LOG.warn("handle:: Error modifying MARC record", e);

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -1,0 +1,148 @@
+package org.folio.dao;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.reactivex.Flowable;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.reactivex.FlowableHelper;
+import io.vertx.sqlclient.Row;
+import org.folio.TestMocks;
+import org.folio.TestUtil;
+import org.folio.dao.util.MatchField;
+import org.folio.dao.util.SnapshotDaoUtil;
+import org.folio.processing.value.StringValue;
+import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.MarcRecordSearchRequest;
+import org.folio.rest.jaxrs.model.ParsedRecord;
+import org.folio.rest.jaxrs.model.RawRecord;
+import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.Snapshot;
+import org.folio.services.AbstractLBServiceTest;
+import org.folio.services.RecordSearchParameters;
+import org.folio.services.util.TypeConnection;
+import org.folio.services.util.parser.ParseFieldsResult;
+import org.folio.services.util.parser.ParseLeaderResult;
+import org.folio.services.util.parser.SearchExpressionParser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.jaxrs.model.Record.State.ACTUAL;
+import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
+import static org.folio.rest.jooq.Tables.RECORDS_LB;
+
+@RunWith(VertxUnitRunner.class)
+public class RecordDaoImplTest extends AbstractLBServiceTest {
+
+  private static final String ENABLE_FALLBACK_QUERY_FIELD = "enableFallbackQuery";
+
+  private RecordDao recordDao;
+  private Record record;
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    Async async = context.async();
+    recordDao = new RecordDaoImpl(postgresClientFactory);
+    RawRecord rawRecord = new RawRecord()
+      .withContent(new ObjectMapper().readValue(TestUtil.readFileFromPath(RAW_MARC_RECORD_CONTENT_SAMPLE_PATH), String.class));
+    ParsedRecord marcRecord = new ParsedRecord()
+      .withContent(new ObjectMapper().readValue(TestUtil.readFileFromPath(PARSED_MARC_RECORD_CONTENT_SAMPLE_PATH), JsonObject.class).encode());
+
+    Snapshot snapshot = TestMocks.getSnapshot(0);
+    String recordId = UUID.randomUUID().toString();
+
+    this.record = new Record()
+      .withId(recordId)
+      .withState(ACTUAL)
+      .withMatchedId(recordId)
+      .withSnapshotId(snapshot.getJobExecutionId())
+      .withGeneration(0)
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(rawRecord.withId(recordId))
+      .withParsedRecord(marcRecord.withId(recordId))
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId(UUID.randomUUID().toString()));
+
+    SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)
+      .compose(savedSnapshot -> recordDao.saveRecord(record, TENANT_ID))
+      .onComplete(save -> {
+        if (save.failed()) {
+          context.fail(save.cause());
+        }
+        async.complete();
+      });
+  }
+
+  @After
+  public void cleanUp(TestContext context) {
+    Async async = context.async();
+    SnapshotDaoUtil.deleteAll(postgresClientFactory.getQueryExecutor(TENANT_ID)).onComplete(delete -> {
+      if (delete.failed()) {
+        context.fail(delete.cause());
+      }
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnRecordOnGetMatchedRecordsWhenThereIsNoTrackingRecordAndFallbackQueryEnabled(TestContext context) {
+    Async async = context.async();
+    ReflectionTestUtils.setField(recordDao, ENABLE_FALLBACK_QUERY_FIELD, true);
+    MatchField matchField = new MatchField("100", "1", "", "a", StringValue.of("Mozart, Wolfgang Amadeus,"));
+
+    Future<List<Record>> future = deleteTrackingRecordById(record.getId())
+      .compose(v -> recordDao.getMatchedRecords(matchField, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(1, ar.result().size());
+      context.assertEquals(record.getId(), ar.result().get(0).getId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnIdOnStreamMarcRecordIdsWhenThereIsNoTrackingRecordAndFallbackQueryEnabled(TestContext context) {
+    Async async = context.async();
+    ReflectionTestUtils.setField(recordDao, ENABLE_FALLBACK_QUERY_FIELD, true);
+    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest()
+      .withFieldsSearchExpression("001.value = '393893'");
+    RecordSearchParameters searchParams = RecordSearchParameters.from(searchRequest);
+    ParseLeaderResult parseLeaderResult = SearchExpressionParser.parseLeaderSearchExpression(searchParams.getLeaderSearchExpression());
+    ParseFieldsResult parseFieldsResult = SearchExpressionParser.parseFieldsSearchExpression(searchParams.getFieldsSearchExpression());
+    ArrayList<String> ids = new ArrayList<>();
+
+    Future<Flowable<Row>> future = deleteTrackingRecordById(record.getId())
+      .map(v -> recordDao.streamMarcRecordIds(parseLeaderResult, parseFieldsResult, searchParams, TENANT_ID));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      FlowableHelper.toReadStream(ar.result())
+        .exceptionHandler(context::fail)
+        .handler(row -> ids.add(String.valueOf(row.getUUID(RECORDS_LB.EXTERNAL_ID.getName()))))
+        .endHandler(v -> {
+          context.assertEquals(1, ids.size());
+          context.assertEquals(record.getExternalIdsHolder().getInstanceId(), ids.get(0));
+          async.complete();
+        });
+    });
+  }
+
+  private Future<Boolean> deleteTrackingRecordById(String recordId) {
+    return postgresClientFactory.getQueryExecutor(TENANT_ID).execute(dslContext -> dslContext
+        .deleteFrom(MARC_RECORDS_TRACKING)
+        .where(MARC_RECORDS_TRACKING.MARC_ID.eq(UUID.fromString(recordId))))
+      .map(deleted -> deleted != 0);
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -141,7 +141,7 @@ public abstract class AbstractRestVerticleTest {
         throw new Exception(message);
     }
 
-    TenantClient tenantClient = new TenantClient(okapiUrl, "diku", "dummy-token");
+    TenantClient tenantClient = new TenantClient(okapiUrl, TENANT_ID, "dummy-token");
     DeploymentOptions restVerticleDeploymentOptions = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", okapiPort));
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, res -> {


### PR DESCRIPTION
## Purpose
Allow DI marc-to-marc matching and records search to work correctly until migration scripts which are required by MODSOURCE-601 are completed, in order to avoid downtime during the those scripts execution.


## Approach
* add alternative/fallback query that performs a search without indexers version usage to DAO method that provides marc-to-marc matching and to the method aimed for retrieving marc identifiers by search query.
This alternative query should be executed when the search results of the current queries are empty and newly introduced parameter `srs.record.matching.fallback-query.enable` = true.
* fix PgException handling in AbstractUpdateModifyEventHandler to prevent import job from being stuck if PgException is not related to matchedId-generation uniqueness constraint violation.
* add tests



## Learning
[MODSOURCE-671](https://issues.folio.org/browse/MODSOURCE-671)