### PR TITLE
MODSOURCE-608: Missing metadata in quick-marc editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * [MODINV-967](https://folio-org.atlassian.net/browse/MODINV-967) Move "Modify" action processing to inventory
 * [MODINV-935](https://folio-org.atlassian.net/browse/MODINV-935) Move Marc-Bib matching event handler to inventory
 * [MODSOURCE-749](https://folio-org.atlassian.net/browse/MODSOURCE-749) 00X fields reset position when Creating/Deriving/Editing MARC records
+* [MODSOURCE-608](https://folio-org.atlassian.net/browse/MODSOURCE-608) "PMSystem" displayed as source in "quickmarc" view when record was created by "Non-matches" action of job profile
 
 ## 2023-10-13 v5.7.0
 * [MODSOURCE-648](https://issues.folio.org/browse/MODSOURCE-648) Upgrade mod-source-record-storage to Java 17

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AbstractPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AbstractPostProcessingEventHandlerTest.java
@@ -59,6 +59,7 @@ public abstract class AbstractPostProcessingEventHandlerTest extends AbstractLBS
   protected static final String PARSED_CONTENT_WITHOUT_001_FIELD =
     "{\"leader\":\"01589ccm a2200373   4500\",\"fields\":[{\"245\":{\"ind1\":\"1\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"Neue Ausgabe sämtlicher Werke,\"}]}},{\"999\":{\"ind1\":\"f\",\"ind2\":\"f\",\"subfields\":[{\"s\":\"bc37566c-0053-4e8b-bd39-15935ca36894\"}]}}]}";
   protected static final String MAPPING_METADATA__URL = "/mapping-metadata";
+  private static final String USER_ID = "userId";
   protected static final String recordId = UUID.randomUUID().toString();
   private static RawRecord rawRecord;
   private static ParsedRecord parsedRecord;
@@ -159,7 +160,8 @@ public abstract class AbstractPostProcessingEventHandlerTest extends AbstractLBS
       .withJobExecutionId(record.getSnapshotId())
       .withTenant(TENANT_ID)
       .withOkapiUrl(mockServer.baseUrl())
-      .withToken(TOKEN);
+      .withToken(TOKEN)
+      .withAdditionalProperty(USER_ID, UUID.randomUUID().toString());
   }
 
   protected JsonObject createExternalEntity(String id, String hrid) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
@@ -155,6 +155,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
             context.assertNotNull(rec.getExternalIdsHolder());
             context.assertTrue(expectedAuthorityId.equals(rec.getExternalIdsHolder().getAuthorityId()));
             context.assertNotEquals(rec.getId(), record.getId());
+            context.assertNotNull(rec.getMetadata().getUpdatedByUserId());
             async.complete();
           });
         });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
@@ -12,9 +12,6 @@ import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -216,6 +213,7 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
 
         String actualAuthorityId = getInventoryId(fields);
         context.assertEquals(expectedAuthorityId, actualAuthorityId);
+        context.assertNotNull(savedRecord.getMetadata().getUpdatedByUserId());
         async.complete();
       });
     });

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/handlers/AuthorityPostProcessingEventHandlerTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +29,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.services.RecordService;
 import org.folio.services.SnapshotService;
 import org.junit.Assert;
@@ -121,7 +123,9 @@ public class AuthorityPostProcessingEventHandlerTest extends AbstractPostProcess
           .withSnapshotId(snapshotId2)
           .withRawRecord(record.getRawRecord().withId(recordForUdateId))
           .withParsedRecord(record.getParsedRecord().withId(recordForUdateId))
-          .withGeneration(1);
+          .withGeneration(1)
+          .withMetadata(new Metadata().withCreatedByUserId(UUID.randomUUID().toString())
+            .withCreatedDate(new Date()));
 
         HashMap<String, String> payloadContextForUpdate = new HashMap<>();
         payloadContextForUpdate.put(AUTHORITY.value(), authority.encode());


### PR DESCRIPTION
## Purpose
"PMSystem" displayed as source in "quickmarc" view when record was created by "Non-matches" action of job profile
## Approach
MODSOURCE-608: Added user metadata during post processing
## Learning
[MODSOURCE-608](https://folio-org.atlassian.net/browse/MODSOURCE-608)
