### PR TITLE
MODSOURCE-692 - Test adding default value for version column in marc_indexers

### DIFF
--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -68,5 +68,6 @@
   <include file="scripts/v-5.7.0/2023-04-13--16-00-update-fill-in-trigger.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.7.0/2023-08-29--16-00-define-version-column-default-value.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-08-29--16-00-define-version-column-default-value.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-08-29--16-00-define-version-column-default-value.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+  <changeSet id="2023-08-29--16-00-define-version-column-default-value" author="RuslanLavrov">
+    <dropColumn tableName="marc_indexers">
+      <column name="version"/>
+    </dropColumn>
+    <addColumn tableName="marc_indexers">
+      <column name="version" type="integer" defaultValue="0"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
to replace leverage of migration script for marc_indexers version update by default value column option for marc_indexers "version" column since the script execution takes a lot of time


## Approach
* add migration script to recreate `marc_indexers.version` column specifying default value as 0


## Learning
[MODSOURCE-684](https://issues.folio.org/browse/MODSOURCE-684)