### PR TITLE
MODSOURCE-642 update 005 field(transaction date) on updating MARC record

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -105,13 +105,13 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
                   fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
                 }
 
-                updateLatestTransactionDate(changedRecord, mappingParameters);
                 remove035WithActualHrId(changedRecord, hrId);
                 remove003FieldIfNeeded(changedRecord, hrId);
               }
 
               increaseGeneration(changedRecord);
               setUpdatedBy(changedRecord, userId);
+              updateLatestTransactionDate(changedRecord, mappingParameters);
               payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));
             })
         )

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -47,6 +47,7 @@ import static org.folio.services.util.AdditionalFieldsUtil.fill035FieldInMarcRec
 import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlledField;
 import static org.folio.services.util.AdditionalFieldsUtil.remove003FieldIfNeeded;
 import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrId;
+import static org.folio.services.util.AdditionalFieldsUtil.updateLatestTransactionDate;
 
 public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
 
@@ -91,26 +92,29 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
 
       mappingParametersCache.get(payload.getJobExecutionId(), okapiParams)
         .map(mapMappingParametersOrFail(format(MAPPING_PARAMETERS_NOT_FOUND_MSG, payload.getJobExecutionId())))
-        .compose(mappingParameters -> modifyRecord(payload, mappingProfile, mappingParameters))
-        .onSuccess(v -> prepareModificationResult(payload, marcMappingOption))
-        .map(v -> Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class))
-        .onSuccess(changedRecord -> {
-          if (isHridFillingNeeded() || isUpdateOption(marcMappingOption)) {
-            addControlledFieldToMarcRecord(changedRecord, HR_ID_FROM_FIELD, hrId, true);
+        .compose(mappingParameters ->
+          modifyRecord(payload, mappingProfile, mappingParameters)
+            .onSuccess(v -> prepareModificationResult(payload, marcMappingOption))
+            .map(v -> Json.decodeValue(payloadContext.get(modifiedEntityType().value()), Record.class))
+            .onSuccess(changedRecord -> {
+              if (isHridFillingNeeded() || isUpdateOption(marcMappingOption)) {
+                addControlledFieldToMarcRecord(changedRecord, HR_ID_FROM_FIELD, hrId, true);
 
-            String changed001 = getValueFromControlledField(changedRecord, HR_ID_FROM_FIELD);
-            if (StringUtils.isNotBlank(incoming001) && !incoming001.equals(changed001)) {
-              fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
-            }
+                String changed001 = getValueFromControlledField(changedRecord, HR_ID_FROM_FIELD);
+                if (StringUtils.isNotBlank(incoming001) && !incoming001.equals(changed001)) {
+                  fill035FieldInMarcRecordIfNotExists(changedRecord, incoming001);
+                }
 
-            remove035WithActualHrId(changedRecord, hrId);
-            remove003FieldIfNeeded(changedRecord, hrId);
-          }
+                updateLatestTransactionDate(changedRecord, mappingParameters);
+                remove035WithActualHrId(changedRecord, hrId);
+                remove003FieldIfNeeded(changedRecord, hrId);
+              }
 
-          increaseGeneration(changedRecord);
-          setUpdatedBy(changedRecord, userId);
-          payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));
-        })
+              increaseGeneration(changedRecord);
+              setUpdatedBy(changedRecord, userId);
+              payloadContext.put(modifiedEntityType().value(), Json.encode(changedRecord));
+            })
+        )
         .compose(changedRecord -> {
           String centralTenantId = payload.getContext().get(CENTRAL_TENANT_ID);
           if (centralTenantId != null) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -158,12 +158,12 @@ public abstract class AbstractLBServiceTest {
     context.assertNotNull(actual.getUpdatedDate());
   }
 
-  String get005FieldExpectedDate() {
+  protected String get005FieldExpectedDate() {
     return AdditionalFieldsUtil.dateTime005Formatter
       .format(ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
   }
 
-  void validate005Field(TestContext testContext, String expectedDate, Record record) {
+  protected void validate005Field(TestContext testContext, String expectedDate, Record record) {
     String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
     testContext.assertEquals(expectedDate.substring(0, 10),
       actualDate.substring(0, 10));

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.BeforeClass;
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
+import static org.junit.Assert.assertEquals;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -166,6 +167,12 @@ public abstract class AbstractLBServiceTest {
   protected void validate005Field(TestContext testContext, String expectedDate, Record record) {
     String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
     testContext.assertEquals(expectedDate.substring(0, 10),
+      actualDate.substring(0, 10));
+  }
+
+  protected void validate005Field(String expectedDate, Record record) {
+    String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
+    assertEquals(expectedDate.substring(0, 10),
       actualDate.substring(0, 10));
   }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/AbstractLBServiceTest.java
@@ -18,16 +18,23 @@ import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.services.util.AdditionalFieldsUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
+import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public abstract class AbstractLBServiceTest {
 
@@ -151,4 +158,14 @@ public abstract class AbstractLBServiceTest {
     context.assertNotNull(actual.getUpdatedDate());
   }
 
+  String get005FieldExpectedDate() {
+    return AdditionalFieldsUtil.dateTime005Formatter
+      .format(ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
+  }
+
+  void validate005Field(TestContext testContext, String expectedDate, Record record) {
+    String actualDate = AdditionalFieldsUtil.getValueFromControlledField(record, TAG_005);
+    testContext.assertEquals(expectedDate.substring(0, 10),
+      actualDate.substring(0, 10));
+  }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
@@ -245,6 +245,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
@@ -283,6 +284,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
         getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }
@@ -292,6 +294,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
@@ -329,6 +332,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
         getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
@@ -5,15 +5,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static org.folio.ActionProfile.Action.MODIFY;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_CREATED;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_UPDATED;
-import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_AUTHORITY;
-import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MappingDetail.MarcMappingOption.UPDATE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
-import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeaderAndDate;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -69,7 +67,6 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.services.caches.MappingParametersSnapshotCache;
 import org.folio.services.handlers.actions.MarcAuthorityUpdateModifyEventHandler;
-import org.folio.services.handlers.actions.MarcBibUpdateModifyEventHandler;
 
 @RunWith(VertxUnitRunner.class)
 public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
@@ -201,6 +198,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
@@ -233,10 +231,11 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
-        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+        getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }
@@ -280,8 +279,8 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
-        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+        getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
       async.complete();
@@ -327,8 +326,8 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_AUTHORITY.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
-        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+        getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       async.complete();
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -316,6 +316,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String expectedParsedContent =
       "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -352,6 +353,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
         Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
       context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
         getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
+      validate005Field(context, expectedDate, actualRecord);
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
       async.complete();
@@ -363,6 +365,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String expectedParsedContent =
       "{\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}]}},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}]}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
@@ -402,8 +405,9 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
         .onComplete(ar -> {
           context.assertTrue(ar.succeeded());
           context.assertTrue(ar.result().isPresent());
-          context.assertEquals(getParsedContentWithoutLeader(Json.encode(ar.result().get().getParsedRecord().getContent())),
-            getParsedContentWithoutLeader(expectedParsedContent));
+          context.assertEquals(getParsedContentWithoutLeaderAndDate(Json.encode(ar.result().get().getParsedRecord().getContent())),
+            getParsedContentWithoutLeaderAndDate(expectedParsedContent));
+          validate005Field(context, expectedDate, actualRecord);
           snapshotService.getSnapshotById(snapshot.getJobExecutionId(), CENTRAL_TENANT_ID)
             .onComplete(ar2 -> {
               context.assertTrue(ar2.succeeded());
@@ -582,6 +586,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String incomingParsedContent =
       "{\"leader\":\"05490cam a2200877Ia 4500\",\"fields\":[{\"001\":\"ocn297303223\"},{\"003\":\"OCoLC\"},{\"005\":\"20210226180151.2\"},{\"006\":\"m     o  d        \"},{\"007\":\"cr unu---uuaua\"},{\"008\":\"090107s1954    dcua    ob    100 0 eng d\"},{\"010\":{\"subfields\":[{\"a\":\"   55000367 \"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"015\":{\"subfields\":[{\"a\":\"B67-25185 \"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"016\":{\"subfields\":[{\"a\":\"000002550474\"},{\"2\":\"AU\"}],\"ind1\":\"7\",\"ind2\":\" \"}},{\"019\":{\"subfields\":[{\"a\":\"780330352\"},{\"a\":\"1057910652\"},{\"a\":\"1078369885\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"a\":\"9780841221574\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"a\":\"084122157X\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"a\":\"0841200122\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"a\":\"9780841200128\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"z\":\"9780841200128\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"z\":\"0841200122\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"024\":{\"subfields\":[{\"a\":\"9780841200128\"}],\"ind1\":\"3\",\"ind2\":\" \"}},{\"029\":{\"subfields\":[{\"a\":\"AU@\"},{\"b\":\"000048638076\"}],\"ind1\":\"1\",\"ind2\":\" \"}},{\"035\":{\"subfields\":[{\"a\":\"(OCoLC)on297303223\"},{\"z\":\"(OCoLC)780330352\"},{\"z\":\"(OCoLC)1057910652\"},{\"z\":\"(OCoLC)1078369885\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"035\":{\"subfields\":[{\"a\":\"10.1021/ba-1954-0011\"}],\"ind1\":\"9\",\"ind2\":\" \"}},{\"037\":{\"subfields\":[{\"b\":\"00001081\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"040\":{\"subfields\":[{\"a\":\"OCLCE\"},{\"b\":\"eng\"},{\"e\":\"pn\"},{\"c\":\"OCLCE\"},{\"d\":\"MUU\"},{\"d\":\"OCLCQ\"},{\"d\":\"COO\"},{\"d\":\"OCLCF\"},{\"d\":\"OCLCA\"},{\"d\":\"AU@\"},{\"d\":\"OCLCQ\"},{\"d\":\"OCL\"},{\"d\":\"ACY\"},{\"d\":\"OCLCQ\"},{\"d\":\"OCLCA\"},{\"d\":\"YOU\"},{\"d\":\"CASSC\"},{\"d\":\"OCLCA\"},{\"d\":\"MERER\"},{\"d\":\"OCLCO\"},{\"d\":\"CUY\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"049\":{\"subfields\":[{\"a\":\"AUMM\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"050\":{\"subfields\":[{\"a\":\"QD1\"},{\"b\":\".A355 no. 11\"}],\"ind1\":\" \",\"ind2\":\"4\"}},{\"060\":{\"subfields\":[{\"a\":\"QU 188\"},{\"b\":\"N285 1954\"}],\"ind1\":\" \",\"ind2\":\"4\"}},{\"072\":{\"subfields\":[{\"a\":\"SCI\"},{\"x\":\"013050\"},{\"2\":\"bisacsh\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"082\":{\"subfields\":[{\"a\":\"541.3452\"},{\"a\":\"541.375*\"}],\"ind1\":\"0\",\"ind2\":\"4\"}},{\"083\":{\"subfields\":[{\"z\":\"2\"},{\"a\":\"4947\"},{\"2\":\"22\"}],\"ind1\":\"0\",\"ind2\":\" \"}},{\"084\":{\"subfields\":[{\"a\":\"SCI007000\"},{\"2\":\"bisacsh\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"092\":{\"subfields\":[{\"a\":\"551.46 ǂ2 23/eng/2012\"}],\"ind1\":\"0\",\"ind2\":\" \"}},{\"111\":{\"subfields\":[{\"a\":\"Symposium on Natural Plant Hydrocolloids\"},{\"d\":\"(1952 :\"},{\"c\":\"Atlantic City, N.J.)\"}],\"ind1\":\"2\",\"ind2\":\" \"}},{\"245\":{\"subfields\":[{\"a\":\"Natural plant hydrocolloids :\"},{\"b\":\"a collection of papers comprising the Symposium on Natural Plant Hydrocolloids, presented before the Divisions of Colloid Chemistry and Agricultural and Food Chemistry at the 122nd meeting of the American Chemical Society, Atlantic City, N.J., September 1952.\"}],\"ind1\":\"1\",\"ind2\":\"0\"}},{\"260\":{\"subfields\":[{\"a\":\"Washington, D.C. :\"},{\"b\":\"American Chemical Society,\"},{\"c\":\"1954.\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"300\":{\"subfields\":[{\"a\":\"1 online resource (iii, 103 pages) :\"},{\"b\":\"illustrations.\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"336\":{\"subfields\":[{\"a\":\"text\"},{\"b\":\"txt\"},{\"2\":\"rdacontent\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"337\":{\"subfields\":[{\"a\":\"computer\"},{\"b\":\"c\"},{\"2\":\"rdamedia\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"338\":{\"subfields\":[{\"a\":\"online resource\"},{\"b\":\"cr\"},{\"2\":\"rdacarrier\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"490\":{\"subfields\":[{\"a\":\"Advances in chemistry series,\"},{\"x\":\"0065-2393 ;\"},{\"v\":\"no. 11\"}],\"ind1\":\"1\",\"ind2\":\" \"}},{\"504\":{\"subfields\":[{\"a\":\"Includes bibliographical references.\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"505\":{\"subfields\":[{\"t\":\"Introductory Remarks /\"},{\"r\":\"STOLOFF, LEONARD /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch001 --\"},{\"t\":\"Calcium Pectinates, Their Preparation and Uses /\"},{\"r\":\"WOODMANSEE, CLINTON W.; BAKER, GEORCE L. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch002 --\"},{\"t\":\"Factors Influencing Gelation with Pectin /\"},{\"r\":\"OWENS, HARRY S.; SWENSON, HAROLD A.; SCHULTZ, THOMAS H. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch003 --\"},{\"t\":\"Agar Since 1943 /\"},{\"r\":\"SELBY, HORACE H. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch004 --\"},{\"t\":\"Technology of Gum Arabic /\"},{\"r\":\"MANTELL, CHARLES L. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch005 --\"},{\"t\":\"Chemistry, Properties, and Application Of Gum Karaya /\"},{\"r\":\"GOLDSTEIN, ARTHUR M. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch006 --\"},{\"t\":\"History, Production, and Uses of Tragacanth /\"},{\"r\":\"BEACH, D. C. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch007 --\"},{\"t\":\"Guar Gum, Locust Bean Gum, and Others /\"},{\"r\":\"WHISTLER, ROY L. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch008 --\"},{\"t\":\"Some Properties of Locust Bean Gum /\"},{\"r\":\"DEUEL, HANS; NEUKOM, HANS /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch009 --\"},{\"t\":\"Observations on Pectic Substances /\"},{\"r\":\"DEUEL, HANS; SOLMS, JÜRG /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch010 --\"},{\"t\":\"Algin in Review /\"},{\"r\":\"STEINER, ARNOLD B.; McNEELY, WILLIAM H. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch011 --\"},{\"t\":\"Alginates from Common British Brown Marine Algae /\"},{\"r\":\"BLACK, W. A . P.; WOODWARD, F. N. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch012 --\"},{\"t\":\"Irish Moss Extractives /\"},{\"r\":\"STOLOFF, LEONARD /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch013 --\"},{\"t\":\"Effect of Different Ions on Gel Strength Of Red Seaweed Extracts /\"},{\"r\":\"MARSHALL, S. M.; ORR, A. P. /\"},{\"u\":\"http://dx.doi.org/10.1021/ba-1954-0011.ch014\"}],\"ind1\":\"0\",\"ind2\":\"0\"}},{\"506\":{\"subfields\":[{\"a\":\"Online full text is restricted to subscribers.\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"583\":{\"subfields\":[{\"a\":\"committed to retain\"},{\"c\":\"20160630\"},{\"d\":\"20310630\"},{\"f\":\"EAST\"},{\"u\":\"https://eastlibraries.org/retained-materials\"},{\"5\":\"DCHS\"}],\"ind1\":\"1\",\"ind2\":\" \"}},{\"588\":{\"subfields\":[{\"a\":\"Print version record.\"}],\"ind1\":\"0\",\"ind2\":\" \"}},{\"650\":{\"subfields\":[{\"a\":\"Biocolloids\"},{\"v\":\"Congresses.\"}],\"ind1\":\" \",\"ind2\":\"0\"}},{\"650\":{\"subfields\":[{\"a\":\"SCIENCE\"},{\"x\":\"Chemistry\"},{\"x\":\"Physical & Theoretical.\"},{\"2\":\"bisacsh\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"650\":{\"subfields\":[{\"a\":\"Biocolloids.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst00831997\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"650\":{\"subfields\":[{\"a\":\"Colloids\"},{\"x\":\"chemistry.\"}],\"ind1\":\"1\",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Colloids\"},{\"x\":\"economics.\"}],\"ind1\":\"1\",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Pectins\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Agar\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Gum Arabic\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Karaya Gum\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Tragacanth\"},{\"x\":\"history.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Tragacanth\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Plant Gums\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Alginates\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Phaeophyta\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Chondrus\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"650\":{\"subfields\":[{\"a\":\"Rhodophyta\"},{\"x\":\"chemistry.\"}],\"ind1\":\" \",\"ind2\":\"2\"}},{\"655\":{\"subfields\":[{\"a\":\"Electronic books.\"}],\"ind1\":\" \",\"ind2\":\"4\"}},{\"655\":{\"subfields\":[{\"a\":\"Conference papers and proceedings.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01423772\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"710\":{\"subfields\":[{\"a\":\"American Chemical Society.\"},{\"b\":\"Division of Agricultural and Food Chemistry.\"},{\"0\":\"http://id.loc.gov/authorities/names/n79007703\"}],\"ind1\":\"2\",\"ind2\":\" \"}},{\"710\":{\"subfields\":[{\"a\":\"American Chemical Society.\"},{\"b\":\"Division of Colloid and Surface Chemistry.\"},{\"0\":\"http://id.loc.gov/authorities/names/n80109319\"}],\"ind1\":\"2\",\"ind2\":\" \"}},{\"710\":{\"subfields\":[{\"a\":\"American Chemical Society.\"},{\"b\":\"Meeting\"},{\"n\":\"(122nd :\"},{\"d\":\"1952 :\"},{\"c\":\"Atlantic City, N.J.)\"}],\"ind1\":\"2\",\"ind2\":\" \"}},{\"776\":{\"subfields\":[{\"i\":\"Print version:\"},{\"a\":\"American Chemical Society. Division of Colloid and Surface Chemistry.\"},{\"t\":\"Natural plant hydrocolloids.\"},{\"d\":\"Washington, D.C. : American Chemical Society, 1954\"},{\"w\":\"(DLC)   55000367\"},{\"w\":\"(OCoLC)280432\"}],\"ind1\":\"0\",\"ind2\":\"8\"}},{\"830\":{\"subfields\":[{\"a\":\"Advances in chemistry series ;\"},{\"v\":\"11.\"}],\"ind1\":\" \",\"ind2\":\"0\"}},{\"850\":{\"subfields\":[{\"a\":\"AAP\"},{\"a\":\"CU\"},{\"a\":\"DLC\"},{\"a\":\"MiU \"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://silk.library.umass.edu/login?url=https://pubs.acs.org/doi/book/10.1021/ba-1954-0011\"},{\"z\":\"UMass: Link to resource\"}],\"ind1\":\"4\",\"ind2\":\"0\"}},{\"891\":{\"subfields\":[{\"9\":\"853\"},{\"8\":\"1\"},{\"a\":\"(year/year)\"}],\"ind1\":\"3\",\"ind2\":\"3\"}},{\"938\":{\"subfields\":[{\"a\":\"ebrary\"},{\"b\":\"EBRY\"},{\"n\":\"ebr10728707\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent =
@@ -616,7 +621,9 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
 
       var actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
-      verifyRecords(context, expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+      verifyRecords(context, getParsedContentWithoutDate(expectedParsedContent),
+        getParsedContentWithoutDate(actualRecord.getParsedRecord().getContent().toString()));
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }
@@ -1025,9 +1032,10 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     }
   }
 
-  public static String getParsedContentWithoutLeader(String parsedContent) {
+  public static String getParsedContentWithoutLeaderAndDate(String parsedContent) {
     JsonObject parsedContentAsJson = new JsonObject(parsedContent);
-    removeLeaderFromRecord(parsedContentAsJson);
+    parsedContentAsJson.remove("leader");
+    remove005FieldFromRecord(parsedContentAsJson);
 
     return parsedContentAsJson.encode();
   }
@@ -1037,19 +1045,6 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     remove005FieldFromRecord(parsedContentAsJson);
 
     return parsedContentAsJson.encode();
-  }
-
-  public static String getParsedContentWithoutLeaderAndDate(String parsedContent) {
-    JsonObject parsedContentAsJson = new JsonObject(parsedContent);
-    removeLeaderFromRecord(parsedContentAsJson);
-    remove005FieldFromRecord(parsedContentAsJson);
-
-    return parsedContentAsJson.encode();
-  }
-
-  private static JsonObject removeLeaderFromRecord(JsonObject recordJson) {
-    recordJson.remove("leader");
-    return recordJson;
   }
 
   private static JsonObject remove005FieldFromRecord(JsonObject recordJson) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
@@ -12,7 +12,7 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTI
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
-import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeaderAndDate;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -199,6 +199,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String expectedParsedContent = "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     HashMap<String, String> payloadContext = new HashMap<>();
     record.getParsedRecord().setContent(Json.encode(record.getParsedRecord().getContent()));
@@ -231,9 +232,10 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent), getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent), getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(userId, actualRecord.getMetadata().getUpdatedByUserId());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }
@@ -243,6 +245,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
@@ -277,10 +280,11 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
-        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+        getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
       context.assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }
@@ -290,6 +294,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     // given
     Async async = context.async();
 
+    String expectedDate = get005FieldExpectedDate();
     String incomingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406512\"},{\"003\":\"OCLC\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
     String expectedParsedContent = "{\"leader\":\"00134nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"ybp7406512\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"999\":{\"subfields\":[{\"s\":\"eae222e8-70fd-4422-852c-60d22bae36b8\"}],\"ind1\":\"f\",\"ind2\":\"f\"}}]}";
     Record incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(incomingParsedContent));
@@ -324,9 +329,10 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       context.assertEquals(DI_SRS_MARC_HOLDINGS_RECORD_UPDATED.value(), eventPayload.getEventType());
 
       Record actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_HOLDINGS.value()), Record.class);
-      context.assertEquals(getParsedContentWithoutLeader(expectedParsedContent),
-        getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+      context.assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+        getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
       context.assertEquals(Record.State.ACTUAL, actualRecord.getState());
+      validate005Field(context, expectedDate, actualRecord);
       async.complete();
     });
   }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
@@ -278,8 +278,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
   public void shouldUpdateField005WhenThisFiledIsNotProtected(TestContext context) throws IOException {
     Async async = context.async();
 
-    String expectedDate = AdditionalFieldsUtil.dateTime005Formatter
-      .format(ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
+    String expectedDate = get005FieldExpectedDate();
 
     String recordId = UUID.randomUUID().toString();
     RawRecord rawRecord = new RawRecord().withId(recordId)
@@ -322,9 +321,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
         context.assertTrue(getAr.result().isPresent());
         Record updatedRecord = getAr.result().get();
 
-        String actualDate = AdditionalFieldsUtil.getValueFromControlledField(updatedRecord, TAG_005);
-        Assert.assertEquals(expectedDate.substring(0, 10),
-          actualDate.substring(0, 10));
+        validate005Field(context, expectedDate, updatedRecord);
 
         async.complete();
       });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/HoldingsPostProcessingEventHandlerTest.java
@@ -236,8 +236,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
   public void shouldUpdateField005WhenThisFiledIsNotProtected(TestContext context) throws IOException {
     Async async = context.async();
 
-    String expectedDate = AdditionalFieldsUtil.dateTime005Formatter
-      .format(ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
+    String expectedDate = get005FieldExpectedDate();
 
     String recordId = UUID.randomUUID().toString();
     RawRecord rawRecord = new RawRecord().withId(recordId)
@@ -281,9 +280,7 @@ public class HoldingsPostProcessingEventHandlerTest extends AbstractPostProcessi
         context.assertTrue(getAr.result().isPresent());
         Record updatedRecord = getAr.result().get();
 
-        String actualDate = AdditionalFieldsUtil.getValueFromControlledField(updatedRecord, TAG_005);
-        Assert.assertEquals(expectedDate.substring(0, 10),
-          actualDate.substring(0, 10));
+        validate005Field(context, expectedDate, updatedRecord);
 
         async.complete();
       });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/InstancePostProcessingEventHandlerTest.java
@@ -560,8 +560,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
   public void shouldUpdateField005WhenThisFiledIsNotProtected(TestContext context) throws IOException {
     Async async = context.async();
 
-    String expectedDate = AdditionalFieldsUtil.dateTime005Formatter
-      .format(ZonedDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
+    String expectedDate = get005FieldExpectedDate();
 
     String recordId = UUID.randomUUID().toString();
     RawRecord rawRecord = new RawRecord().withId(recordId)
@@ -605,9 +604,7 @@ public class InstancePostProcessingEventHandlerTest extends AbstractPostProcessi
         context.assertTrue(getAr.result().isPresent());
         Record updatedRecord = getAr.result().get();
 
-        String actualDate = AdditionalFieldsUtil.getValueFromControlledField(updatedRecord, TAG_005);
-        Assert.assertEquals(expectedDate.substring(0, 10),
-          actualDate.substring(0, 10));
+        validate005Field(context, expectedDate, updatedRecord);
 
         async.complete();
       });

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -214,7 +214,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
     Record actualRecord =
       Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
     assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
-     getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
+      getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
     assertEquals(Record.State.ACTUAL, actualRecord.getState());
     assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
     assertNotNull(observedRecords.get(0).getHeaders().lastHeader(RECORD_ID_HEADER));

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -173,6 +173,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
     WireMock.stubFor(get(new UrlPathPattern(new RegexPattern(PROFILE_SNAPSHOT_URL + "/.*"), true))
       .willReturn(WireMock.ok().withBody(Json.encode(profileSnapshotWrapper))));
 
+    String expectedDate = get005FieldExpectedDate();
     String expectedParsedContent =
       "{\"leader\":\"00107nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"856\":{\"subfields\":[{\"u\":\"http://libproxy.smith.edu?url=example.com\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
@@ -217,6 +218,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
     assertEquals(Record.State.ACTUAL, actualRecord.getState());
     assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
+    validate005Field(expectedDate, actualRecord);
     assertNotNull(observedRecords.get(0).getHeaders().lastHeader(RECORD_ID_HEADER));
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -3,7 +3,7 @@ package org.folio.verticle.consumers;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
-import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeader;
+import static org.folio.services.MarcBibUpdateModifyEventHandlerTest.getParsedContentWithoutLeaderAndDate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -213,7 +213,8 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
 
     Record actualRecord =
       Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);
-    assertEquals(getParsedContentWithoutLeader(expectedParsedContent), getParsedContentWithoutLeader(actualRecord.getParsedRecord().getContent().toString()));
+    assertEquals(getParsedContentWithoutLeaderAndDate(expectedParsedContent),
+     getParsedContentWithoutLeaderAndDate(actualRecord.getParsedRecord().getContent().toString()));
     assertEquals(Record.State.ACTUAL, actualRecord.getState());
     assertEquals(dataImportEventPayload.getJobExecutionId(), actualRecord.getSnapshotId());
     assertNotNull(observedRecords.get(0).getHeaders().lastHeader(RECORD_ID_HEADER));


### PR DESCRIPTION
## Purpose
[MODSOURCE-642](https://issues.folio.org/browse/MODSOURCE-642)  Update 005 field(transaction date) on updating MARC bibliographic/MARC authority/MARC holdings 

## Approach
Generation of transaction date and setting it to 005 field logic already exists for creating records. Reuse it for updates: add setting 005 field to AbstractUpdateModifyEventHandler.java which contains common logic for update of all record types.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
