### PR TITLE
MODSOURCE-674 - Ensure only one background job can be triggered to clean up outdated marc indexers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURCE-601](https://issues.folio.org/browse/MODSOURCE-601) Optimize Insert & Update of marc_records_lb table
 * [MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635) Delete marc_indexers records associated with "OLD" source records
 * [MODSOURCE-636](https://issues.folio.org/browse/MODSOURCE-636) Implement async migration service
+* [MODSOURCE-674](https://issues.folio.org/browse/MODSOURCE-674) Ensure only one background job can be triggered to clean up outdated marc indexers
 
 ### Asynchronous migration job API
 | METHOD | URL                                     | DESCRIPTION                                     |

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -142,8 +142,8 @@ public class RecordDaoImpl implements RecordDao {
   private static final String COUNT = "count";
   private static final String TABLE_FIELD_TEMPLATE = "{0}.{1}";
   private static final String MARC_INDEXERS_PARTITION_PREFIX = "marc_indexers_";
-  private static final String GET_LOCK_FUNCTION = "pg_try_advisory_xact_lock";
-  private static final int INDEXERS_DELETION_LOCK_PREFIX_ID = "delete_marc_indexers".hashCode();
+  static final String GET_LOCK_FUNCTION = "pg_try_advisory_xact_lock";
+  static final int INDEXERS_DELETION_LOCK_PREFIX_ID = "delete_marc_indexers".hashCode();
 
   private static final int DEFAULT_LIMIT_FOR_GET_RECORDS = 1;
   private static final String UNIQUE_VIOLATION_SQL_STATE = "23505";

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -143,6 +143,7 @@ public class RecordDaoImpl implements RecordDao {
   private static final String TABLE_FIELD_TEMPLATE = "{0}.{1}";
   private static final String MARC_INDEXERS_PARTITION_PREFIX = "marc_indexers_";
   private static final String GET_LOCK_FUNCTION = "pg_try_advisory_xact_lock";
+  private static final int INDEXERS_DELETION_LOCK_PREFIX_ID = "delete_marc_indexers".hashCode();
 
   private static final int DEFAULT_LIMIT_FOR_GET_RECORDS = 1;
   private static final String UNIQUE_VIOLATION_SQL_STATE = "23505";
@@ -1141,7 +1142,7 @@ public class RecordDaoImpl implements RecordDao {
 
   private Future<Boolean> acquireLock(ReactiveClassicGenericQueryExecutor txQE, String tenantId) {
     return txQE.findOneRow(dsl -> dsl.select(DSL.field("{0}", Boolean.class,
-      DSL.function(GET_LOCK_FUNCTION, SQLDataType.BOOLEAN, val(tenantId.hashCode()))))
+      DSL.function(GET_LOCK_FUNCTION, SQLDataType.BOOLEAN, val(INDEXERS_DELETION_LOCK_PREFIX_ID), val(tenantId.hashCode()))))
     ).map(row -> row.getBoolean(0));
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/AdvisoryLockUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/AdvisoryLockUtil.java
@@ -1,0 +1,33 @@
+package org.folio.dao.util;
+
+import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
+import io.vertx.core.Future;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+
+import static org.jooq.impl.DSL.val;
+
+public class AdvisoryLockUtil {
+
+  private static final String GET_LOCK_FUNCTION = "pg_try_advisory_xact_lock";
+
+  private AdvisoryLockUtil() {
+  }
+
+  /**
+   * Obtains a transactional level lock in the database by specified {@code key1} and {@code key2} keys
+   * using the passed transactional {@code queryExecutor}.
+   *
+   * @param queryExecutor query executor
+   * @param key1          first key for lock identification
+   * @param key2          second key for lock identification
+   * @return future with {@code true} if lock successfully obtained, otherwise {@code false}
+   * if the lock by specified keys is already obtained by another transaction.
+   */
+  public static Future<Boolean> acquireLock(ReactiveClassicGenericQueryExecutor queryExecutor, int key1, int key2) {
+    return queryExecutor.findOneRow(dsl -> dsl.select(DSL.field("{0}", Boolean.class,
+      DSL.function(GET_LOCK_FUNCTION, SQLDataType.BOOLEAN, val(key1), val(key2))))
+    ).map(row -> row.getBoolean(0));
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -11,6 +11,7 @@ import io.vertx.reactivex.FlowableHelper;
 import io.vertx.sqlclient.Row;
 import org.folio.TestMocks;
 import org.folio.TestUtil;
+import org.folio.dao.util.AdvisoryLockUtil;
 import org.folio.dao.util.MatchField;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.processing.value.StringValue;
@@ -26,8 +27,6 @@ import org.folio.services.util.TypeConnection;
 import org.folio.services.util.parser.ParseFieldsResult;
 import org.folio.services.util.parser.ParseLeaderResult;
 import org.folio.services.util.parser.SearchExpressionParser;
-import org.jooq.impl.DSL;
-import org.jooq.impl.SQLDataType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,11 +38,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.folio.dao.RecordDaoImpl.INDEXERS_DELETION_LOCK_PREFIX_ID;
+import static org.folio.dao.RecordDaoImpl.INDEXERS_DELETION_LOCK_NAMESPACE_ID;
 import static org.folio.rest.jaxrs.model.Record.State.ACTUAL;
 import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
 import static org.folio.rest.jooq.Tables.RECORDS_LB;
-import static org.jooq.impl.DSL.val;
 
 @RunWith(VertxUnitRunner.class)
 public class RecordDaoImplTest extends AbstractLBServiceTest {
@@ -146,11 +144,10 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
   public void shouldReturnFalseWhenPreviousIndexersDeletionIsInProgress(TestContext context) {
     Async async = context.async();
 
-    Future<Boolean> future = postgresClientFactory.getQueryExecutor(TENANT_ID).transaction(txQE -> txQE
-      .findOneRow(dsl -> dsl.select(DSL.field("{0}", Boolean.class, DSL.function("pg_try_advisory_xact_lock",
-        SQLDataType.BOOLEAN, val(INDEXERS_DELETION_LOCK_PREFIX_ID), val(TENANT_ID.hashCode())))))
-      .compose(v -> recordDao.deleteMarcIndexersOldVersions(TENANT_ID))
-    );
+    Future<Boolean> future = postgresClientFactory.getQueryExecutor(TENANT_ID)
+    // gets lock on DB in same way as deleteMarcIndexersOldVersions() method to model indexers deletion being in progress
+      .transaction(txQE -> AdvisoryLockUtil.acquireLock(txQE, INDEXERS_DELETION_LOCK_NAMESPACE_ID, TENANT_ID.hashCode())
+        .compose(v -> recordDao.deleteMarcIndexersOldVersions(TENANT_ID)));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -138,6 +138,20 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     });
   }
 
+  @Test
+  public void shouldReturnFalseWhenPreviousIndexersDeletionIsInProgress(TestContext context) {
+    Async async = context.async();
+
+    recordDao.deleteMarcIndexersOldVersions(TENANT_ID);
+    Future<Boolean> future = recordDao.deleteMarcIndexersOldVersions(TENANT_ID);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertFalse(ar.result());
+      async.complete();
+    });
+  }
+
   private Future<Boolean> deleteTrackingRecordById(String recordId) {
     return postgresClientFactory.getQueryExecutor(TENANT_ID).execute(dslContext -> dslContext
         .deleteFrom(MARC_RECORDS_TRACKING)


### PR DESCRIPTION
## Purpose
to prevent module instances from blocking each other while attempting to delete marc indexers on the same tenant


## Approach
* apply advisory lock for deletion marc indexers on certain tenant to prevent this deletion from being executed by multiple module instances for the same tenant at the same time


## Learning
[MODSOURCE-674](https://issues.folio.org/browse/MODSOURCE-674)