### PR TITLE
MODSOURCE-666: Create script to clean up records with inconsistent matched id values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * [MODSOURCE-690](https://issues.folio.org/browse/MODSOURCE-690) Make changes in SRS post processing handler to update MARC for shared Instance
 * [MODSOURCE-646](https://issues.folio.org/browse/MODSOURCE-646) Make changes to perform MARC To MARC Matching in Local Tenant & Central Tenant
 * [MODSOURCE-667](https://issues.folio.org/browse/MODSOURCE-667) Upgrade folio-kafka-wrapper to 3.0.0 version
+* [MODSOURCE-666](https://issues.folio.org/browse/MODSOURCE-666) Create script to clean up records with inconsistent matched id values
 
 ### Asynchronous migration job API
 | METHOD | URL                                     | DESCRIPTION                                     |

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -69,5 +69,6 @@
   <include file="scripts/v-5.7.0/2023-05-22--16-00-create-records-state-index.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.7.0/2023-05-31--16-00-create-async-migration-jobs-table.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.7.0/2023-08-29--16-00-define-version-column-default-value.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.7.0/2023-10-10--16-00-clean-up-records-with-inconsistent-id.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-10-10--16-00-clean-up-records-with-inconsistent-id.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.7.0/2023-10-10--16-00-clean-up-records-with-inconsistent-id.xml
@@ -1,0 +1,57 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+  <changeSet id="2023-10-10--16-00-clean-up-records-with-inconsistent-id" author="MaksatGalymzhan">
+    <sql splitStatements="false">
+      UPDATE ${database.defaultSchemaName}.records_lb
+      SET generation=(
+      SELECT MAX(nested_query_rl.generation)+1
+      FROM ${database.defaultSchemaName}.records_lb nested_query_rl
+      WHERE nested_query_rl.matched_id = rl.matched_id),
+      matched_id = mi.value::UUID
+      FROM  ${database.defaultSchemaName}.records_lb rl,
+      ${database.defaultSchemaName}.marc_indexers mi
+      WHERE rl.matched_id = mi.marc_id
+      AND
+      rl.matched_id::text != mi.value
+      AND
+      rl.state='ACTUAL'
+      AND
+      mi.field_no='999'
+      AND
+      mi.ind1='f'
+      AND
+      mi.ind2='f'
+      AND
+      mi.subfield_no='s';
+
+      UPDATE ${database.defaultSchemaName}.records_lb
+      SET state='OLD'
+      FROM ${database.defaultSchemaName}.records_lb rl,
+      ${database.defaultSchemaName}.marc_indexers mi
+      WHERE rl.matched_id = mi.marc_id
+      AND
+      rl.matched_id::text = mi.value
+      AND
+      rl.state='ACTUAL'
+      AND
+      mi.field_no='999'
+      AND
+      mi.ind1='f'
+      AND
+      mi.ind2='f'
+      AND
+      mi.subfield_no='s'
+      AND
+      rl.generation!=(
+      SELECT MAX(nested_query_rl.generation)
+      FROM ${database.defaultSchemaName}.records_lb nested_query_rl
+      WHERE nested_query_rl.matched_id = rl.matched_id);
+
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
Create script to clean up records with inconsistent matched id values
## Approach
Create script to fix existing records - if 999 ff s UUID is different from matched_id and status ACTUAL - get highest generation for matched_id and overwrite matched_id to be the same as 999 ff s with incremented generation. If more than 1 ACTUAL record with the same matched_id - set status OLD to all the other records. [MODSOURCE-666](https://issues.folio.org/browse/MODSOURCE-666).
