### PR TITLE
[MODSOURCE-731] Bump version of source-storage-records interface to 3.2

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -54,7 +54,7 @@
     },
     {
       "id": "source-storage-records",
-      "version": "3.1",
+      "version": "3.2",
       "handlers": [
         {
           "methods": [


### PR DESCRIPTION
## Purpose
Bump version of source-storage-records interface to 3.2 after adding of new **PUT /source-storage/records/{id}/generation** endpoint