### PR TITLE
MODSOURCE-733 Reduce memory allocations of Strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2024-xx-xx 5.8.0-SNAPSHOT
+* [MODSOURCE-733](https://issues.folio.org/browse/MODSOURCE-733) Reduce Memory Allocation of Strings
 * [MODSOURCE-506](https://issues.folio.org/browse/MODSOURCE-506) Remove rawRecord field from source record
 * [MODSOURCE-709](https://issues.folio.org/browse/MODSOURCE-709) MARC authority record is not created when use Job profile with match profile by absent subfield/field
 * [MODSOURCE-677](https://issues.folio.org/browse/MODSOURCE-677)  Import is completed with errors when control field that differs from 001 is used for marc-to-marc matching

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,7 +75,7 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
     String key = targetRecord.key();
 
     try {
-      Event event = Json.decodeValue(targetRecord.value(), Event.class);
+      Event event = DatabindCodec.mapper().readValue(targetRecord.value(), Event.class);
       RecordCollection recordCollection = Json.decodeValue(event.getEventPayload(), RecordCollection.class);
 
       List<KafkaHeader> kafkaHeaders = targetRecord.headers();

--- a/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
@@ -55,18 +55,18 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
   private Vertx vertx;
 
   @Override
-  public void handle(Throwable throwable, KafkaConsumerRecord<String, byte[]> record) {
-    LOGGER.trace("handle:: Handling record {}", record);
-      Event event = null;
+  public void handle(Throwable throwable, KafkaConsumerRecord<String, byte[]> consumerRecord) {
+    LOGGER.trace("handle:: Handling record {}", consumerRecord);
+      Event event;
       try {
-          event = DatabindCodec.mapper().readValue(record.value(), Event.class);
+          event = DatabindCodec.mapper().readValue(consumerRecord.value(), Event.class);
       } catch (IOException e) {
           LOGGER.error("Something happened when deserializing record", e);
           return;
       }
       RecordCollection recordCollection = Json.decodeValue(event.getEventPayload(), RecordCollection.class);
 
-    List<KafkaHeader> kafkaHeaders = record.headers();
+    List<KafkaHeader> kafkaHeaders = consumerRecord.headers();
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
 
     String jobExecutionId = okapiConnectionParams.getHeaders().get(JOB_EXECUTION_ID_HEADER);

--- a/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/errorhandlers/ParsedRecordChunksErrorHandler.java
@@ -3,6 +3,7 @@ package org.folio.errorhandlers;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
@@ -23,6 +24,7 @@ import org.folio.services.util.EventHandlingUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +40,7 @@ import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_LOG_SRS_MARC_BI
  * with status 'Completed with errors' with showing error messge instead of hanging progress bar.
  */
 @Component
-public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler<String, String> {
+public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler<String, byte[]> {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
@@ -53,10 +55,16 @@ public class ParsedRecordChunksErrorHandler implements ProcessRecordErrorHandler
   private Vertx vertx;
 
   @Override
-  public void handle(Throwable throwable, KafkaConsumerRecord<String, String> record) {
+  public void handle(Throwable throwable, KafkaConsumerRecord<String, byte[]> record) {
     LOGGER.trace("handle:: Handling record {}", record);
-    Event event = Json.decodeValue(record.value(), Event.class);
-    RecordCollection recordCollection = Json.decodeValue(event.getEventPayload(), RecordCollection.class);
+      Event event = null;
+      try {
+          event = DatabindCodec.mapper().readValue(record.value(), Event.class);
+      } catch (IOException e) {
+          LOGGER.error("Something happened when deserializing record", e);
+          return;
+      }
+      RecordCollection recordCollection = Json.decodeValue(event.getEventPayload(), RecordCollection.class);
 
     List<KafkaHeader> kafkaHeaders = record.headers();
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityDomainConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityDomainConsumersVerticle.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class AuthorityDomainConsumersVerticle extends AbstractConsumerVerticle {
+public class AuthorityDomainConsumersVerticle extends AbstractConsumerVerticle<String, String> {
 
   private final AuthorityDomainKafkaHandler authorityDomainKafkaHandler;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AuthorityLinkChunkConsumersVerticle.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class AuthorityLinkChunkConsumersVerticle extends AbstractConsumerVerticle {
+public class AuthorityLinkChunkConsumersVerticle extends AbstractConsumerVerticle<String, String> {
 
   private final AuthorityLinkChunkKafkaHandler kafkaHandler;
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/DataImportConsumersVerticle.java
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class DataImportConsumersVerticle extends AbstractConsumerVerticle {
+public class DataImportConsumersVerticle extends AbstractConsumerVerticle<String, byte[]> {
 
   private static final List<String> EVENTS = Arrays.asList(
     DI_INVENTORY_AUTHORITY_CREATED_READY_FOR_POST_PROCESSING.value(),
@@ -65,7 +65,7 @@ public class DataImportConsumersVerticle extends AbstractConsumerVerticle {
     DI_SRS_MARC_HOLDINGS_RECORD_MATCHED.value()
   );
 
-  private final AsyncRecordHandler<String, String> dataImportKafkaHandler;
+  private final AsyncRecordHandler<String, byte[]> dataImportKafkaHandler;
 
   @Value("${srs.kafka.DataImportConsumer.loadLimit:5}")
   private int loadLimit;
@@ -73,7 +73,7 @@ public class DataImportConsumersVerticle extends AbstractConsumerVerticle {
   @Autowired
   public DataImportConsumersVerticle(KafkaConfig kafkaConfig,
                                      @Qualifier("DataImportKafkaHandler")
-                                     AsyncRecordHandler<String, String> dataImportKafkaHandler) {
+                                     AsyncRecordHandler<String, byte[]> dataImportKafkaHandler) {
     super(kafkaConfig);
     this.dataImportKafkaHandler = dataImportKafkaHandler;
   }
@@ -84,13 +84,18 @@ public class DataImportConsumersVerticle extends AbstractConsumerVerticle {
   }
 
   @Override
-  protected AsyncRecordHandler<String, String> recordHandler() {
+  protected AsyncRecordHandler<String, byte[]> recordHandler() {
     return dataImportKafkaHandler;
   }
 
   @Override
   protected List<String> eventTypes() {
     return EVENTS;
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/ParsedRecordChunkConsumersVerticle.java
@@ -15,11 +15,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class ParsedRecordChunkConsumersVerticle extends AbstractConsumerVerticle {
+public class ParsedRecordChunkConsumersVerticle extends AbstractConsumerVerticle<String, byte[]> {
 
-  private final AsyncRecordHandler<String, String> parsedRecordChunksKafkaHandler;
+  private final AsyncRecordHandler<String, byte[]> parsedRecordChunksKafkaHandler;
 
-  private final ProcessRecordErrorHandler<String, String> parsedRecordChunksErrorHandler;
+  private final ProcessRecordErrorHandler<String, byte[]> parsedRecordChunksErrorHandler;
 
   @Value("${srs.kafka.ParsedMarcChunkConsumer.loadLimit:5}")
   private int loadLimit;
@@ -27,16 +27,16 @@ public class ParsedRecordChunkConsumersVerticle extends AbstractConsumerVerticle
   @Autowired
   protected ParsedRecordChunkConsumersVerticle(KafkaConfig kafkaConfig,
                                                @Qualifier("parsedRecordChunksKafkaHandler")
-                                               AsyncRecordHandler<String, String> parsedRecordChunksKafkaHandler,
+                                               AsyncRecordHandler<String, byte[]> parsedRecordChunksKafkaHandler,
                                                @Qualifier("parsedRecordChunksErrorHandler")
-                                               ProcessRecordErrorHandler<String, String> parsedRecordChunksErrorHandler) {
+                                               ProcessRecordErrorHandler<String, byte[]> parsedRecordChunksErrorHandler) {
     super(kafkaConfig);
     this.parsedRecordChunksKafkaHandler = parsedRecordChunksKafkaHandler;
     this.parsedRecordChunksErrorHandler = parsedRecordChunksErrorHandler;
   }
 
   @Override
-  protected ProcessRecordErrorHandler<String, String> processRecordErrorHandler() {
+  protected ProcessRecordErrorHandler<String, byte[]> processRecordErrorHandler() {
     return parsedRecordChunksErrorHandler;
   }
 
@@ -46,13 +46,18 @@ public class ParsedRecordChunkConsumersVerticle extends AbstractConsumerVerticle
   }
 
   @Override
-  protected AsyncRecordHandler<String, String> recordHandler() {
+  protected AsyncRecordHandler<String, byte[]> recordHandler() {
     return parsedRecordChunksKafkaHandler;
   }
 
   @Override
   protected List<String> eventTypes() {
     return List.of(DI_RAW_RECORDS_CHUNK_PARSED.value());
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return "org.apache.kafka.common.serialization.ByteArrayDeserializer";
   }
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/QuickMarcConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/QuickMarcConsumersVerticle.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class QuickMarcConsumersVerticle extends AbstractConsumerVerticle {
+public class QuickMarcConsumersVerticle extends AbstractConsumerVerticle<String, String> {
 
   private final QuickMarcKafkaHandler kafkaHandler;
 

--- a/mod-source-record-storage-server/src/main/resources/vertx-default-jul-logging.properties
+++ b/mod-source-record-storage-server/src/main/resources/vertx-default-jul-logging.properties
@@ -1,5 +1,0 @@
-handlers = java.util.logging.ConsoleHandler
-.level = ALL
-
-logger.cql2pgjson.level = ERROR
-logger.cql2pgjson.name = org.folio.cql2pgjson.CQL2PgJSON


### PR DESCRIPTION
## Purpose
Reduce memory allocations of strings to reduce memory requirements of SRS and improve performance at the limit

## Approach
Prior to this change, byte arrays obtained from the Kafka clients are converted to Strings before being passed to a consumer handler. The String is then converted to a POJO for further logic. Due to requirements of data import, kafka payloads can be large. For example, if payload for a parsed MARC record is 1MB(this is a common occurrence), its string representation will be 1MB + other bytes.

After this change, byte arrays are coverted directly to POJO so intermediate Strings are not created. Internally, Jackson streams the byte array rather than create a String representation. This means that memory used is not directly proportional to the size of the kafka payloads encountered.

This is a problem in SRS because large strings are created. In production, large payloads containing parsed marc records and current node of complex Job profiles exists.

