### PR TITLE
MODSOURCE-719: Bump Kafka, Spring, Snappy fixing vulns

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -210,6 +210,32 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>  <!-- remove this dependency when using kafka-junit >= 3.6.0 -->
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafkaclients.version}</version>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>  <!-- remove this dependency when using kafka-junit >= 3.6.0 -->
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.13</artifactId>
+      <version>${kafkaclients.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>  <!-- remove this dependency when using kafka-junit >= 3.6.0 -->
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.13</artifactId>
+      <version>${kafkaclients.version}</version>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>  <!-- remove this dependency when using kafka-junit >= 3.6.0 -->
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-tools</artifactId>
+      <version>${kafkaclients.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.5.1</rest-assured.version>
     <kafkaclients.version>3.6.0</kafkaclients.version>
-    <kafkajunit.version>3.3.0</kafkajunit.version>
+    <kafkajunit.version>3.5.1</kafkajunit.version>
     <spring.version>5.3.30</spring.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>
   </properties>


### PR DESCRIPTION
https://issues.folio.org/browse/MODSOURCE-719

Upgrade kafkaclients from 3.3.2 to 3.6.0.

This fixes Deserialization of Untrusted Data in kafkaclients:
https://nvd.nist.gov/vuln/detail/CVE-2023-25194

The kafkaclients upgrade indirectly upgrades snappy-java from 1.1.8.4 to 1.1.10.4 fixing Allocation of Resources Without Limits or Throttling, Denial of Service (DoS), and Integer Overflow or Wraparound:
https://nvd.nist.gov/vuln/detail/CVE-2023-43642
https://nvd.nist.gov/vuln/detail/CVE-2023-34455
https://nvd.nist.gov/vuln/detail/CVE-2023-34454
https://nvd.nist.gov/vuln/detail/CVE-2023-34453

Upgrade Spring from 5.3.23 to 5.3.30 fixing spring-expression vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2023-20863
https://nvd.nist.gov/vuln/detail/CVE-2023-20861