### PR TITLE
MODSOURCE-667 Upgrade folio-kafka-wrapper to 3.0.0 version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURCE-530](https://issues.folio.org/browse/MODSOURCE-530) Fix duplicate records in incoming file causes problems after overlay process with no error reported
 * [MODSOURCE-690](https://issues.folio.org/browse/MODSOURCE-690) Make changes in SRS post processing handler to update MARC for shared Instance
 * [MODSOURCE-646](https://issues.folio.org/browse/MODSOURCE-646) Make changes to perform MARC To MARC Matching in Local Tenant & Central Tenant
+* [MODSOURCE-667](https://issues.folio.org/browse/MODSOURCE-667) Upgrade folio-kafka-wrapper to 3.0.0 version
 
 ### Asynchronous migration job API
 | METHOD | URL                                     | DESCRIPTION                                     |


### PR DESCRIPTION
## Purpose
Upgrade folio-kafka-wrapper to 3.0.0 version
## Approach
Upgrade the version of folio-kafka-wrapper to 3.0.0 (first, update to latest SNAPSHOT version for testing, then to v3.0.0 after release). Check out the readme at https://github.com/folio-org/folio-kafka-wrapper/blob/master/README.md for usage.

Acceptance Criteria
- kafka records are built using KafkaProducerRecordBuilder
- topic names are generated using KafkaTopicNameHelper
