### PR TITLE
MODSOURCE-758 execute schema init on non-eventloop thread

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -60,11 +60,14 @@ public class ModTenantAPI extends TenantAPI {
     Vertx vertx = context.owner();
 
     return super.loadData(attributes, tenantId, headers, context)
-      .compose(num -> {
-      LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
-      return setLoadSampleParameter(attributes, context)
-        .compose(v -> createStubSnapshot(attributes)).map(num);
-    });
+      .compose(num -> vertx.executeBlocking(() -> {
+            LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
+            return null;
+          })
+          .compose(ar -> setLoadSampleParameter(attributes, context))
+          .compose(v -> createStubSnapshot(attributes))
+          .map(num)
+      );
   }
 
   @Validate


### PR DESCRIPTION
## Purpose
curb blocking of the eventloop when tenant schema initialization occurs

## Approach
run tenant schema initialization on a worker thread away from the eventloop.

