### PR TITLE
[MODSOURCE-530] Send DuplicateException if incoming file contains duplicate records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * [MODSOURCE-635](https://issues.folio.org/browse/MODSOURCE-635) Delete marc_indexers records associated with "OLD" source records
 * [MODSOURCE-636](https://issues.folio.org/browse/MODSOURCE-636) Implement async migration service
 * [MODSOURCE-674](https://issues.folio.org/browse/MODSOURCE-674) Ensure only one background job can be triggered to clean up outdated marc indexers
+* [MODSOURCE-530](https://issues.folio.org/browse/MODSOURCE-530) Fix duplicate records in incoming file causes problems after overlay process with no error reported
 
 ### Asynchronous migration job API
 | METHOD | URL                                     | DESCRIPTION                                     |

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -480,6 +480,8 @@ public class RecordDaoImpl implements RecordDao {
       recordCollection.getRecords()
         .stream()
         .map(RecordDaoUtil::ensureRecordHasId)
+        .map(RecordDaoUtil::ensureRecordHasMatchedId)
+        .map(RecordDaoUtil::ensureRecordHasGeneration)
         .map(RecordDaoUtil::ensureRecordHasSuppressDiscovery)
         .map(RecordDaoUtil::ensureRecordForeignKeys)
         .forEach(record -> {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -481,7 +481,6 @@ public class RecordDaoImpl implements RecordDao {
         .stream()
         .map(RecordDaoUtil::ensureRecordHasId)
         .map(RecordDaoUtil::ensureRecordHasMatchedId)
-        .map(RecordDaoUtil::ensureRecordHasGeneration)
         .map(RecordDaoUtil::ensureRecordHasSuppressDiscovery)
         .map(RecordDaoUtil::ensureRecordForeignKeys)
         .forEach(record -> {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
@@ -7,7 +7,7 @@ public enum IdType {
   AUTHORITY("authorityId"),
   EXTERNAL("externalId"),
   // NOTE: not really external id but is default from dto
-  RECORD("matchedId");
+  RECORD("id");
 
   private final String idField;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/IdType.java
@@ -7,7 +7,7 @@ public enum IdType {
   AUTHORITY("authorityId"),
   EXTERNAL("externalId"),
   // NOTE: not really external id but is default from dto
-  RECORD("id");
+  RECORD("matchedId");
 
   private final String idField;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -350,6 +350,17 @@ public final class RecordDaoUtil {
     return null;
   }
 
+  public static IdType getExternalIdType(Record.RecordType recordType) {
+    if (Record.RecordType.MARC_BIB == recordType) {
+      return IdType.INSTANCE;
+    } else if (Record.RecordType.MARC_HOLDING == recordType) {
+      return IdType.HOLDINGS;
+    } else if (Record.RecordType.MARC_AUTHORITY == recordType) {
+      return IdType.AUTHORITY;
+    }
+    return null;
+  }
+
   public static String getExternalHrid(ExternalIdsHolder externalIdsHolder, Record.RecordType recordType) {
     if (Objects.isNull(externalIdsHolder)) {
       return null;

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -185,13 +185,6 @@ public final class RecordDaoUtil {
     return record;
   }
 
-  public static Record ensureRecordHasGeneration(Record record) {
-    if (Objects.isNull(record.getGeneration())) {
-      record.setGeneration(0);
-    }
-    return record;
-  }
-
   /**
    * Make sure record has additional info suppress discovery.
    *

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -173,6 +173,26 @@ public final class RecordDaoUtil {
   }
 
   /**
+   * Make sure record has matched id.
+   *
+   * @param record record
+   * @return record with matched id
+   */
+  public static Record ensureRecordHasMatchedId(Record record) {
+    if (Objects.isNull(record.getMatchedId())) {
+      record.setMatchedId(UUID.randomUUID().toString());
+    }
+    return record;
+  }
+
+  public static Record ensureRecordHasGeneration(Record record) {
+    if (Objects.isNull(record.getGeneration())) {
+      record.setGeneration(0);
+    }
+    return record;
+  }
+
+  /**
    * Make sure record has additional info suppress discovery.
    *
    * @param record record

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -90,6 +90,9 @@ public class RecordServiceImpl implements RecordService {
 
     recordTypeToActualSourceRecord.put(Record.RecordType.MARC_AUTHORITY,
       (record, tenantId) -> recordDao.getSourceRecordByExternalId(record.getExternalIdsHolder().getAuthorityId(), IdType.AUTHORITY, RecordState.ACTUAL, tenantId));
+
+    recordTypeToActualSourceRecord.put(Record.RecordType.EDIFACT,
+      (record, tenantId) -> Future.succeededFuture(Optional.empty()));
   }
 
   @Override
@@ -289,7 +292,7 @@ public class RecordServiceImpl implements RecordService {
       return Future.succeededFuture(record.withMatchedId(marcField999s));
     }
     Promise<Record> promise = Promise.promise();
-    if (record.getExternalIdsHolder() != null && record.getRecordType() != null) {
+    if (record.getExternalIdsHolder() != null && record.getState() != Record.State.OLD) {
       recordTypeToActualSourceRecord.get(record.getRecordType()).apply(record, tenantId)
         .onComplete((ar) -> {
           if (ar.succeeded()) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -278,6 +278,7 @@ public class RecordServiceImpl implements RecordService {
   private Future<Record> setMatchedIdForRecord(Record record, String tenantId) {
     String marcField999s = getFieldFromMarcRecord(record, TAG_999, INDICATOR, INDICATOR, SUBFIELD_S);
     if (marcField999s != null) {
+      // Set matched id from 999$s marc field
       LOG.debug(format("setMatchedIdForRecord:: Set matchedId: %s from 999$s field for record with id: %s", marcField999s, record.getId()));
       return Future.succeededFuture(record.withMatchedId(marcField999s));
     }
@@ -291,11 +292,13 @@ public class RecordServiceImpl implements RecordService {
           if (ar.succeeded()) {
             Optional<SourceRecord> sourceRecord = ar.result();
             if (sourceRecord.isPresent()) {
+              // Set matched id from existing source record
               String sourceRecordId = sourceRecord.get().getRecordId();
               LOG.debug(format("setMatchedIdForRecord:: Set matchedId: %s from source record for record with id: %s",
                 sourceRecordId, record.getId()));
               promise.complete(record.withMatchedId(sourceRecordId));
             } else {
+              // Set matched id same as record id
               LOG.debug(format("setMatchedIdForRecord:: Set matchedId same as record id: %s", record.getId()));
               promise.complete(record.withMatchedId(record.getId()));
             }
@@ -305,6 +308,7 @@ public class RecordServiceImpl implements RecordService {
           }
         });
     } else {
+      // Set matched id same as record id
       promise.complete(record.withMatchedId(record.getId()));
     }
     return promise.future().onSuccess(r -> addFieldToMarcRecord(r, TAG_999, SUBFIELD_S, r.getMatchedId()));

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -103,6 +103,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
         })
         .onFailure(throwable -> {
           LOG.warn(FAIL_MSG, eventType, throwable);
+          dataImportEventPayload.setEventType(getNextEventType(dataImportEventPayload));
           future.completeExceptionally(throwable);
         });
     } catch (Exception e) {
@@ -123,6 +124,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
   }
 
   protected abstract void sendAdditionalEvent(DataImportEventPayload dataImportEventPayload, Record record);
+  protected abstract String getNextEventType(DataImportEventPayload dataImportEventPayload);
 
   protected String getEventKey() {
     return String.valueOf(indexer.incrementAndGet() % 100);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
@@ -2,12 +2,8 @@ package org.folio.services.handlers;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_UPDATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.services.util.AdditionalFieldsUtil.HR_ID_FROM_FIELD;
 import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AuthorityPostProcessingEventHandler.java
@@ -2,8 +2,12 @@ package org.folio.services.handlers;
 
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_AUTHORITY_RECORD_UPDATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_CREATED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.services.util.AdditionalFieldsUtil.HR_ID_FROM_FIELD;
 import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
 
@@ -48,6 +52,18 @@ public class AuthorityPostProcessingEventHandler extends AbstractPostProcessingE
         sendLogEvent(dataImportEventPayload, DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED, key, kafkaHeaders);
       }
     }
+  }
+
+  @Override
+  protected String getNextEventType(DataImportEventPayload dataImportEventPayload) {
+    var eventType = dataImportEventPayload.getEventType();
+    if (DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING.value().equals(eventType)) {
+      return DI_LOG_SRS_MARC_AUTHORITY_RECORD_CREATED.value();
+    }
+    if (DI_INVENTORY_AUTHORITY_UPDATED_READY_FOR_POST_PROCESSING.value().equals(eventType)) {
+      return DI_LOG_SRS_MARC_AUTHORITY_RECORD_UPDATED.value();
+    }
+    return eventType;
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/HoldingsPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/HoldingsPostProcessingEventHandler.java
@@ -30,6 +30,11 @@ public class HoldingsPostProcessingEventHandler extends AbstractPostProcessingEv
   }
 
   @Override
+  protected String getNextEventType(DataImportEventPayload dataImportEventPayload) {
+    return dataImportEventPayload.getEventType();
+  }
+
+  @Override
   protected DataImportEventTypes replyEventType() {
     return DI_SRS_MARC_HOLDINGS_HOLDING_HRID_SET;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/InstancePostProcessingEventHandler.java
@@ -47,6 +47,18 @@ public class InstancePostProcessingEventHandler extends AbstractPostProcessingEv
     sendEventToDataImportLog(dataImportEventPayload, record);
   }
 
+  @Override
+  protected String getNextEventType(DataImportEventPayload dataImportEventPayload) {
+    var eventType = dataImportEventPayload.getEventType();
+    if (DI_INVENTORY_INSTANCE_CREATED_READY_FOR_POST_PROCESSING.value().equals(eventType)) {
+      return  DI_LOG_SRS_MARC_BIB_RECORD_CREATED.value();
+    }
+    if (DI_INVENTORY_INSTANCE_UPDATED_READY_FOR_POST_PROCESSING.value().equals(eventType)) {
+      return DI_LOG_SRS_MARC_BIB_RECORD_UPDATED.value();
+    }
+    return eventType;
+  }
+
   protected DataImportEventTypes replyEventType() {
     return DI_SRS_MARC_BIB_INSTANCE_HRID_SET;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -604,7 +604,9 @@ public final class AdditionalFieldsUtil {
           if (reader.hasNext()) {
             return reader.next();
           }
-        } catch (Exception ignored) {}
+        } catch (Exception ex) {
+          LOGGER.warn("computeMarcRecord:: Error during the building of MarcReader", ex);
+        }
         return null;
       }
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -101,8 +101,7 @@ public final class AdditionalFieldsUtil {
             Context context = Vertx.currentContext();
             if (context != null) {
               context.runOnContext(ar -> serviceExecutor.run());
-            }
-            else {
+            } else {
               // The common pool below is used because it is the  default executor for caffeine
               ForkJoinPool.commonPool().execute(serviceExecutor);
             }
@@ -170,12 +169,16 @@ public final class AdditionalFieldsUtil {
   }
 
   public static String getFieldFromMarcRecord(Record record, String field, char ind1, char ind2, char subfield) {
-    List<VariableField> variableFields = computeMarcRecord(record).getVariableFields(field);
-    Optional<DataField> dataField = variableFields.stream().filter(v -> v instanceof DataField)
-      .map(v -> (DataField) v)
-      .filter(v -> ind1 == v.getIndicator1() && ind2 == v.getIndicator2())
-      .findFirst();
-    return dataField.map(value -> value.getSubfieldsAsString(String.valueOf(subfield))).orElse(null);
+    org.marc4j.marc.Record marcRecord = computeMarcRecord(record);
+    if (marcRecord != null) {
+      List<VariableField> variableFields = marcRecord.getVariableFields(field);
+      Optional<DataField> dataField = variableFields.stream().filter(v -> v instanceof DataField)
+        .map(v -> (DataField) v)
+        .filter(v -> ind1 == v.getIndicator1() && ind2 == v.getIndicator2())
+        .findFirst();
+      return dataField.map(value -> value.getSubfieldsAsString(String.valueOf(subfield))).orElse(null);
+    }
+    return null;
   }
 
   /**
@@ -517,7 +520,7 @@ public final class AdditionalFieldsUtil {
    * @param actualHrId - actual HrId
    */
   public static void remove035WithActualHrId(Record record, String actualHrId) {
-      removeField(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId);
+    removeField(record, HR_ID_TO_FIELD, HR_ID_FIELD_SUB, actualHrId);
   }
 
   /**
@@ -596,10 +599,12 @@ public final class AdditionalFieldsUtil {
         return parsedRecordContentCache.get(content);
       } catch (Exception e) {
         LOGGER.warn("computeMarcRecord:: Error during the transformation to marc record", e);
-        MarcReader reader = buildMarcReader(record);
-        if (reader.hasNext()) {
-          return reader.next();
-        }
+        try {
+          MarcReader reader = buildMarcReader(record);
+          if (reader.hasNext()) {
+            return reader.next();
+          }
+        } catch (Exception ignored) {}
         return null;
       }
     }
@@ -615,7 +620,7 @@ public final class AdditionalFieldsUtil {
   /**
    * Check if any field with the subfield code exists.
    *
-   * @param sourceRecord  - source record.
+   * @param sourceRecord - source record.
    * @param subFieldCode - subfield code.
    * @return true if exists, otherwise false.
    */

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -169,6 +169,15 @@ public final class AdditionalFieldsUtil {
     return result;
   }
 
+  public static String getFieldFromMarcRecord(Record record, String field, char ind1, char ind2, char subfield) {
+    List<VariableField> variableFields = computeMarcRecord(record).getVariableFields(field);
+    Optional<DataField> dataField = variableFields.stream().filter(v -> v instanceof DataField)
+      .map(v -> (DataField) v)
+      .filter(v -> ind1 == v.getIndicator1() && ind2 == v.getIndicator2())
+      .findFirst();
+    return dataField.map(value -> value.getSubfieldsAsString(String.valueOf(subfield))).orElse(null);
+  }
+
   /**
    * Adds new controlled field to marc record
    *

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -37,6 +37,7 @@ import org.junit.Rule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.UUID;
 
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
@@ -71,6 +72,7 @@ public abstract class AbstractRestVerticleTest {
   private static final String OKAPI_URL_ENV = "OKAPI_URL";
   private static final int PORT = NetworkUtils.nextFreePort();
   protected static final String OKAPI_URL = "http://localhost:" + PORT;
+  private static final String MAX_POOL_SIZE = "50";
 
   static Vertx vertx;
   static RequestSpecification spec;
@@ -126,13 +128,16 @@ public abstract class AbstractRestVerticleTest {
         postgresSQLContainer = new PostgreSQLContainer<>(POSTGRES_IMAGE);
         postgresSQLContainer.start();
 
-        Envs.setEnv(
-          postgresSQLContainer.getHost(),
-          postgresSQLContainer.getFirstMappedPort(),
-          postgresSQLContainer.getUsername(),
-          postgresSQLContainer.getPassword(),
-          postgresSQLContainer.getDatabaseName()
-        );
+        HashMap<String, String> envs = new HashMap<>();
+        envs.put(Envs.DB_HOST.toString(), postgresSQLContainer.getHost());
+        envs.put(Envs.DB_PORT.toString(), String.valueOf(postgresSQLContainer.getFirstMappedPort()));
+        envs.put(Envs.DB_USERNAME.toString(), postgresSQLContainer.getUsername());
+        envs.put(Envs.DB_PASSWORD.toString(), postgresSQLContainer.getPassword());
+        envs.put(Envs.DB_DATABASE.toString(), postgresSQLContainer.getDatabaseName());
+        envs.put(Envs.DB_MAXPOOLSIZE.toString(), MAX_POOL_SIZE);
+
+        Envs.setEnv(envs);
+
         break;
       default:
         String message = "No understood database choice made." +

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
@@ -191,13 +191,15 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_CREATED);
 
+    ExternalIdsHolder externalIdsHolder = new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString());
     Record record1 = new Record()
       .withId(matchedId)
       .withSnapshotId(snapshot_1.getJobExecutionId())
       .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(marcRecord)
-      .withMatchedId(matchedId);
+      .withMatchedId(matchedId)
+      .withExternalIdsHolder(externalIdsHolder);
 
     Record created1 = RestAssured.given()
       .spec(spec)
@@ -234,7 +236,8 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(marcRecord)
-      .withMatchedId(matchedId);
+      .withMatchedId(matchedId)
+      .withExternalIdsHolder(externalIdsHolder);
 
     Record created2 = RestAssured.given()
       .spec(spec)
@@ -372,7 +375,10 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
     ParsedRecord parsedRecord = new ParsedRecord().withId(srsId)
       .withContent(new JsonObject().put("leader", "01542ccm a2200361   4500")
         .put("fields", new JsonArray().add(new JsonObject().put("999", new JsonObject()
-          .put("subfields", new JsonArray().add(new JsonObject().put("s", srsId)))))));
+          .put("subfields",
+            new JsonArray().add(new JsonObject().put("s", srsId)))
+          .put("ind1", "f")
+          .put("ind2", "f")))).encode());
 
     Record newRecord = new Record()
       .withId(srsId)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -868,7 +868,9 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withContent(new JsonObject().put("leader", "01542dcm a2200361   4500")
         .put("fields", new JsonArray().add(new JsonObject().put("999", new JsonObject()
           .put("subfields",
-            new JsonArray().add(new JsonObject().put("s", firstSrsId)).add(new JsonObject().put("i", firstInstanceId)))))));
+            new JsonArray().add(new JsonObject().put("s", firstSrsId)).add(new JsonObject().put("i", firstInstanceId)))
+          .put("ind1", "f")
+          .put("ind2", "f")))));
 
     Record deleted_record_1 = new Record()
       .withId(firstSrsId)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -870,7 +870,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
           .put("subfields",
             new JsonArray().add(new JsonObject().put("s", firstSrsId)).add(new JsonObject().put("i", firstInstanceId)))
           .put("ind1", "f")
-          .put("ind2", "f")))));
+          .put("ind2", "f")))).encode());
 
     Record deleted_record_1 = new Record()
       .withId(firstSrsId)
@@ -916,7 +916,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD&deleted=false")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(3))
+      .body("sourceRecords.size()", is(4))
       .body("totalRecords", is(4))
       .body("sourceRecords*.deleted", everyItem(is(false)));
     async.complete();
@@ -929,7 +929,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD&deleted=true")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(4))
+      .body("sourceRecords.size()", is(5))
       .body("totalRecords", is(5));
     async.complete();
 
@@ -946,7 +946,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=INSTANCE&deleted=false")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(3))
+      .body("sourceRecords.size()", is(4))
       .body("totalRecords", is(4))
       .body("sourceRecords*.deleted", everyItem(is(false)));
     async.complete();
@@ -959,7 +959,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=INSTANCE&deleted=true")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(4))
+      .body("sourceRecords.size()", is(5))
       .body("totalRecords", is(5));
     async.complete();
 
@@ -971,7 +971,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(3))
+      .body("sourceRecords.size()", is(4))
       .body("totalRecords", is(4));
     async.complete();
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -132,7 +132,10 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withRawRecord(rawRecord)
       .withMatchedId(FIRST_UUID)
       .withOrder(0)
-      .withState(Record.State.ACTUAL);
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId(UUID.randomUUID().toString())
+        .withInstanceHrid("12345"));
     record_2 = new Record()
       .withId(SECOND_UUID)
       .withSnapshotId(snapshot_2.getJobExecutionId())
@@ -152,7 +155,10 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withRawRecord(rawRecord)
       .withErrorRecord(errorRecord)
       .withMatchedId(THIRD_UUID)
-      .withState(Record.State.ACTUAL);
+      .withState(Record.State.ACTUAL)
+      .withExternalIdsHolder(new ExternalIdsHolder()
+        .withInstanceId(UUID.randomUUID().toString())
+        .withInstanceHrid("12345"));
     record_4 = new Record()
       .withId(FOURTH_UUID)
       .withSnapshotId(snapshot_1.getJobExecutionId())
@@ -205,8 +211,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withOrder(0)
       .withState(Record.State.ACTUAL)
       .withExternalIdsHolder(new ExternalIdsHolder()
-        .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid("12345"));
+        .withAuthorityId(UUID.randomUUID().toString())
+        .withAuthorityHrid("12345"));
     record_9 = new Record()
       .withId(NINTH_UUID)
       .withSnapshotId(snapshot_5.getJobExecutionId())
@@ -217,8 +223,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withOrder(0)
       .withState(Record.State.ACTUAL)
       .withExternalIdsHolder(new ExternalIdsHolder()
-        .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid("12345"));
+        .withHoldingsId(UUID.randomUUID().toString())
+        .withHoldingsHrid("12345"));
   }
 
   @Before
@@ -1577,7 +1583,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(THIRD_UUID)
       .withOrder(11)
       .withState(Record.State.ACTUAL);
-    setExternalIds(record, recordType, SECOND_UUID, secondHrid);
+    setExternalIds(record, recordType, FOURTH_UUID, secondHrid);
 
     RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
@@ -769,13 +769,20 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
     postSnapshots(testContext, snapshot_2);
 
     String matchedId = UUID.randomUUID().toString();
+    JsonObject parsedContent = new JsonObject((String) marcRecord.getContent());
+    parsedContent.getJsonArray("fields").add(new JsonObject().put("999", new JsonObject()
+      .put("subfields",
+        new JsonArray().add(new JsonObject().put("s", matchedId)))
+      .put("ind1", "f")
+      .put("ind2", "f")));
+    ParsedRecord parsedRecord = new ParsedRecord().withContent(parsedContent.encode());
 
     Record newRecord = new Record()
       .withId(matchedId)
       .withSnapshotId(snapshot_2.getJobExecutionId())
       .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
-      .withParsedRecord(marcRecord)
+      .withParsedRecord(parsedRecord)
       .withMatchedId(matchedId)
       .withState(Record.State.ACTUAL)
       .withAdditionalInfo(

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -471,7 +471,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .withMatchedId(THIRD_UUID)
       .withOrder(11)
       .withState(Record.State.ACTUAL)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(SECOND_UUID).withInstanceHrid(secondHrid));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(FOURTH_UUID).withInstanceHrid(secondHrid));
 
     RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -164,8 +164,8 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withOrder(101)
     .withState(Record.State.ACTUAL)
     .withExternalIdsHolder(new ExternalIdsHolder()
-      .withInstanceId(UUID.randomUUID().toString())
-      .withInstanceHrid("12345"));
+      .withAuthorityId(UUID.randomUUID().toString())
+      .withAuthorityHrid("12345"));
   private static Record marc_holdings_record_1 = new Record()
     .withId(EIGHTH_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
@@ -176,8 +176,8 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withOrder(101)
     .withState(Record.State.ACTUAL)
     .withExternalIdsHolder(new ExternalIdsHolder()
-      .withInstanceId(UUID.randomUUID().toString())
-      .withInstanceHrid("12345"));
+      .withHoldingsId(UUID.randomUUID().toString())
+      .withHoldingsHrid("12345"));
 
   @Before
   public void setUp(TestContext context) {
@@ -938,7 +938,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       "and 005.03_02 = '41' " +
       "and 005.date in '20120101-20190101' " +
       "and 035.value is 'present' " +
-      "and 999.value is 'absent' " +
+      "and 999.value is 'present' " +
       "and 041.g is 'present' " +
       "and 041.z is 'absent' " +
       "and 050.ind1 is 'present' " +

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
@@ -13,6 +13,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -78,7 +79,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
   private static final String MATCHED_MARC_BIB_KEY = "MATCHED_MARC_AUTHORITY";
   private static final String USER_ID_HEADER = "userId";
 
-  private static String recordId = UUID.randomUUID().toString();
+  private static String recordId = "eae222e8-70fd-4422-852c-60d22bae36b8";
   private static String userId = UUID.randomUUID().toString();
   private static RawRecord rawRecord;
   private static ParsedRecord parsedRecord;
@@ -200,7 +201,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     // given
     Async async = context.async();
 
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     payloadContext.put(MARC_AUTHORITY.value(), Json.encode(record));
@@ -232,7 +233,8 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
       async.complete();
@@ -245,7 +247,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -278,7 +280,8 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
       async.complete();
@@ -291,7 +294,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -324,7 +327,8 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       async.complete();
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -97,7 +97,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       "{\"100\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Chin, Staceyann Test,\"},{\"e\":\"author.\"},{\"0\":\"http://id.loc.gov/authorities/names/n2008052404\"},{\"9\":\"5a56ffa8-e274-40ca-8620-34a23b5b45dd\"}]}}]}";
   private static final String instanceId = UUID.randomUUID().toString();
   private static final ObjectMapper mapper = new ObjectMapper();
-  private static final String recordId = UUID.randomUUID().toString();
+  private static final String recordId = "eae222e8-70fd-4422-852c-60d22bae36b8";
   private static final String userId = UUID.randomUUID().toString();
   private static RawRecord rawRecord;
   private static ParsedRecord parsedRecord;
@@ -245,7 +245,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     Async async = context.async();
 
     String expectedParsedContent =
-      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(record));
@@ -278,7 +278,8 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
 
       Record actualRecord =
         Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
       async.complete();
@@ -293,7 +294,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     String incomingParsedContent =
       "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent =
-      "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+      "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     var instanceId = UUID.randomUUID().toString();
     Record incomingRecord = new Record()
       .withParsedRecord(new ParsedRecord().withContent(incomingParsedContent))
@@ -330,7 +331,8 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
 
       Record actualRecord =
         Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
       async.complete();
@@ -701,7 +703,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     String incomingParsedContent =
       "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent =
-      "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+      "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     var instanceId = UUID.randomUUID().toString();
     Record incomingRecord = new Record()
       .withParsedRecord(new ParsedRecord().withContent(incomingParsedContent))
@@ -754,7 +756,8 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
 
       Record actualRecord =
         Json.decodeValue(dataImportEventPayloadOriginalRecord.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayloadOriginalRecord.getJobExecutionId(), actualRecord.getSnapshotId());
     });
@@ -880,5 +883,10 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     } catch (JsonProcessingException e) {
       context.fail(e);
     }
+  }
+  public static String getParsedContentWithoutLeader(String parsedContent) {
+    JsonObject parsedContentAsJson = new JsonObject(parsedContent);
+    parsedContentAsJson.remove("leader");
+    return parsedContentAsJson.encode();
   }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -76,7 +77,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
   private static final String MATCHED_MARC_BIB_KEY = "MATCHED_MARC_HOLDINGS";
   private static final String USER_ID_HEADER = "userId";
 
-  private static String recordId = UUID.randomUUID().toString();
+  private static String recordId = "eae222e8-70fd-4422-852c-60d22bae36b8";
   private static String userId = UUID.randomUUID().toString();
   private static RawRecord rawRecord;
   private static ParsedRecord parsedRecord;
@@ -198,7 +199,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     // given
     Async async = context.async();
 
-    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     payloadContext.put(MARC_HOLDINGS.value(), Json.encode(record));
@@ -230,7 +231,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent), getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
       async.complete();
@@ -243,7 +244,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -276,7 +277,8 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
       async.complete();
@@ -289,7 +291,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     Async async = context.async();
 
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -322,7 +324,8 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
+        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       async.complete();
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
@@ -140,7 +140,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
       if (ar.failed()) {
         context.fail(ar.cause());
       }
-      recordService.getSourceRecordById(record.getMatchedId(), IdType.RECORD, RecordState.ACTUAL, TENANT_ID).onComplete(getNew -> {
+      recordService.getSourceRecordById(record.getId(), IdType.RECORD, RecordState.ACTUAL, TENANT_ID).onComplete(getNew -> {
         if (getNew.failed()) {
           context.fail(getNew.cause());
         }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -5,6 +5,7 @@ import io.reactivex.Flowable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -338,8 +339,15 @@ public class RecordServiceTest extends AbstractLBServiceTest {
 
   @Test
   public void shouldSaveMarcBibRecordWithMatchedIdFrom999field(TestContext context) {
-    String marc999 = "e567b8e2-a45b-45f1-a85a-6b6312bdf4d8";
+    String marc999 = UUID.randomUUID().toString();
     Record original = TestMocks.getMarcBibRecord();
+    ParsedRecord parsedRecord = new ParsedRecord().withId(marc999)
+      .withContent(new JsonObject().put("leader", "01542ccm a2200361   4500")
+        .put("fields", new JsonArray().add(new JsonObject().put("999", new JsonObject()
+          .put("subfields",
+            new JsonArray().add(new JsonObject().put("s", marc999)))
+          .put("ind1", "f")
+          .put("ind2", "f")))).encode());
     Record record = new Record()
       .withId(UUID.randomUUID().toString())
       .withSnapshotId(original.getSnapshotId())
@@ -347,9 +355,9 @@ public class RecordServiceTest extends AbstractLBServiceTest {
       .withState(State.ACTUAL)
       .withOrder(original.getOrder())
       .withRawRecord(original.getRawRecord())
-      .withParsedRecord(original.getParsedRecord())
+      .withParsedRecord(parsedRecord)
       .withAdditionalInfo(original.getAdditionalInfo())
-      .withExternalIdsHolder(original.getExternalIdsHolder())
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()))
       .withMetadata(original.getMetadata());
     Async async = context.async();
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/RecordServiceTest.java
@@ -344,9 +344,10 @@ public class RecordServiceTest extends AbstractLBServiceTest {
   public void shouldFailToSaveRecord(TestContext context) {
     Async async = context.async();
     Record valid = TestMocks.getRecord(0);
+    String fakeSnapshotId = "fakeId";
     Record invalid = new Record()
       .withId(valid.getId())
-      .withSnapshotId(valid.getSnapshotId())
+      .withSnapshotId(fakeSnapshotId)
       .withRecordType(valid.getRecordType())
       .withState(valid.getState())
       .withGeneration(valid.getGeneration())
@@ -358,7 +359,7 @@ public class RecordServiceTest extends AbstractLBServiceTest {
       .withMetadata(valid.getMetadata());
     recordService.saveRecord(invalid, TENANT_ID).onComplete(save -> {
       context.assertTrue(save.failed());
-      String expected = "null value in column \"matched_id\" violates not-null constraint";
+      String expected = "Invalid UUID string: " + fakeSnapshotId;
       context.assertTrue(save.cause().getMessage().contains(expected));
       async.complete();
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
@@ -96,7 +96,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
       if (e != null) {
         context.fail(e);
       }
-      recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -143,7 +143,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
           if (ex != null) {
             context.fail(ex);
           }
-          recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(recordAr -> {
+          recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(recordAr -> {
             if (recordAr.failed()) {
               context.fail(recordAr.cause());
             }
@@ -175,9 +175,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_AUTHORITY)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -199,7 +197,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
       if (e != null) {
         context.fail(e);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -293,9 +291,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_AUTHORITY)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -317,7 +313,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -358,9 +354,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_AUTHORITY)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -384,7 +378,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
@@ -93,7 +93,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
       if (e != null) {
         context.fail(e);
       }
-      recordDao.getRecordByMatchedId(record.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -133,9 +133,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_HOLDING)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -158,7 +156,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
       if (e != null) {
         context.fail(e);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -251,9 +249,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_HOLDING)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -276,7 +272,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -317,9 +313,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_HOLDING)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -345,7 +339,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -177,9 +177,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -202,7 +200,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
       if (e != null) {
         context.fail(e);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -244,12 +242,13 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
     Record incomingRecord = new Record()
       .withRawRecord(rawRecord)
       .withId(recordId)
-      .withMatchedId(existingRecord.getMatchedId())
       .withSnapshotId(snapshotId2)
       .withRecordType(MARC_BIB)
       .withParsedRecord(parsedRecord);
 
     JsonObject instanceJson = createExternalEntity(UUID.randomUUID().toString(), "in001");
+    existingRecord.getExternalIdsHolder().setInstanceId(instanceJson.getString("id"));
+    existingRecord.getExternalIdsHolder().setInstanceHrid(instanceJson.getString("hrid"));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(INSTANCE.value(), instanceJson.encode());
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
@@ -296,12 +295,13 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
     Record incomingRecord = new Record()
       .withRawRecord(rawRecord)
       .withId(recordId)
-      .withMatchedId(existingRecord.getMatchedId())
       .withSnapshotId(snapshotId2)
       .withRecordType(MARC_BIB)
       .withParsedRecord(parsedRecord);
 
     JsonObject instanceJson = createExternalEntity(UUID.randomUUID().toString(), "in00000000040");
+    existingRecord.getExternalIdsHolder().setInstanceId(instanceJson.getString("id"));
+    existingRecord.getExternalIdsHolder().setInstanceHrid(instanceJson.getString("hrid"));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(INSTANCE.value(), instanceJson.encode());
     payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
@@ -405,9 +405,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -430,7 +428,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }
@@ -471,9 +469,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
 
     Record defaultRecord = new Record()
       .withId(recordId)
-      .withMatchedId(recordId)
       .withSnapshotId(snapshotId1)
-      .withGeneration(0)
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord);
@@ -498,7 +494,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
       if (throwable != null) {
         context.fail(throwable);
       }
-      recordDao.getRecordByMatchedId(defaultRecord.getMatchedId(), TENANT_ID).onComplete(getAr -> {
+      recordDao.getRecordByMatchedId(recordId, TENANT_ID).onComplete(getAr -> {
         if (getAr.failed()) {
           context.fail(getAr.cause());
         }

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -3,6 +3,7 @@ package org.folio.verticle.consumers;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -85,7 +86,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
   private static final String CHUNK_ID_HEADER = "chunkId";
 
   private final String snapshotId = UUID.randomUUID().toString();
-  private final String recordId = UUID.randomUUID().toString();
+  private final String recordId = "eae222e8-70fd-4422-852c-60d22bae36b8";
 
   private final MarcMappingDetail marcMappingDetail = new MarcMappingDetail()
     .withOrder(0)
@@ -173,7 +174,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .willReturn(WireMock.ok().withBody(Json.encode(profileSnapshotWrapper))));
 
     String expectedParsedContent =
-      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
@@ -212,7 +213,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
 
     Record actualRecord =
       Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-    assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+    assertEquals(getParsedContentWithoutLeader(expectedParsedContent), getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
     assertEquals(Record.State.ACTUAL, actualRecord.getState());
     assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
     assertNotNull(observedRecords.get(0).getHeaders().lastHeader(RECORD_ID_HEADER));

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -86,7 +86,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
   private static final String CHUNK_ID_HEADER = "chunkId";
 
   private final String snapshotId = UUID.randomUUID().toString();
-  private final String recordId = "eae222e8-70fd-4422-852c-60d22bae36b8";
+  private final String recordId = UUID.randomUUID().toString();
 
   private final MarcMappingDetail marcMappingDetail = new MarcMappingDetail()
     .withOrder(0)
@@ -134,7 +134,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withAuthorityId(UUID.randomUUID().toString()));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()));
 
     ReactiveClassicGenericQueryExecutor queryExecutor = postgresClientFactory.getQueryExecutor(TENANT_ID);
     RecordDaoImpl recordDao = new RecordDaoImpl(postgresClientFactory);
@@ -174,7 +174,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .willReturn(WireMock.ok().withBody(Json.encode(profileSnapshotWrapper))));
 
     String expectedParsedContent =
-      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
+      "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())


### PR DESCRIPTION
## Purpose
Duplicate records in incoming file causes problems after overlay process with no error reported

## Approach
Changed a way of assigning matched id, now it generated during save record process, matched id is retrieved from 999$s field, in case if the parsed record does not contain this field, assigning id of exiting source record with a same external id

