### PR TITLE
MODSOURCE-757 Expose DB Reconnection Attempt Config Options

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -460,6 +460,10 @@
         "value": "15"
       },
       {
+        "name": "DB_RECONNECTATTEMPTS",
+        "value": "3"
+      },
+      {
         "name": "KAFKA_HOST",
         "value": "10.0.2.15"
       },

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/PostgresClientFactory.java
@@ -51,6 +51,8 @@ public class PostgresClientFactory {
   private static final String CONNECTION_TIMEOUT = "DB_CONNECTION_TIMEOUT";
   private static final String DEFAULT_CONNECTION_TIMEOUT_VALUE = "30";
   private static final String IDLE_TIMEOUT = "connectionReleaseDelay";
+  private static final String DB_RECONNECTATTEMPTS = "reconnectAttempts";
+  private static final String DB_RECONNECTINTERVAL = "reconnectInterval";
   private static final String MODULE_NAME = ModuleName.getModuleName();
 
   private static final String DEFAULT_SCHEMA_PROPERTY = "search_path";
@@ -227,6 +229,8 @@ public class PostgresClientFactory {
       .setPassword(postgresConfig.getString(PASSWORD))
       .setIdleTimeout(postgresConfig.getInteger(IDLE_TIMEOUT, 60000))
       .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
+      .setReconnectAttempts(postgresConfig.getInteger(DB_RECONNECTATTEMPTS, 0))
+      .setReconnectInterval(postgresConfig.getLong(DB_RECONNECTINTERVAL, 1L))
       .addProperty(DEFAULT_SCHEMA_PROPERTY, convertToPsqlStandard(tenantId));
   }
 


### PR DESCRIPTION
## Purpose
Counter io.netty.channel.StacklessClosedChannelException exceptions that are generated intermittently.

## Approach
Allow reconnect attempts configuration to be configured for the Vert.x postgres client. Also, include a default reconnect attempt of 3 to the module descriptor.

## Learning
https://folio-org.atlassian.net/browse/MODSOURCE-757
