### PR TITLE
MODSOURCE-739 Create Kafka topics instead of relying on auto create in mod-srs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODSOURCE-722](https://issues.folio.org/browse/MODSOURCE-722)  deleteMarcIndexersOldVersions: relation "marc_records_tracking" does not exist
 * [MODSOURMAN-1106](https://issues.folio.org/browse/MODSOURMAN-1106) The status of Instance is '-' in the Import log after uploading file. The numbers of updated SRS and Instance are not displayed in the Summary table.
 * [MODSOURCE-717](https://issues.folio.org/browse/MODSOURCE-717) MARC modifications not processed when placed after Holdings Update action in a job profile
+* [MODSOURCE-739](https://issues.folio.org/browse/MODSOURCE-739) Create Kafka topics instead of relying on auto create in mod-srs
 
 ## 2023-10-13 v5.7.0
 * [MODSOURCE-648](https://issues.folio.org/browse/MODSOURCE-648) Upgrade mod-source-record-storage to Java 17

--- a/README.md
+++ b/README.md
@@ -125,7 +125,18 @@ After setup, it is good to check logs in all related modules for errors. Data im
   * "_srs.kafka.AuthorityLinkChunkConsumer.loadLimit_": 2
 * Relevant from the **Poppy** release, module versions from 5.7.0:
   * "_srs.linking-rules-cache.expiration.time.hours_": 12
-
+* Variables for setting number of partitions of topics:
+  * MARC_BIB
+  * DI_PARSED_RECORDS_CHUNK_SAVED
+  * DI_SRS_MARC_BIB_INSTANCE_HRID_SET
+  * DI_SRS_MARC_BIB_RECORD_MODIFIED
+  * DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING
+  * DI_SRS_MARC_BIB_RECORD_MATCHED
+  * DI_SRS_MARC_BIB_RECORD_NOT_MATCHED
+  * DI_SRS_MARC_AUTHORITY_RECORD_MATCHED
+  * DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED
+  * DI_SRS_MARC_AUTHORITY_RECORD_DELETED
+    Default value for all partitions is 1
 ## Database schemas
 
 The mod-source-record-storage module uses relational approach and Liquibase to define database schemas.

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -1,11 +1,17 @@
 package org.folio.rest.impl;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import java.util.Date;
+import java.util.Map;
+import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.RecordStorageKafkaTopic;
@@ -17,16 +23,10 @@ import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.Snapshot.Status;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.services.SRSKafkaTopicService;
 import org.folio.services.SnapshotService;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.ws.rs.core.Response;
-import java.util.Date;
-import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 public class ModTenantAPI extends TenantAPI {
 
@@ -42,6 +42,9 @@ public class ModTenantAPI extends TenantAPI {
   @Autowired
   private SnapshotService snapshotService;
 
+  @Autowired
+  private SRSKafkaTopicService srsKafkaTopicService;
+
   private final String tenantId;
 
   public ModTenantAPI(Vertx vertx, String tenantId) { //NOSONAR
@@ -55,14 +58,13 @@ public class ModTenantAPI extends TenantAPI {
                            Map<String, String> headers, Context context) {
     // create topics before loading data
     Vertx vertx = context.owner();
-    return new KafkaAdminClientService(vertx)
-      .createKafkaTopics(RecordStorageKafkaTopic.values(), tenantId)
-      .compose(x -> super.loadData(attributes, tenantId, headers, context))
+
+    return super.loadData(attributes, tenantId, headers, context)
       .compose(num -> {
-        LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
-        return setLoadSampleParameter(attributes, context)
-          .compose(v -> createStubSnapshot(attributes)).map(num);
-      });
+      LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
+      return setLoadSampleParameter(attributes, context)
+        .compose(v -> createStubSnapshot(attributes)).map(num);
+    });
   }
 
   @Validate
@@ -73,7 +75,16 @@ public class ModTenantAPI extends TenantAPI {
     Future<Void> result = tenantAttributes.getPurge() != null && tenantAttributes.getPurge()
       ? new KafkaAdminClientService(context.owner()).deleteKafkaTopics(RecordStorageKafkaTopic.values(), tenantId(headers))
       : Future.succeededFuture();
-    result.onComplete(x -> super.postTenant(tenantAttributes, headers, handler, context));
+    result.onComplete(x -> super.postTenant(tenantAttributes, headers, ar -> {
+      if (ar.succeeded()) {
+        Vertx vertx = context.owner();
+        var kafkaAdminClientService = new KafkaAdminClientService(vertx);
+        kafkaAdminClientService.createKafkaTopics(srsKafkaTopicService.createTopicObjects(), tenantId);
+        handler.handle(Future.succeededFuture(ar.result()));
+      } else {
+        handler.handle(Future.failedFuture(ar.cause()));
+      }
+    }, context));
   }
 
   private Future<Void> setLoadSampleParameter(TenantAttributes attributes, Context context) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageRecordsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageRecordsImpl.java
@@ -113,7 +113,7 @@ public class SourceStorageRecordsImpl implements SourceStorageRecords {
       }
     });
   }
-
+// delete by instance id - ticket
   @Override
   public void deleteSourceStorageRecordsById(String id, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -168,6 +168,7 @@ public class SourceStorageRecordsImpl implements SourceStorageRecords {
       Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
+
         recordService.updateSuppressFromDiscoveryForRecord(id, toExternalIdType(idType), suppress, tenantId)
           .map(PutSourceStorageRecordsSuppressFromDiscoveryByIdResponse::respond200WithTextPlain)
           .map(Response.class::cast).otherwise(ExceptionHelper::mapExceptionToResponse)

--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageRecordsImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/SourceStorageRecordsImpl.java
@@ -113,7 +113,7 @@ public class SourceStorageRecordsImpl implements SourceStorageRecords {
       }
     });
   }
-// delete by instance id - ticket
+
   @Override
   public void deleteSourceStorageRecordsById(String id, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -168,7 +168,6 @@ public class SourceStorageRecordsImpl implements SourceStorageRecords {
       Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-
         recordService.updateSuppressFromDiscoveryForRecord(id, toExternalIdType(idType), suppress, tenantId)
           .map(PutSourceStorageRecordsSuppressFromDiscoveryByIdResponse::respond200WithTextPlain)
           .map(Response.class::cast).otherwise(ExceptionHelper::mapExceptionToResponse)

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
@@ -1,5 +1,8 @@
 package org.folio.services;
 
+import static org.folio.kafka.KafkaTopicNameHelper.formatTopicName;
+import static org.folio.kafka.services.KafkaEnvironmentProperties.environment;
+
 import org.folio.kafka.services.KafkaTopic;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
@@ -90,6 +93,11 @@ public class SRSKafkaTopicService {
     @Override
     public int numPartitions() {
       return numPartitions;
+    }
+
+    @Override
+    public String fullTopicName(String tenant) {
+      return formatTopicName(environment(), tenant, topicName());
     }
   }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
@@ -43,31 +43,22 @@ public class SRSKafkaTopicService {
   private Integer diMarcAuthorityRecordDeletedPartitions;
 
   public KafkaTopic[] createTopicObjects() {
-    var marcBib = new SRSKafkaTopic("MARC_BIB", marcBibPartitions);
-    var diParsedRecordChunkSaved = new SRSKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", diParsedRecordsChunkSavedPartitions);
-    var diSrsMarcBibInstanceHridSet = new SRSKafkaTopic("DI_SRS_MARC_BIB_INSTANCE_HRID_SET",
-      diSrsMarcBibInstanceHridSetPartitions);
-    var diSrsMarcBibRecordModified = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED", diSrsMarcBibRecordModifiedPartitions);
-    var diSrsMarcBibRecordModifiedReadyForPostProcessing = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
-      diSrsMarcBibRecordModifiedReadyForPostProcessingPartitions);
-    var diMarcBibRecordMatched = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MATCHED",
-      diMarcBibRecordMatchedPartitions);
-    var diMarcBibRecordNotMatched = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
-      diMarcBibRecordNotMatchedPartitions);
-    var diMarcAuthorityRecordMatched = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
-      diMarcAuthorityRecordMatchedPartitions);
-
-    var diMarcAuthorityRecordNotMatched = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
-      diMarcAuthorityRecordNotMatchedPartitions);
-
-    var diMarcAuthorityRecordDeleted = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_DELETED",
-      diMarcAuthorityRecordDeletedPartitions);
-
-    return new SRSKafkaTopic[] {marcBib, diParsedRecordChunkSaved,
-                                diSrsMarcBibInstanceHridSet, diSrsMarcBibRecordModified,
-                                diSrsMarcBibRecordModifiedReadyForPostProcessing, diMarcBibRecordMatched,
-                                diMarcBibRecordNotMatched, diMarcAuthorityRecordMatched,
-                                diMarcAuthorityRecordNotMatched, diMarcAuthorityRecordDeleted};
+    return new SRSKafkaTopic[] {
+      new SRSKafkaTopic("MARC_BIB", marcBibPartitions),
+      new SRSKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", diParsedRecordsChunkSavedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_BIB_INSTANCE_HRID_SET", diSrsMarcBibInstanceHridSetPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED", diSrsMarcBibRecordModifiedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
+        diSrsMarcBibRecordModifiedReadyForPostProcessingPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MATCHED", diMarcBibRecordMatchedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
+        diMarcBibRecordNotMatchedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
+        diMarcAuthorityRecordMatchedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
+        diMarcAuthorityRecordNotMatchedPartitions),
+      new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_DELETED",
+      diMarcAuthorityRecordDeletedPartitions)};
   }
 
   public static class SRSKafkaTopic implements KafkaTopic {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/SRSKafkaTopicService.java
@@ -1,0 +1,95 @@
+package org.folio.services;
+
+import org.folio.kafka.services.KafkaTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+@Service
+@PropertySource(value = "kafka.properties")
+public class SRSKafkaTopicService {
+
+  @Value("${marcBib.partitions}")
+  private Integer marcBibPartitions;
+
+  @Value("${di_parsed_records_chunk_saved.partitions}")
+  private Integer diParsedRecordsChunkSavedPartitions;
+
+  @Value("${di_srs_marc_bib_instance_hrid_set.partitions}")
+  private Integer diSrsMarcBibInstanceHridSetPartitions;
+
+  @Value("${di_srs_marc_bib_record_modified.partitions}")
+  private Integer diSrsMarcBibRecordModifiedPartitions;
+
+  @Value("${di_srs_marc_bib_record_modified_ready_for_post_processing.partitions}")
+  private Integer diSrsMarcBibRecordModifiedReadyForPostProcessingPartitions;
+
+  @Value("${di_marc_bib_record_matched.partitions}")
+  private Integer diMarcBibRecordMatchedPartitions;
+
+  @Value("${di_marc_bib_record_not_matched.partitions}")
+  private Integer diMarcBibRecordNotMatchedPartitions;
+
+  @Value("${di_marc_authority_record_matched.partitions}")
+  private Integer diMarcAuthorityRecordMatchedPartitions;
+
+  @Value("${di_marc_authority_record_not_matched.partitions}")
+  private Integer diMarcAuthorityRecordNotMatchedPartitions;
+
+  @Value("${di_marc_authority_record_deleted.partitions}")
+  private Integer diMarcAuthorityRecordDeletedPartitions;
+
+  public KafkaTopic[] createTopicObjects() {
+    var marcBib = new SRSKafkaTopic("MARC_BIB", marcBibPartitions);
+    var diParsedRecordChunkSaved = new SRSKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", diParsedRecordsChunkSavedPartitions);
+    var diSrsMarcBibInstanceHridSet = new SRSKafkaTopic("DI_SRS_MARC_BIB_INSTANCE_HRID_SET",
+      diSrsMarcBibInstanceHridSetPartitions);
+    var diSrsMarcBibRecordModified = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED", diSrsMarcBibRecordModifiedPartitions);
+    var diSrsMarcBibRecordModifiedReadyForPostProcessing = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
+      diSrsMarcBibRecordModifiedReadyForPostProcessingPartitions);
+    var diMarcBibRecordMatched = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MATCHED",
+      diMarcBibRecordMatchedPartitions);
+    var diMarcBibRecordNotMatched = new SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
+      diMarcBibRecordNotMatchedPartitions);
+    var diMarcAuthorityRecordMatched = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
+      diMarcAuthorityRecordMatchedPartitions);
+
+    var diMarcAuthorityRecordNotMatched = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
+      diMarcAuthorityRecordNotMatchedPartitions);
+
+    var diMarcAuthorityRecordDeleted = new SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_DELETED",
+      diMarcAuthorityRecordDeletedPartitions);
+
+    return new SRSKafkaTopic[] {marcBib, diParsedRecordChunkSaved,
+                                diSrsMarcBibInstanceHridSet, diSrsMarcBibRecordModified,
+                                diSrsMarcBibRecordModifiedReadyForPostProcessing, diMarcBibRecordMatched,
+                                diMarcBibRecordNotMatched, diMarcAuthorityRecordMatched,
+                                diMarcAuthorityRecordNotMatched, diMarcAuthorityRecordDeleted};
+  }
+
+  public static class SRSKafkaTopic implements KafkaTopic {
+
+    private final String topic;
+    private final int numPartitions;
+
+    public SRSKafkaTopic(String topic, int numPartitions) {
+      this.topic = topic;
+      this.numPartitions = numPartitions;
+    }
+
+    @Override
+    public String moduleName() {
+      return "srs";
+    }
+
+    @Override
+    public String topicName() {
+      return topic;
+    }
+
+    @Override
+    public int numPartitions() {
+      return numPartitions;
+    }
+  }
+}

--- a/mod-source-record-storage-server/src/main/resources/kafka.properties
+++ b/mod-source-record-storage-server/src/main/resources/kafka.properties
@@ -1,0 +1,11 @@
+
+marcBib.partitions = ${MARC_BIB_PARTITIONS:1}
+di_parsed_records_chunk_saved.partitions = ${DI_PARSED_RECORDS_CHUNK_SAVED_PARTITIONS:1}
+di_srs_marc_bib_instance_hrid_set.partitions = ${DI_SRS_MARC_BIB_INSTANCE_HRID_SET_PARTITIONS:1}
+di_srs_marc_bib_record_modified.partitions = ${DI_SRS_MARC_BIB_RECORD_MODIFIED_PARTITIONS:1}
+di_srs_marc_bib_record_modified_ready_for_post_processing.partitions = ${DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING_PARTITIONS:1}
+di_marc_bib_record_matched.partitions = ${DI_SRS_MARC_BIB_RECORD_MATCHED_PARTITIONS:1}
+di_marc_bib_record_not_matched.partitions = ${DI_SRS_MARC_BIB_RECORD_NOT_MATCHED_PARTITIONS:1}
+di_marc_authority_record_matched.partitions = ${DI_SRS_MARC_AUTHORITY_RECORD_MATCHED_PARTITIONS:1}
+di_marc_authority_record_not_matched.partitions = ${DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED_PARTITIONS:1}
+di_marc_authority_record_deleted.partitions = ${DI_SRS_MARC_AUTHORITY_RECORD_DELETED_PARTITIONS:1}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/kafka/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/kafka/KafkaAdminClientServiceTest.java
@@ -145,15 +145,15 @@ public class KafkaAdminClientServiceTest {
   }
 
   private final Set<String> allExpectedTopics = Set.of(
-    "folio.foo-tenant.srs.MARC_BIB",
-    "folio.foo-tenant.srs.DI_PARSED_RECORDS_CHUNK_SAVED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_INSTANCE_HRID_SET",
-    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MODIFIED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
-    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MATCHED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
-    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_DELETED"
+    "folio.foo-tenant.MARC_BIB",
+    "folio.foo-tenant.DI_PARSED_RECORDS_CHUNK_SAVED",
+    "folio.foo-tenant.DI_SRS_MARC_BIB_INSTANCE_HRID_SET",
+    "folio.foo-tenant.DI_SRS_MARC_BIB_RECORD_MODIFIED",
+    "folio.foo-tenant.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
+    "folio.foo-tenant.DI_SRS_MARC_BIB_RECORD_MATCHED",
+    "folio.foo-tenant.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
+    "folio.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
+    "folio.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
+    "folio.foo-tenant.DI_SRS_MARC_AUTHORITY_RECORD_DELETED"
   );
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/kafka/KafkaAdminClientServiceTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/kafka/KafkaAdminClientServiceTest.java
@@ -1,23 +1,5 @@
 package org.folio.services.kafka;
 
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.kafka.admin.KafkaAdminClient;
-import io.vertx.kafka.admin.NewTopic;
-import org.apache.kafka.common.errors.TopicExistsException;
-import org.folio.RecordStorageKafkaTopic;
-import org.folio.kafka.services.KafkaAdminClientService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,18 +15,53 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.folio.kafka.services.KafkaAdminClientService;
+import org.folio.kafka.services.KafkaTopic;
+import org.folio.services.SRSKafkaTopicService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allExpectedTopics = Set.of("folio.foo-tenant.srs.marc-bib");
 
   private final String STUB_TENANT = "foo-tenant";
   private KafkaAdminClient mockClient;
   private Vertx vertx;
+  @Mock
+  private SRSKafkaTopicService srsKafkaTopicService;
 
   @Before
   public void setUp() {
     vertx = mock(Vertx.class);
     mockClient = mock(KafkaAdminClient.class);
+    srsKafkaTopicService = mock(SRSKafkaTopicService.class);
+    KafkaTopic[] topicObjects = {
+      new SRSKafkaTopicService.SRSKafkaTopic("MARC_BIB", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_PARSED_RECORDS_CHUNK_SAVED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_BIB_INSTANCE_HRID_SET", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_MATCHED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_BIB_RECORD_NOT_MATCHED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_MATCHED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED", 10),
+      new SRSKafkaTopicService.SRSKafkaTopic("DI_SRS_MARC_AUTHORITY_RECORD_DELETED", 10)
+    };
+
+    when(srsKafkaTopicService.createTopicObjects()).thenReturn(topicObjects);
   }
 
   @Test
@@ -123,7 +140,20 @@ public class KafkaAdminClientServiceTest {
       mocked.when(() -> KafkaAdminClient.create(eq(vertx), anyMap())).thenReturn(client);
 
       return new KafkaAdminClientService(vertx)
-        .createKafkaTopics(RecordStorageKafkaTopic.values(), STUB_TENANT);
+        .createKafkaTopics(srsKafkaTopicService.createTopicObjects(), STUB_TENANT);
     }
   }
+
+  private final Set<String> allExpectedTopics = Set.of(
+    "folio.foo-tenant.srs.MARC_BIB",
+    "folio.foo-tenant.srs.DI_PARSED_RECORDS_CHUNK_SAVED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_INSTANCE_HRID_SET",
+    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MODIFIED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING",
+    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_MATCHED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_BIB_RECORD_NOT_MATCHED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_MATCHED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_NOT_MATCHED",
+    "folio.foo-tenant.srs.DI_SRS_MARC_AUTHORITY_RECORD_DELETED"
+  );
 }


### PR DESCRIPTION
## Purpose
Create Kafka topics instead of relying on auto create in mod-srs [MODSOURCE-739](https://issues.folio.org/browse/MODSOURCE-739)

## Approach
* create kafka topics during tenant init
* add tests