### PR TITLE
MODSOURCE-709 MARC authority record is not created when use Job profile with match profile by absent subfield/field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2024-xx-xx 5.8.0-SNAPSHOT
+* [MODSOURCE-709](https://issues.folio.org/browse/MODSOURCE-709) MARC authority record is not created when use Job profile with match profile by absent subfield/field
 * [MODSOURCE-677](https://issues.folio.org/browse/MODSOURCE-677)  Import is completed with errors when control field that differs from 001 is used for marc-to-marc matching
 
 ## 2023-10-13 v5.7.0

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -158,6 +158,7 @@ public class RecordDaoImpl implements RecordDao {
   private static final String WILDCARD = "*";
   private static final String PERCENT = "%";
   private static final String HASH = "#";
+  private static final String VALUE = "value";
 
   private static final Field<Integer> COUNT_FIELD = field(name(COUNT), Integer.class);
 
@@ -328,15 +329,15 @@ public class RecordDaoImpl implements RecordDao {
   private Condition getMatchedFieldCondition(MatchField matchedField, String partition) {
     Map<String, String> params = new HashMap<>();
     params.put("partition", partition);
-    params.put("value", getValueInSqlFormat(matchedField.getValue()));
-    if (matchedField.isControlField() && !params.get("value").isEmpty()) {
+    params.put(VALUE, getValueInSqlFormat(matchedField.getValue()));
+    if (matchedField.isControlField() && !params.get(VALUE).isEmpty()) {
       String sql = StrSubstitutor.replace(CONTROL_FIELD_CONDITION_TEMPLATE, params, "{", "}");
       return condition(sql);
     } else {
       params.put("ind1", getSqlInd(matchedField.getInd1()));
       params.put("ind2", getSqlInd(matchedField.getInd2()));
       params.put("subfield", matchedField.getSubfield());
-      String sqlTemplate = params.get("value").isEmpty()
+      String sqlTemplate = params.get(VALUE).isEmpty()
                            ? DATA_FIELD_CONDITION_TEMPLATE_EMPTY_VALUE
                            : DATA_FIELD_CONDITION_TEMPLATE;
       String sql = StrSubstitutor.replace(sqlTemplate, params, "{", "}");

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -150,6 +150,8 @@ public class RecordDaoImpl implements RecordDao {
 
   public static final String CONTROL_FIELD_CONDITION_TEMPLATE = "\"{partition}\".\"value\" in ({value})";
   public static final String DATA_FIELD_CONDITION_TEMPLATE = "\"{partition}\".\"value\" in ({value}) and \"{partition}\".\"ind1\" LIKE '{ind1}' and \"{partition}\".\"ind2\" LIKE '{ind2}' and \"{partition}\".\"subfield_no\" = '{subfield}'";
+  public static final String DATA_FIELD_CONDITION_TEMPLATE_EMPTY_VALUE = "\"{partition}\".\"ind1\" LIKE '{ind1}' and" +
+    " \"{partition}\".\"ind2\" LIKE '{ind2}' and \"{partition}\".\"subfield_no\" = '{subfield}'";
   private static final String VALUE_IN_SINGLE_QUOTES = "'%s'";
   private static final String RECORD_NOT_FOUND_BY_ID_TYPE = "Record with %s id: %s was not found";
   private static final String INVALID_PARSED_RECORD_MESSAGE_TEMPLATE = "Record %s has invalid parsed record; %s";
@@ -327,14 +329,17 @@ public class RecordDaoImpl implements RecordDao {
     Map<String, String> params = new HashMap<>();
     params.put("partition", partition);
     params.put("value", getValueInSqlFormat(matchedField.getValue()));
-    if (matchedField.isControlField()) {
+    if (matchedField.isControlField() && !params.get("value").isEmpty()) {
       String sql = StrSubstitutor.replace(CONTROL_FIELD_CONDITION_TEMPLATE, params, "{", "}");
       return condition(sql);
     } else {
       params.put("ind1", getSqlInd(matchedField.getInd1()));
       params.put("ind2", getSqlInd(matchedField.getInd2()));
       params.put("subfield", matchedField.getSubfield());
-      String sql = StrSubstitutor.replace(DATA_FIELD_CONDITION_TEMPLATE, params, "{", "}");
+      String sqlTemplate = params.get("value").isEmpty()
+                           ? DATA_FIELD_CONDITION_TEMPLATE_EMPTY_VALUE
+                           : DATA_FIELD_CONDITION_TEMPLATE;
+      String sql = StrSubstitutor.replace(sqlTemplate, params, "{", "}");
       return condition(sql);
     }
   }


### PR DESCRIPTION
## Purpose
MARC authority record is not created when use Job profile with match profile by absent subfield/field. 
[MODSOURCE-709](https://issues.folio.org/browse/MODSOURCE-709)

## Approach
Fixed condition statement to remove empty value from sql script when matching records

![image](https://github.com/folio-org/mod-source-record-storage/assets/101543142/c32e879e-f402-402c-a8e0-b9bb67460a5d)

