### PR TITLE
MODSOURCE-763 SRS MARC query search won't allow you to create two search conditions for a single field (SPIKE)

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -194,6 +194,11 @@
       <version>3.1.1</version>
     </dependency>
     <dependency>
+      <groupId>com.github.jsqlparser</groupId>
+      <artifactId>jsqlparser</artifactId>
+      <version>4.9</version>
+    </dependency>
+    <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
       <version>${kafkajunit.version}</version>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import io.vertx.sqlclient.Row;
+import net.sf.jsqlparser.JSQLParserException;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;
 import org.folio.rest.jaxrs.model.MarcBibCollection;
@@ -128,7 +129,7 @@ public interface RecordDao {
    * @param tenantId              tenant id
    * @return {@link Flowable} of {@link Record id}
    */
-  Flowable<Row> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters, String tenantId);
+  Flowable<Row> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters, String tenantId) throws JSQLParserException;
 
   /**
    * Searches for {@link Record} by id

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -221,6 +221,9 @@ public class RecordDaoImpl implements RecordDao {
     "UNION " +
     "SELECT marc_id " +
     "FROM deleted_rows2";
+  public static final String OR = " or ";
+  public static final String MARC_INDEXERS = "marc_indexers";
+  public static final String RECORDS_LB1 = "records_lb";
 
   private final PostgresClientFactory postgresClientFactory;
 
@@ -435,7 +438,7 @@ public class RecordDaoImpl implements RecordDao {
       if (expression instanceof AndExpression) {
         combinedExpression.append(" and ");
       } else if (expression instanceof OrExpression) {
-        combinedExpression.append(" or ");
+        combinedExpression.append(OR);
       }
       if (containsParenthesis(rightExpression)) {
         combinedExpression.append(buildCteDistinctCountCondition(rightExpression));
@@ -477,7 +480,7 @@ public class RecordDaoImpl implements RecordDao {
     int i = 1;
     for (Expression expression : expressions) {
       cteWhereCondition.append(expression.toString());
-      if (i < expressions.size()) cteWhereCondition.append(" or ");
+      if (i < expressions.size()) cteWhereCondition.append(OR);
       i++;
     }
     return cteWhereCondition.toString();
@@ -497,9 +500,9 @@ public class RecordDaoImpl implements RecordDao {
 
       commonTableExpression = DSL.name(CTE).as(
         select(
-          field("marc_id"))
-          .from("marc_indexers").join(RECORDS_LB)
-          .on("marc_indexers.marc_id = records_lb.id")
+          field(MARC_ID))
+          .from(MARC_INDEXERS).join(RECORDS_LB.getName())
+          .on(MARC_INDEXERS + "." + MARC_ID + " = " + RECORDS_LB.getName() + "." + ID)
           .where(DSL.condition(cteWhereExpression, parseFieldsResult.getBindingParams().toArray()))
           .groupBy(field(MARC_ID))
           .having(DSL.condition(cteHavingExpression, parseFieldsResult.getBindingParams().toArray()))

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -421,8 +421,8 @@ public class RecordDaoImpl implements RecordDao {
 
   private static String buildCteDistinctCountCondition(Expression expression) {
     StringBuilder combinedExpression = new StringBuilder();
-    if (expression instanceof Parenthesis) {
-      Expression innerExpression = ((Parenthesis) expression).getExpression();
+    if (expression instanceof Parenthesis parenthesis) {
+      Expression innerExpression = parenthesis.getExpression();
       if (containsParenthesis(innerExpression)) {
         combinedExpression.append(buildCteDistinctCountCondition(innerExpression));
       } else {
@@ -449,12 +449,10 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   private static void parseExpression(Expression expr, List<Expression> expressions) {
-    if (expr instanceof BinaryExpression) {
-      BinaryExpression binExpr = (BinaryExpression) expr;
+    if (expr instanceof BinaryExpression binExpr) {
       parseExpression(binExpr.getLeftExpression(), expressions);
       parseExpression(binExpr.getRightExpression(), expressions);
-    } else if (expr instanceof Parenthesis) {
-      Parenthesis parenthesis = (Parenthesis) expr;
+    } else if (expr instanceof Parenthesis parenthesis) {
       if (containsParenthesis(parenthesis.getExpression())) parseExpression(parenthesis.getExpression(), expressions);
       else expressions.add(parenthesis);
     }
@@ -463,8 +461,7 @@ public class RecordDaoImpl implements RecordDao {
   private static boolean containsParenthesis(Expression expr) {
     if (expr instanceof Parenthesis) {
       return true;
-    } else if (expr instanceof BinaryExpression) {
-      BinaryExpression binExpr = (BinaryExpression) expr;
+    } else if (expr instanceof BinaryExpression binExpr) {
       return containsParenthesis(binExpr.getLeftExpression()) || containsParenthesis(binExpr.getRightExpression());
     } else {
       return false;

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -530,6 +530,7 @@ public class RecordDaoImpl implements RecordDao {
       sql = select().from(searchQuery).rightJoin(countQuery).on(DSL.trueCondition()).getSQL(ParamType.INLINED);
     }
     String finalSql = sql;
+    LOG.trace("streamMarcRecordIds :: SQL : {}", finalSql);
     return getCachedPool(tenantId)
             .rxGetConnection()
             .flatMapPublisher(conn -> conn.rxBegin()

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1,39 +1,5 @@
 package org.folio.dao;
 
-import static java.lang.String.format;
-import static java.util.Collections.emptyList;
-import static org.folio.dao.util.AdvisoryLockUtil.acquireLock;
-import static org.folio.dao.util.ErrorRecordDaoUtil.ERROR_RECORD_CONTENT;
-import static org.folio.dao.util.ParsedRecordDaoUtil.PARSED_RECORD_CONTENT;
-import static org.folio.dao.util.RawRecordDaoUtil.RAW_RECORD_CONTENT;
-import static org.folio.dao.util.RecordDaoUtil.RECORD_NOT_FOUND_TEMPLATE;
-import static org.folio.dao.util.RecordDaoUtil.ensureRecordForeignKeys;
-import static org.folio.dao.util.RecordDaoUtil.filterRecordByExternalIdNonNull;
-import static org.folio.dao.util.RecordDaoUtil.filterRecordByState;
-import static org.folio.dao.util.RecordDaoUtil.filterRecordByType;
-import static org.folio.dao.util.RecordDaoUtil.getExternalHrid;
-import static org.folio.dao.util.RecordDaoUtil.getExternalId;
-import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
-import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
-import static org.folio.rest.jooq.Tables.ERROR_RECORDS_LB;
-import static org.folio.rest.jooq.Tables.MARC_RECORDS_LB;
-import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
-import static org.folio.rest.jooq.Tables.RAW_RECORDS_LB;
-import static org.folio.rest.jooq.Tables.RECORDS_LB;
-import static org.folio.rest.jooq.Tables.SNAPSHOTS_LB;
-import static org.folio.rest.jooq.enums.RecordType.MARC_BIB;
-import static org.folio.rest.util.QueryParamUtil.toRecordType;
-import static org.jooq.impl.DSL.condition;
-import static org.jooq.impl.DSL.countDistinct;
-import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.inline;
-import static org.jooq.impl.DSL.max;
-import static org.jooq.impl.DSL.name;
-import static org.jooq.impl.DSL.primaryKey;
-import static org.jooq.impl.DSL.select;
-import static org.jooq.impl.DSL.table;
-import static org.jooq.impl.DSL.trueCondition;
-
 import com.google.common.collect.Lists;
 import io.github.jklingsporn.vertx.jooq.classic.reactivepg.ReactiveClassicGenericQueryExecutor;
 import io.github.jklingsporn.vertx.jooq.shared.internal.QueryResult;
@@ -45,24 +11,6 @@ import io.vertx.core.Vertx;
 import io.vertx.reactivex.pgclient.PgPool;
 import io.vertx.reactivex.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Row;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.commons.lang3.StringUtils;
@@ -108,6 +56,7 @@ import org.folio.services.RecordSearchParameters;
 import org.folio.services.util.TypeConnection;
 import org.folio.services.util.parser.ParseFieldsResult;
 import org.folio.services.util.parser.ParseLeaderResult;
+import org.jooq.CommonTableExpression;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -133,6 +82,62 @@ import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.folio.dao.util.AdvisoryLockUtil.acquireLock;
+import static org.folio.dao.util.ErrorRecordDaoUtil.ERROR_RECORD_CONTENT;
+import static org.folio.dao.util.ParsedRecordDaoUtil.PARSED_RECORD_CONTENT;
+import static org.folio.dao.util.RawRecordDaoUtil.RAW_RECORD_CONTENT;
+import static org.folio.dao.util.RecordDaoUtil.RECORD_NOT_FOUND_TEMPLATE;
+import static org.folio.dao.util.RecordDaoUtil.ensureRecordForeignKeys;
+import static org.folio.dao.util.RecordDaoUtil.filterRecordByExternalIdNonNull;
+import static org.folio.dao.util.RecordDaoUtil.filterRecordByState;
+import static org.folio.dao.util.RecordDaoUtil.filterRecordByType;
+import static org.folio.dao.util.RecordDaoUtil.getExternalHrid;
+import static org.folio.dao.util.RecordDaoUtil.getExternalId;
+import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
+import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
+import static org.folio.rest.jooq.Tables.ERROR_RECORDS_LB;
+import static org.folio.rest.jooq.Tables.MARC_RECORDS_LB;
+import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
+import static org.folio.rest.jooq.Tables.RAW_RECORDS_LB;
+import static org.folio.rest.jooq.Tables.RECORDS_LB;
+import static org.folio.rest.jooq.Tables.SNAPSHOTS_LB;
+import static org.folio.rest.jooq.enums.RecordType.MARC_BIB;
+import static org.folio.rest.util.QueryParamUtil.toRecordType;
+import static org.jooq.impl.DSL.condition;
+import static org.jooq.impl.DSL.countDistinct;
+import static org.jooq.impl.DSL.exists;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.inline;
+import static org.jooq.impl.DSL.max;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.primaryKey;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.table;
+import static org.jooq.impl.DSL.trueCondition;
 
 @Component
 public class RecordDaoImpl implements RecordDao {
@@ -166,7 +171,7 @@ public class RecordDaoImpl implements RecordDao {
 
   private static final Field<Integer> COUNT_FIELD = field(name(COUNT), Integer.class);
 
-  private static final Field<?>[] RECORD_FIELDS = new Field<?>[] {
+  private static final Field<?>[] RECORD_FIELDS = new Field<?>[]{
     RECORDS_LB.ID,
     RECORDS_LB.SNAPSHOT_ID,
     RECORDS_LB.MATCHED_ID,
@@ -406,52 +411,59 @@ public class RecordDaoImpl implements RecordDao {
           .doAfterTerminate(tx::commit)));
   }
 
-  @Override
-  public Flowable<Row> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters, String tenantId) {
-    /* Building a search query */
-    SelectJoinStep searchQuery = DSL.selectDistinct(RECORDS_LB.EXTERNAL_ID).from(RECORDS_LB);
-    appendJoin(searchQuery, parseLeaderResult, parseFieldsResult);
-    appendWhere(searchQuery, parseLeaderResult, parseFieldsResult, searchParameters);
-    if (searchParameters.getOffset() != null) {
-      searchQuery.offset(searchParameters.getOffset());
-    }
-    if (searchParameters.getLimit() != null) {
-      searchQuery.limit(searchParameters.getLimit());
-    }
-    /* Building a count query */
-    SelectJoinStep countQuery = DSL.select(countDistinct(RECORDS_LB.EXTERNAL_ID)).from(RECORDS_LB);
-    appendJoin(countQuery, parseLeaderResult, parseFieldsResult);
-    appendWhere(countQuery, parseLeaderResult, parseFieldsResult, searchParameters);
-    /* Join both in one query */
-    String sql = DSL.select().from(searchQuery).rightJoin(countQuery).on(DSL.trueCondition()).getSQL(ParamType.INLINED);
 
-    return getCachedPool(tenantId)
-      .rxGetConnection()
-      .flatMapPublisher(conn -> conn.rxBegin()
-        .flatMapPublisher(tx -> conn.rxPrepare(sql)
-          .flatMapPublisher(pq -> pq.createStream(10000)
-            .toFlowable()
-            .filter(row -> !enableFallbackQuery || row.getInteger(COUNT) != 0)
-            .switchIfEmpty(streamMarcRecordIdsWithoutIndexersVersionUsage(conn, parseLeaderResult, parseFieldsResult, searchParameters))
-            .map(this::toRow))
-          .doAfterTerminate(tx::commit)));
+  private String distinctCountConditions(ParseFieldsResult parseFieldsResult, List<String> conditions) {
+    int minPassCriteria = 1;
+
+    StringBuilder combinedExpression = new StringBuilder();
+    AtomicInteger counter = new AtomicInteger();
+
+    for (String condition : conditions) {
+      if (condition.trim().equals("or") || condition.trim().equals("and")) {
+        combinedExpression.append(" ").append(condition).append(" ");
+      } else {
+        combinedExpression.append(countDistinct(DSL.case_().when(DSL.condition(condition), counter.getAndIncrement())).eq(minPassCriteria));
+        combinedExpression.append(" ");
+      }
+    }
+    return combinedExpression.toString();
+  }
+
+  private static List<String> conditionSplitter(String expression) {
+    List<String> result = new ArrayList<>();
+    int start = 0;
+    Stack<Integer> parenthesisStack = new Stack<>();
+
+    for (int i = 0; i < expression.length(); i++) {
+      char c = expression.charAt(i);
+      if (c == '(') {
+        parenthesisStack.push(i);
+      } else if (c == ')') {
+        if (!parenthesisStack.isEmpty()) {
+          parenthesisStack.pop();
+          if (parenthesisStack.isEmpty()) {
+            // When the stack is empty, we're at the top level:
+            String condition = expression.substring(start, i + 1).trim();
+            if (!condition.isEmpty()) result.add(condition);
+
+            // Look ahead for logical operators
+            int nextStart = expression.indexOf('(', i);
+            if (nextStart > i) {
+              String operator = expression.substring(i + 1, nextStart).trim();
+              if (!operator.isEmpty()) result.add(operator);
+            }
+            start = nextStart;
+          }
+        }
+      }
+    }
+    return result;
   }
 
   private void appendJoin(SelectJoinStep selectJoinStep, ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult) {
     if (parseLeaderResult.isEnabled() && !parseLeaderResult.isIndexedFieldsCriteriaOnly()) {
       Table<org.jooq.Record> marcIndexersLeader = table(name("marc_indexers_leader"));
       selectJoinStep.innerJoin(marcIndexersLeader).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexersLeader, name(MARC_ID))));
-    }
-    if (parseFieldsResult.isEnabled()) {
-      parseFieldsResult.getFieldsToJoin().forEach(fieldToJoin -> {
-        Table<org.jooq.Record> marcIndexers = table(name(MARC_INDEXERS_PARTITION_PREFIX + fieldToJoin)).as("i" + fieldToJoin);
-        Field<UUID> marcIndexersMarcIdField = field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexers, name(MARC_ID));
-        Field<Integer> marcIndexersVersionField = field(TABLE_FIELD_TEMPLATE, Integer.class, marcIndexers, name(VERSION));
-        selectJoinStep.innerJoin(marcIndexers).on(RECORDS_LB.ID.eq(field(TABLE_FIELD_TEMPLATE, UUID.class, marcIndexers, name(MARC_ID))))
-          .innerJoin(MARC_RECORDS_TRACKING.as("mrt_"+ fieldToJoin)) // join to marc_records_tracking to return latest version
-          .on(marcIndexersMarcIdField.eq(MARC_RECORDS_TRACKING.as("mrt_"+ fieldToJoin).MARC_ID)
-            .and(marcIndexersVersionField.eq(MARC_RECORDS_TRACKING.as("mrt_"+ fieldToJoin).VERSION)));
-      });
     }
   }
 
@@ -463,7 +475,8 @@ public class RecordDaoImpl implements RecordDao {
       ? DSL.condition(parseLeaderResult.getWhereExpression(), parseLeaderResult.getBindingParams().toArray())
       : DSL.noCondition();
     Condition fieldsCondition = parseFieldsResult.isEnabled()
-      ? DSL.condition(parseFieldsResult.getWhereExpression(), parseFieldsResult.getBindingParams().toArray())
+      ? exists(select(field("*")).from("cte")
+            .where("records_lb.id = cte.marc_id"))
       : DSL.noCondition();
     step.where(leaderCondition)
       .and(fieldsCondition)
@@ -960,6 +973,67 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
+  public Flowable<Row> streamMarcRecordIds(ParseLeaderResult parseLeaderResult, ParseFieldsResult parseFieldsResult, RecordSearchParameters searchParameters, String tenantId) {
+    /* Building a search query */
+
+    //      TODO: adjust bracets in condtion statements
+    List<String> conditions;
+    CommonTableExpression commonTableExpression = null;
+    if (parseFieldsResult.isEnabled()) {
+      conditions = conditionSplitter(parseFieldsResult.getWhereExpression());
+
+      String conditionForHavingStatement = distinctCountConditions(parseFieldsResult, conditions);
+      commonTableExpression = DSL.name("cte").as(
+              select(
+                      field("marc_id"))
+                      .from("marc_indexers").join(RECORDS_LB)
+                      .on("marc_indexers.marc_id = records_lb.id")
+                      .groupBy(field("marc_id"))
+                      .having(DSL.condition(conditionForHavingStatement, parseFieldsResult.getBindingParams().toArray()))
+      );
+    }
+    SelectJoinStep searchQuery = DSL.selectDistinct(RECORDS_LB.EXTERNAL_ID).from(RECORDS_LB);
+    appendJoin(searchQuery, parseLeaderResult, parseFieldsResult);
+    appendWhere(searchQuery, parseLeaderResult, parseFieldsResult, searchParameters);
+    if (searchParameters.getOffset() != null) {
+      searchQuery.offset(searchParameters.getOffset());
+    }
+    if (searchParameters.getLimit() != null) {
+      searchQuery.limit(searchParameters.getLimit());
+    }
+    /* Building a count query */
+    SelectJoinStep countQuery = DSL.select(countDistinct(RECORDS_LB.EXTERNAL_ID)).from(RECORDS_LB);
+    appendJoin(countQuery, parseLeaderResult, parseFieldsResult);
+    appendWhere(countQuery, parseLeaderResult, parseFieldsResult, searchParameters);
+    /* Join both in one query */
+    String sql = "";
+    if (parseFieldsResult.isEnabled()) {
+      sql = DSL.with(commonTableExpression).select().from(searchQuery).rightJoin(countQuery).on(DSL.trueCondition()).getSQL(ParamType.INLINED);
+    } else {
+      sql = select().from(searchQuery).rightJoin(countQuery).on(DSL.trueCondition()).getSQL(ParamType.INLINED);
+    }
+    System.out.println(sql);
+    String finalSql = sql;
+    return getCachedPool(tenantId)
+            .rxGetConnection()
+            .flatMapPublisher(conn -> conn.rxBegin()
+                    .flatMapPublisher(tx -> conn.rxPrepare(finalSql)
+                            .flatMapPublisher(pq -> pq.createStream(10000)
+                                    .toFlowable()
+                                    .filter(row -> !enableFallbackQuery || row.getInteger(COUNT) != 0)
+                                    .switchIfEmpty(streamMarcRecordIdsWithoutIndexersVersionUsage(conn, parseLeaderResult, parseFieldsResult, searchParameters))
+                                    .map(this::toRow))
+                            .doAfterTerminate(tx::commit)));
+  }
+
+  @Override
+  public Future<Optional<Record>> getRecordByExternalId(String externalId, IdType idType,
+                                                        String tenantId) {
+    return getQueryExecutor(tenantId)
+      .transaction(txQE -> getRecordByExternalId(txQE, externalId, idType));
+  }
+
+  @Override
   public Future<ParsedRecordsBatchResponse> updateParsedRecords(RecordCollection recordCollection, String tenantId) {
     logRecordCollection("updateParsedRecords:: Updating", recordCollection, tenantId);
     Promise<ParsedRecordsBatchResponse> promise = Promise.promise();
@@ -1062,8 +1136,8 @@ public class RecordDaoImpl implements RecordDao {
             }
 
           }).map(Record::getParsedRecord)
-            .filter(parsedRecord -> Objects.nonNull(parsedRecord.getId()))
-            .collect(Collectors.toList());
+                .filter(parsedRecord -> Objects.nonNull(parsedRecord.getId()))
+                .collect(Collectors.toList());
 
         try (Connection connection = getConnection(tenantId)) {
           DSL.using(connection).transaction(ctx -> {
@@ -1103,43 +1177,20 @@ public class RecordDaoImpl implements RecordDao {
         } catch (SQLException e) {
           LOG.warn("updateParsedRecords:: Failed to update records", e);
           blockingPromise.fail(e);
-        }},
-        false,
-          result -> {
-            if (result.failed()) {
-              LOG.warn("updateParsedRecords:: Error during update of parsed records", result.cause());
-              promise.fail(result.cause());
-            } else {
-              LOG.debug("updateParsedRecords:: Parsed records update was successful");
-              promise.complete(result.result());
-            }
-          });
+        }
+      },
+            false,
+            result -> {
+              if (result.failed()) {
+                LOG.warn("updateParsedRecords:: Error during update of parsed records", result.cause());
+                promise.fail(result.cause());
+              } else {
+                LOG.debug("updateParsedRecords:: Parsed records update was successful");
+                promise.complete(result.result());
+              }
+            });
 
     return promise.future();
-  }
-
-  @Override
-  public Future<Optional<Record>> getRecordByExternalId(String externalId, IdType idType,
-      String tenantId) {
-    return getQueryExecutor(tenantId)
-      .transaction(txQE -> getRecordByExternalId(txQE, externalId, idType));
-  }
-
-  @Override
-  public Future<Optional<Record>> getRecordByExternalId(ReactiveClassicGenericQueryExecutor txQE,
-      String externalId, IdType idType) {
-    Condition condition = RecordDaoUtil.getExternalIdCondition(externalId, idType)
-      .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL)
-        .or(RECORDS_LB.STATE.eq(RecordState.DELETED)));
-    return txQE.findOneRow(dsl -> dsl.selectFrom(RECORDS_LB)
-      .where(condition)
-      .orderBy(RECORDS_LB.GENERATION.sort(SortOrder.DESC))
-      .limit(1))
-        .map(RecordDaoUtil::toOptionalRecord)
-        .compose(optionalRecord -> optionalRecord
-          .map(record -> lookupAssociatedRecords(txQE, record, false).map(Optional::of))
-          .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_BY_ID_TYPE, idType, externalId)))))
-        .onFailure(v -> txQE.rollback());
   }
 
   @Override
@@ -1178,13 +1229,20 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<Boolean> updateSuppressFromDiscoveryForRecord(String id, IdType idType, Boolean suppress, String tenantId) {
-    LOG.trace("updateSuppressFromDiscoveryForRecord:: Updating suppress from discovery with value {} for record with {} {} for tenant {}", suppress, idType, id, tenantId);
-    return getQueryExecutor(tenantId).transaction(txQE -> getRecordByExternalId(txQE, id, idType)
-      .compose(optionalRecord -> optionalRecord
-        .map(record -> RecordDaoUtil.update(txQE, record.withAdditionalInfo(record.getAdditionalInfo().withSuppressDiscovery(suppress))))
-      .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_BY_ID_TYPE, idType, id))))))
-        .map(u -> true);
+  public Future<Optional<Record>> getRecordByExternalId(ReactiveClassicGenericQueryExecutor txQE,
+                                                        String externalId, IdType idType) {
+    Condition condition = RecordDaoUtil.getExternalIdCondition(externalId, idType)
+      .and(RECORDS_LB.STATE.eq(RecordState.ACTUAL)
+        .or(RECORDS_LB.STATE.eq(RecordState.DELETED)));
+    return txQE.findOneRow(dsl -> dsl.selectFrom(RECORDS_LB)
+                    .where(condition)
+                    .orderBy(RECORDS_LB.GENERATION.sort(SortOrder.DESC))
+                    .limit(1))
+            .map(RecordDaoUtil::toOptionalRecord)
+            .compose(optionalRecord -> optionalRecord
+                    .map(record -> lookupAssociatedRecords(txQE, record, false).map(Optional::of))
+                    .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_BY_ID_TYPE, idType, externalId)))))
+            .onFailure(v -> txQE.rollback());
   }
 
   @Override
@@ -1448,19 +1506,19 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   private Field<?>[] getRecordFields(Name prt) {
-    return (Field<?>[]) ArrayUtils.addAll(RECORD_FIELDS, new Field<?>[] {
+    return (Field<?>[]) ArrayUtils.addAll(RECORD_FIELDS, new Field<?>[]{
       field(TABLE_FIELD_TEMPLATE, JSONB.class, prt, name(CONTENT))
     });
   }
 
   private Field<?>[] getRecordFieldsWithCount(Name prt) {
-    return (Field<?>[]) ArrayUtils.addAll(getRecordFields(prt), new Field<?>[] {
+    return (Field<?>[]) ArrayUtils.addAll(getRecordFields(prt), new Field<?>[]{
       COUNT_FIELD
     });
   }
 
   private Field<?>[] getAllRecordFields(Name prt) {
-    return (Field<?>[]) ArrayUtils.addAll(RECORD_FIELDS, new Field<?>[] {
+    return (Field<?>[]) ArrayUtils.addAll(RECORD_FIELDS, new Field<?>[]{
       field(TABLE_FIELD_TEMPLATE, JSONB.class, prt, name(CONTENT)).as(PARSED_RECORD_CONTENT),
       RAW_RECORDS_LB.CONTENT.as(RAW_RECORD_CONTENT),
       ERROR_RECORDS_LB.CONTENT.as(ERROR_RECORD_CONTENT),
@@ -1469,13 +1527,13 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   private Field<?>[] getAllRecordFieldsWithCount(Name prt) {
-    return (Field<?>[]) ArrayUtils.addAll(getAllRecordFields(prt), new Field<?>[] {
+    return (Field<?>[]) ArrayUtils.addAll(getAllRecordFields(prt), new Field<?>[]{
       COUNT_FIELD
     });
   }
 
   private Field<?>[] getStrippedParsedRecordWithCount(Name prt) {
-    return new Field<?>[] { COUNT_FIELD,
+    return new Field<?>[]{COUNT_FIELD,
       RECORDS_LB.ID, RECORDS_LB.EXTERNAL_ID,
       RECORDS_LB.STATE, RECORDS_LB.RECORD_TYPE,
       field(TABLE_FIELD_TEMPLATE, JSONB.class, prt, name(CONTENT)).as(PARSED_RECORD_CONTENT)
@@ -1513,8 +1571,7 @@ public class RecordDaoImpl implements RecordDao {
     // Validation to ignore records insertion to the returned recordCollection when limit equals zero
     if (limit == 0) {
       return new RecordCollection().withTotalRecords(asRow(result.unwrap()).getInteger(COUNT));
-    }
-    else {
+    } else {
       return toRecordCollection(result);
     }
   }
@@ -1588,4 +1645,13 @@ public class RecordDaoImpl implements RecordDao {
     return condition;
   }
 
+  @Override
+  public Future<Boolean> updateSuppressFromDiscoveryForRecord(String id, IdType idType, Boolean suppress, String tenantId) {
+    LOG.trace("updateSuppressFromDiscoveryForRecord:: Updating suppress from discovery with value {} for record with {} {} for tenant {}", suppress, idType, id, tenantId);
+    return getQueryExecutor(tenantId).transaction(txQE -> getRecordByExternalId(txQE, id, idType)
+                    .compose(optionalRecord -> optionalRecord
+                            .map(record -> RecordDaoUtil.update(txQE, record.withAdditionalInfo(record.getAdditionalInfo().withSuppressDiscovery(suppress))))
+                            .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_BY_ID_TYPE, idType, id))))))
+            .map(u -> true);
+  }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/SearchExpressionParser.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/SearchExpressionParser.java
@@ -74,10 +74,10 @@ public class SearchExpressionParser {
 
   private static String processExpression(String expression, List<Lexeme> lexemes) {
     if (expression.matches(MARC_FIELD.getSearchValue()) || expression.matches(LEADER_FIELD.getSearchValue())) {
-      String splitResult[] = expression.split(SPACE, 3);
+      String[] splitResult = expression.split(SPACE, 3);
       String leftOperand = splitResult[0];
       String operator = splitResult[1];
-      String rightSuffix[] = splitResult[2].split("'*'", 3);
+      String[] rightSuffix = splitResult[2].split("'*'", 3);
       String rightOperand = rightSuffix[1];
       lexemes.add(BinaryOperandLexeme.of(leftOperand, operator, rightOperand));
       return rightSuffix[2];

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/DateRangeBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/DateRangeBinaryOperand.java
@@ -50,18 +50,22 @@ public class DateRangeBinaryOperand extends BinaryOperandLexeme {
 
   @Override
   public String toSqlRepresentation() {
-    String iField = "\"i" + key.substring(0, key.indexOf('.')) + "\"";
-    StringBuilder builder = new StringBuilder("to_date(substring(").append(iField).append(".\"value\", 1, 8), '").append(DATE_PATTERN).append("')");
+    String[] keyParts = getKey().split("\\.");
+    String field = keyParts[0];
+    String fieldNumberToSearch = "\"field_no\" = '" + field + "'";
+
+    StringBuilder builder = new StringBuilder("("+fieldNumberToSearch + " and to_date(substring(").append("value, 1, 8), '").append(DATE_PATTERN).append("')");
+
     if (BINARY_OPERATOR_EQUALS.equals(getOperator()) && !this.rangeSearch) {
-      return builder.append(" = ?").toString();
+      return builder.append(" = ?)").toString();
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator()) && !this.rangeSearch) {
-      return builder.append(" <> ?").toString();
+      return builder.append(" <> ?)").toString();
     } else if (BINARY_OPERATOR_FROM.equals(getOperator()) && !this.rangeSearch) {
-      return builder.append(" >= ?").toString();
+      return builder.append(" >= ?)").toString();
     } else if (BINARY_OPERATOR_TO.equals(getOperator()) && !this.rangeSearch) {
-      return builder.append(" <= ?").toString();
+      return builder.append(" <= ?)").toString();
     } else if (BINARY_OPERATOR_IN.equals(getOperator()) && this.rangeSearch) {
-      return builder.append(" between ? and ?").toString();
+      return builder.append(" between ? and ?)").toString();
     }
     throw new IllegalArgumentException(format("The given expression [%s %s '%s'] is not supported", key, operator.getSearchValue(), value));
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/DateRangeBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/DateRangeBinaryOperand.java
@@ -54,7 +54,7 @@ public class DateRangeBinaryOperand extends BinaryOperandLexeme {
     String field = keyParts[0];
     String fieldNumberToSearch = "\"field_no\" = '" + field + "'";
 
-    StringBuilder builder = new StringBuilder("("+fieldNumberToSearch + " and to_date(substring(").append("value, 1, 8), '").append(DATE_PATTERN).append("')");
+    StringBuilder builder = new StringBuilder("( " + fieldNumberToSearch + " and to_date(substring(").append("value, 1, 8), '").append(DATE_PATTERN).append("')");
 
     if (BINARY_OPERATOR_EQUALS.equals(getOperator()) && !this.rangeSearch) {
       return builder.append(" = ?)").toString();

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
@@ -38,7 +38,7 @@ public class IndicatorBinaryOperand extends BinaryOperandLexeme {
     var field = keyParts[0];
     var indicator = keyParts[1];
     String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
-    var sqlRepresentation = "("+fieldNumberToSearch + " and " + "\"" + indicator + "\"";
+      var sqlRepresentation = "( " + fieldNumberToSearch + " and " + "\"" + indicator + "\"";
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
       return sqlRepresentation + " like ?)";
     } else if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/IndicatorBinaryOperand.java
@@ -37,13 +37,14 @@ public class IndicatorBinaryOperand extends BinaryOperandLexeme {
     String[] keyParts = getKey().split("\\.");
     var field = keyParts[0];
     var indicator = keyParts[1];
-    var sqlRepresentation = "\"" + "i" + field + "\"" + "." + "\"" + indicator + "\"";
+    String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
+    var sqlRepresentation = "("+fieldNumberToSearch + " and " + "\"" + indicator + "\"";
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
-      return sqlRepresentation + " like ?";
+      return sqlRepresentation + " like ?)";
     } else if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {
-      return sqlRepresentation + " = ?";
+      return sqlRepresentation + " = ?)";
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator())) {
-      return sqlRepresentation + " <> ?";
+      return sqlRepresentation + " <> ?)";
     } else if (BINARY_OPERATOR_IS.equals(getOperator())) {
       return PresenceBinaryOperand.getSqlRepresentationForIndicator(field, indicator, value);
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
@@ -33,7 +33,7 @@ public class PositionBinaryOperand extends BinaryOperandLexeme {
   @Override
   public String toSqlRepresentation() {
     String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
-    String prefix = "("+fieldNumberToSearch +" and substring(\"value\", " + startPosition + ", " + endPosition + ")";
+      String prefix = "( " + fieldNumberToSearch + " and substring(\"value\", " + startPosition + ", " + endPosition + ")";
     if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {
       return prefix + " = ?)";
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator())) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PositionBinaryOperand.java
@@ -32,12 +32,12 @@ public class PositionBinaryOperand extends BinaryOperandLexeme {
 
   @Override
   public String toSqlRepresentation() {
-    String iField = "\"" + "i" + field + "\"";
-    String prefix = "substring(" + iField + ".\"value\", " + startPosition + ", " + endPosition + ")";
+    String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
+    String prefix = "("+fieldNumberToSearch +" and substring(\"value\", " + startPosition + ", " + endPosition + ")";
     if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {
-      return prefix + " = ?";
+      return prefix + " = ?)";
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator())) {
-      return prefix + " <> ?";
+      return prefix + " <> ?)";
     }
     throw new IllegalArgumentException(format("Operator [%s] is not supported for the given Position operand", getOperator().getSearchValue()));
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -15,6 +15,7 @@ public class PresenceBinaryOperand {
 
   private static final String PRESENT = "present";
   private static final String ABSENT = "absent";
+  private static final String FIELD_NO = "(\"field_no\" = '";
 
   private PresenceBinaryOperand() {
   }
@@ -22,27 +23,27 @@ public class PresenceBinaryOperand {
   public static String getSqlRepresentationForMarcField(String field, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers))";
+      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers))";
     } else {
-      return "(\"field_no\" = '"+field+"' and id not in (select marc_id from marc_indexers))";
+      return FIELD_NO + field + "' and id not in (select marc_id from marc_indexers))";
     }
   }
 
   public static String getSqlRepresentationForSubField(String field, String subField, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(\"field_no\" = '" + field + "' and id in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
+      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
     } else {
-      return "(\"field_no\" = '" + field + "' and id not in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
+      return FIELD_NO + field + "' and id not in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
     }
   }
 
   public static String getSqlRepresentationForIndicator(String field, String indicator, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers where " + indicator + " <> '#'))";
+      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where " + indicator + " <> '#'))";
     } else {
-      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers where " + indicator + " = '#'))";
+      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where " + indicator + " = '#'))";
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -22,27 +22,27 @@ public class PresenceBinaryOperand {
   public static String getSqlRepresentationForMarcField(String field, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(id in (select marc_id from marc_indexers_" + field + "))";
+      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers))";
     } else {
-      return "(id not in (select marc_id from marc_indexers_" + field + "))";
+      return "(\"field_no\" = '"+field+"' and id not in (select marc_id from marc_indexers))";
     }
   }
 
   public static String getSqlRepresentationForSubField(String field, String subField, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(id in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "')) ";
+      return "(\"field_no\" = '" + field + "' and id in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
     } else {
-      return "(id not in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "')) ";
+      return "(\"field_no\" = '" + field + "' and id not in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
     }
   }
 
   public static String getSqlRepresentationForIndicator(String field, String indicator, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return "(id in (select marc_id from marc_indexers_" + field + " where " + indicator + " <> '#')) ";
+      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers where " + indicator + " <> '#'))";
     } else {
-      return "(id in (select marc_id from marc_indexers_" + field + " where " + indicator + " = '#')) ";
+      return "(\"field_no\" = '"+field+"' and id in (select marc_id from marc_indexers where " + indicator + " = '#'))";
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -25,7 +25,7 @@ public class PresenceBinaryOperand {
     if (PRESENT.equals(value)) {
       return FIELD_NO + field + "' and marc_indexers.marc_id in (select marc_id from marc_indexers_" + field + "))";
     } else {
-      return FIELD_NO + field + "' and marc_indexers.marc_id not in (select marc_id from marc_indexers))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id not in (select marc_id from marc_indexers_" + field + "))";
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -23,27 +23,27 @@ public class PresenceBinaryOperand {
   public static String getSqlRepresentationForMarcField(String field, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id in (select marc_id from marc_indexers_" + field + "))";
     } else {
-      return FIELD_NO + field + "' and id not in (select marc_id from marc_indexers))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id not in (select marc_id from marc_indexers))";
     }
   }
 
   public static String getSqlRepresentationForSubField(String field, String subField, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "'))";
     } else {
-      return FIELD_NO + field + "' and id not in (select marc_id from marc_indexers where subfield_no = '" + subField + "'))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id not in (select marc_id from marc_indexers_" + field + " where subfield_no = '" + subField + "'))";
     }
   }
 
   public static String getSqlRepresentationForIndicator(String field, String indicator, String value) {
     validateValue(value);
     if (PRESENT.equals(value)) {
-      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where " + indicator + " <> '#'))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id in (select marc_id from marc_indexers_" + field + " where " + indicator + " <> '#'))";
     } else {
-      return FIELD_NO + field + "' and id in (select marc_id from marc_indexers where " + indicator + " = '#'))";
+      return FIELD_NO + field + "' and marc_indexers.marc_id in (select marc_id from marc_indexers_" + field + " where " + indicator + " = '#'))";
     }
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/PresenceBinaryOperand.java
@@ -15,7 +15,7 @@ public class PresenceBinaryOperand {
 
   private static final String PRESENT = "present";
   private static final String ABSENT = "absent";
-  private static final String FIELD_NO = "(\"field_no\" = '";
+    private static final String FIELD_NO = "( \"field_no\" = '";
 
   private PresenceBinaryOperand() {
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
@@ -43,7 +43,7 @@ public class SubFieldBinaryOperand extends BinaryOperandLexeme {
     String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
     String subField = keyParts[1];
     StringBuilder stringBuilder = new StringBuilder()
-      .append("(").append(fieldNumberToSearch).append(" and \"subfield_no\" = '").append(subField).append("'")
+            .append("( ").append(fieldNumberToSearch).append(" and \"subfield_no\" = '").append(subField).append("'")
       .append(" and ")
       .append("\"value\" ");
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/SubFieldBinaryOperand.java
@@ -40,12 +40,12 @@ public class SubFieldBinaryOperand extends BinaryOperandLexeme {
   public String toSqlRepresentation() {
     String[] keyParts = getKey().split("\\.");
     String field = keyParts[0];
-    String iField = "\"" + "i" + field + "\"";
+    String fieldNumberToSearch = "\"field_no\" = '" + field+"'";
     String subField = keyParts[1];
     StringBuilder stringBuilder = new StringBuilder()
-      .append("(").append(iField).append(".\"subfield_no\" = '").append(subField).append("'")
+      .append("(").append(fieldNumberToSearch).append(" and \"subfield_no\" = '").append(subField).append("'")
       .append(" and ")
-      .append(iField).append(".\"value\" ");
+      .append("\"value\" ");
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
       return stringBuilder.append("like ?)").toString();
     } else if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
@@ -30,7 +30,7 @@ public class ValueBinaryOperand extends BinaryOperandLexeme {
   public String toSqlRepresentation() {
     StringBuilder stringBuilder = new StringBuilder();
     String field = getKey().split("\\.")[0];
-    String fieldNumberToSearch = "(\"field_no\" = '" + field+"'";
+    String fieldNumberToSearch = "( \"field_no\" = '" + field + "'";
     String prefix = stringBuilder.append(fieldNumberToSearch).append(" and ").append("\"value\"").toString();
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
       return prefix + " like ?)";

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/parser/lexeme/operand/ValueBinaryOperand.java
@@ -30,13 +30,14 @@ public class ValueBinaryOperand extends BinaryOperandLexeme {
   public String toSqlRepresentation() {
     StringBuilder stringBuilder = new StringBuilder();
     String field = getKey().split("\\.")[0];
-    String prefix = stringBuilder.append("\"").append("i").append(field).append("\".\"value\"").toString();
+    String fieldNumberToSearch = "(\"field_no\" = '" + field+"'";
+    String prefix = stringBuilder.append(fieldNumberToSearch).append(" and ").append("\"value\"").toString();
     if (BINARY_OPERATOR_LEFT_ANCHORED_EQUALS.equals(getOperator())) {
-      return prefix + " like ?";
+      return prefix + " like ?)";
     } else if (BINARY_OPERATOR_EQUALS.equals(getOperator())) {
-      return prefix + " = ?";
+      return prefix + " = ?)";
     } else if (BINARY_OPERATOR_NOT_EQUALS.equals(getOperator())) {
-      return stringBuilder.append(" <> ?").toString();
+      return stringBuilder.append(" <> ?)").toString();
     } else if (BINARY_OPERATOR_IS.equals(getOperator())) {
       return PresenceBinaryOperand.getSqlRepresentationForMarcField(field, value);
     }

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -5,9 +5,6 @@ import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.reactivex.FlowableHelper;
-import io.vertx.sqlclient.Row;
-import net.sf.jsqlparser.JSQLParserException;
 import org.folio.TestMocks;
 import org.folio.TestUtil;
 import org.folio.dao.util.AdvisoryLockUtil;
@@ -17,26 +14,20 @@ import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.processing.value.MissingValue;
 import org.folio.processing.value.StringValue;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
-import org.folio.rest.jaxrs.model.MarcRecordSearchRequest;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.services.AbstractLBServiceTest;
-import org.folio.services.RecordSearchParameters;
 import org.folio.services.util.TypeConnection;
-import org.folio.services.util.parser.ParseFieldsResult;
-import org.folio.services.util.parser.ParseLeaderResult;
-import org.folio.services.util.parser.SearchExpressionParser;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import javax.ws.rs.DELETE;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,9 +35,7 @@ import java.util.UUID;
 import static org.folio.dao.RecordDaoImpl.INDEXERS_DELETION_LOCK_NAMESPACE_ID;
 import static org.folio.rest.jaxrs.model.Record.State.ACTUAL;
 import static org.folio.rest.jaxrs.model.Record.State.DELETED;
-import static org.folio.rest.jaxrs.model.Record.State.OLD;
 import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
-import static org.folio.rest.jooq.Tables.RECORDS_LB;
 
 @RunWith(VertxUnitRunner.class)
 public class RecordDaoImplTest extends AbstractLBServiceTest {

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -9,6 +9,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.reactivex.FlowableHelper;
 import io.vertx.sqlclient.Row;
+import net.sf.jsqlparser.JSQLParserException;
 import org.folio.TestMocks;
 import org.folio.TestUtil;
 import org.folio.dao.util.AdvisoryLockUtil;
@@ -176,7 +177,13 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     ArrayList<String> ids = new ArrayList<>();
 
     Future<Flowable<Row>> future = deleteTrackingRecordById(record.getId())
-      .map(v -> recordDao.streamMarcRecordIds(parseLeaderResult, parseFieldsResult, searchParams, TENANT_ID));
+      .map(v -> {
+        try {
+          return recordDao.streamMarcRecordIds(parseLeaderResult, parseFieldsResult, searchParams, TENANT_ID);
+        } catch (JSQLParserException e) {
+          throw new RuntimeException(e);
+        }
+      });
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1452,31 +1452,6 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         async.complete();
     }
 
-    @Test
-    public void shouldProcessSearchQueryIfSearchNeededWithinOneFieldWithDifferentOperands(TestContext testContext) {
-        // given
-        final Async async = testContext.async();
-        postSnapshots(testContext, snapshot_2);
-        postRecords(testContext, marc_bib_record_2);
-        MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-        searchRequest.setFieldsSearchExpression(
-                "050.a ^= 'M3' and 050.b ^= '.M896'");
-        // when
-        ExtractableResponse<Response> response = RestAssured.given()
-                .spec(spec)
-                .body(searchRequest)
-                .when()
-                .post("/source-storage/stream/marc-record-identifiers")
-                .then()
-                .extract();
-        JsonObject responseBody = new JsonObject(response.body().asString());
-        // then
-        assertEquals(HttpStatus.SC_OK, response.statusCode());
-        assertEquals(1, responseBody.getJsonArray("records").size());
-        assertEquals(1, responseBody.getInteger("totalCount").intValue());
-        async.complete();
-    }
-
   private Flowable<String> flowableInputStreamScanner(InputStream inputStream) {
     return Flowable.create(subscriber -> {
         try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8)) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -27,7 +27,6 @@ import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -926,7 +925,6 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
   }
 
   @Test
-  @Ignore
   public void shouldReturnIdOnSearchMarcRecordIdsWhenSearchByFieldsSearchExpression(TestContext testContext) {
     // given
     final Async async = testContext.async();

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1452,6 +1452,31 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         async.complete();
     }
 
+    @Test
+    public void shouldProcessSearchQueryIfSearchNeededWithinOneFieldWithParenthesis(TestContext testContext) {
+        // given
+        final Async async = testContext.async();
+        postSnapshots(testContext, snapshot_2);
+        postRecords(testContext, marc_bib_record_2);
+        MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+        searchRequest.setFieldsSearchExpression(
+                "(050.a ^= 'M3' and 050.b ^= '.M896') and 240.a ^= 'Works'");
+        // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .spec(spec)
+                .body(searchRequest)
+                .when()
+                .post("/source-storage/stream/marc-record-identifiers")
+                .then()
+                .extract();
+        JsonObject responseBody = new JsonObject(response.body().asString());
+        // then
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals(1, responseBody.getJsonArray("records").size());
+        assertEquals(1, responseBody.getInteger("totalCount").intValue());
+        async.complete();
+    }
+
   private Flowable<String> flowableInputStreamScanner(InputStream inputStream) {
     return Flowable.create(subscriber -> {
         try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8)) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -27,6 +27,7 @@ import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -925,6 +926,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
   }
 
   @Test
+  @Ignore
   public void shouldReturnIdOnSearchMarcRecordIdsWhenSearchByFieldsSearchExpression(TestContext testContext) {
     // given
     final Async async = testContext.async();

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1,22 +1,5 @@
 package org.folio.rest.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Scanner;
-import java.util.UUID;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
@@ -29,10 +12,6 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.folio.TestUtil;
 import org.folio.dao.PostgresClientFactory;
 import org.folio.dao.util.ParsedRecordDaoUtil;
@@ -47,6 +26,27 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Record.RecordType;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Scanner;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(VertxUnitRunner.class)
 public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
@@ -77,23 +77,23 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     }
   }
 
-  private static ParsedRecord invalidParsedRecord = new ParsedRecord()
+    private static final ParsedRecord invalidParsedRecord = new ParsedRecord()
     .withContent("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
-  private static ErrorRecord errorRecord = new ErrorRecord()
+    private static final ErrorRecord errorRecord = new ErrorRecord()
     .withDescription("Oops... something happened")
     .withContent("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
 
-  private static Snapshot snapshot_1 = new Snapshot()
+    private static final Snapshot snapshot_1 = new Snapshot()
     .withJobExecutionId(UUID.randomUUID().toString())
     .withStatus(Snapshot.Status.PARSING_IN_PROGRESS);
-  private static Snapshot snapshot_2 = new Snapshot()
+    private static final Snapshot snapshot_2 = new Snapshot()
     .withJobExecutionId(UUID.randomUUID().toString())
     .withStatus(Snapshot.Status.PARSING_IN_PROGRESS);
-  private static Snapshot snapshot_3 = new Snapshot()
+    private static final Snapshot snapshot_3 = new Snapshot()
     .withJobExecutionId(UUID.randomUUID().toString())
     .withStatus(Snapshot.Status.PARSING_IN_PROGRESS);
 
-  private static Record marc_bib_record_1 = new Record()
+    private static final Record marc_bib_record_1 = new Record()
     .withId(FIRST_UUID)
     .withSnapshotId(snapshot_1.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -101,7 +101,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withMatchedId(FIRST_UUID)
     .withOrder(0)
     .withState(Record.State.ACTUAL);
-  private static Record marc_bib_record_2 = new Record()
+    private static final Record marc_bib_record_2 = new Record()
     .withId(SECOND_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -113,7 +113,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withExternalIdsHolder(new ExternalIdsHolder()
       .withInstanceId(UUID.randomUUID().toString())
       .withInstanceHrid("12345"));
-  private static Record marc_bib_record_3 = new Record()
+    private static final Record marc_bib_record_3 = new Record()
     .withId(THIRD_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -121,7 +121,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withErrorRecord(errorRecord)
     .withMatchedId(THIRD_UUID)
     .withState(Record.State.ACTUAL);
-  private static Record marc_bib_record_4 = new Record()
+    private static final Record marc_bib_record_4 = new Record()
     .withId(FOURTH_UUID)
     .withSnapshotId(snapshot_1.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -133,7 +133,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withExternalIdsHolder(new ExternalIdsHolder()
       .withInstanceId(UUID.randomUUID().toString())
       .withInstanceHrid("12345"));
-  private static Record marc_bib_record_5 = new Record()
+    private static final Record marc_bib_record_5 = new Record()
     .withId(FIFTH_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -142,7 +142,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withParsedRecord(invalidParsedRecord)
     .withOrder(101)
     .withState(Record.State.ACTUAL);
-  private static Record marc_bib_record_6 = new Record()
+    private static final Record marc_bib_record_6 = new Record()
     .withId(SIXTH_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(Record.RecordType.MARC_BIB)
@@ -154,7 +154,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withExternalIdsHolder(new ExternalIdsHolder()
       .withInstanceId(UUID.randomUUID().toString())
       .withInstanceHrid("12345"));
-  private static Record marc_auth_record_1 = new Record()
+    private static final Record marc_auth_record_1 = new Record()
     .withId(SEVENTH_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(RecordType.MARC_AUTHORITY)
@@ -166,7 +166,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     .withExternalIdsHolder(new ExternalIdsHolder()
       .withAuthorityId(UUID.randomUUID().toString())
       .withAuthorityHrid("12345"));
-  private static Record marc_holdings_record_1 = new Record()
+    private static final Record marc_holdings_record_1 = new Record()
     .withId(EIGHTH_UUID)
     .withSnapshotId(snapshot_2.getJobExecutionId())
     .withRecordType(RecordType.MARC_HOLDING)
@@ -588,7 +588,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     InputStream response = RestAssured.given()
       .spec(spec)
       .when()
-      .get(SOURCE_STORAGE_STREAM_SOURCE_RECORDS_PATH + "?recordId=" + UUID.randomUUID().toString() + "&limit=1&offset=0")
+            .get(SOURCE_STORAGE_STREAM_SOURCE_RECORDS_PATH + "?recordId=" + UUID.randomUUID() + "&limit=1&offset=0")
       .then()
       .statusCode(HttpStatus.SC_OK)
       .extract().response().asInputStream();
@@ -1425,9 +1425,59 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     async.complete();
   }
 
+    @Test
+    public void shouldProcessSearchQueryIfSearchNeededWithinOneField(TestContext testContext) {
+        // given
+        final Async async = testContext.async();
+        postSnapshots(testContext, snapshot_2);
+        postRecords(testContext, marc_bib_record_2);
+        MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+        searchRequest.setFieldsSearchExpression(
+                "050.a ^= 'M3' and 050.b ^= '.M896'");
+        // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .spec(spec)
+                .body(searchRequest)
+                .when()
+                .post("/source-storage/stream/marc-record-identifiers")
+                .then()
+                .extract();
+        JsonObject responseBody = new JsonObject(response.body().asString());
+        // then
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals(1, responseBody.getJsonArray("records").size());
+        assertEquals(1, responseBody.getInteger("totalCount").intValue());
+        async.complete();
+    }
+
+    @Test
+    public void shouldProcessSearchQueryIfSearchNeededWithinOneFieldWithDifferentOperands(TestContext testContext) {
+        // given
+        final Async async = testContext.async();
+        postSnapshots(testContext, snapshot_2);
+        postRecords(testContext, marc_bib_record_2);
+        MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+        searchRequest.setFieldsSearchExpression(
+                "050.a ^= 'M3' and 050.b ^= '.M896'");
+        // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .spec(spec)
+                .body(searchRequest)
+                .when()
+                .post("/source-storage/stream/marc-record-identifiers")
+                .then()
+                .extract();
+        JsonObject responseBody = new JsonObject(response.body().asString());
+        // then
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals(1, responseBody.getJsonArray("records").size());
+        assertEquals(1, responseBody.getInteger("totalCount").intValue());
+        async.complete();
+    }
+
   private Flowable<String> flowableInputStreamScanner(InputStream inputStream) {
     return Flowable.create(subscriber -> {
-      try (Scanner scanner = new Scanner(inputStream, "UTF-8")) {
+        try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8)) {
         while (scanner.hasNext()) {
           subscriber.onNext(scanner.nextLine());
         }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1476,7 +1476,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     }
 
   @Test
-  public void shouldReturn400IncorrectRequest(TestContext testContext) {
+  public void shouldReturn400WithIncorrectRequest(TestContext testContext) {
     // given
     Async async = testContext.async();
     Record suppressedRecord = new Record()
@@ -1530,6 +1530,81 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
     searchRequest.setLeaderSearchExpression("p_05 = 'c' and p_06 = 'c' and p_07 = 'm'");
     searchRequest.setFieldsSearchExpression("(035.a = '(OCoLC)63611770' and 036.ind1 = '1') or (245.a ^= 'Neue Ausgabe sämtlicher' and 005.value ^= '20141107')");
+    // when
+    ExtractableResponse<Response> response = RestAssured.given()
+      .spec(spec)
+      .body(searchRequest)
+      .when()
+      .post("/source-storage/stream/marc-record-identifiers")
+      .then()
+      .extract();
+    JsonObject responseBody = new JsonObject(response.body().asString());
+    // then
+    assertEquals(HttpStatus.SC_OK, response.statusCode());
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
+    async.complete();
+  }
+
+  @Test
+  public void shouldReturnDataForNotEqualsOperator(TestContext testContext) {
+    // given
+    Async async = testContext.async();
+    Record suppressedRecord = new Record()
+      .withId(marc_bib_record_2.getId())
+      .withSnapshotId(snapshot_2.getJobExecutionId())
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(marc_bib_record_2.getRawRecord())
+      .withParsedRecord(marc_bib_record_2.getParsedRecord())
+      .withMatchedId(marc_bib_record_2.getMatchedId())
+      .withState(Record.State.ACTUAL)
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withExternalIdsHolder(marc_bib_record_2.getExternalIdsHolder());
+    postSnapshots(testContext, snapshot_2);
+    postRecords(testContext, suppressedRecord);
+
+    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+    searchRequest.setLeaderSearchExpression("p_05 = 'c' and p_06 = 'c' and p_07 = 'm'");
+    searchRequest.setFieldsSearchExpression("(035.a = '(OCoLC)63611770' and 036.ind1 not= '1')");
+    // when
+    ExtractableResponse<Response> response = RestAssured.given()
+      .spec(spec)
+      .body(searchRequest)
+      .when()
+      .post("/source-storage/stream/marc-record-identifiers")
+      .then()
+      .extract();
+    JsonObject responseBody = new JsonObject(response.body().asString());
+    // then
+    assertEquals(HttpStatus.SC_OK, response.statusCode());
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
+    async.complete();
+  }
+
+  @Test
+  public void shouldReturnDataForOneFieldNoOperator(TestContext testContext) {
+    // given
+    Async async = testContext.async();
+    Record suppressedRecord = new Record()
+      .withId(marc_bib_record_2.getId())
+      .withSnapshotId(snapshot_2.getJobExecutionId())
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(marc_bib_record_2.getRawRecord())
+      .withParsedRecord(marc_bib_record_2.getParsedRecord())
+      .withMatchedId(marc_bib_record_2.getMatchedId())
+      .withState(Record.State.ACTUAL)
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withExternalIdsHolder(marc_bib_record_2.getExternalIdsHolder());
+    postSnapshots(testContext, snapshot_2);
+    postRecords(testContext, suppressedRecord);
+
+    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+    searchRequest.setLeaderSearchExpression("p_05 = 'c' and p_06 = 'c' and p_07 = 'm'");
+    searchRequest.setFieldsSearchExpression("(948.ind1 = '2' and 948.value = '20130128')" +
+      "  and (948.ind1 = '2' and 948.value = '20141106') " +
+      "  and (948.ind1 = '2' and 948.value = 'm') " +
+      "  and (948.ind1 = '2' and 948.value = 'batch')");
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1434,8 +1434,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         postSnapshots(testContext, snapshot_2);
         postRecords(testContext, marc_bib_record_2);
         MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-        searchRequest.setFieldsSearchExpression(
-                "050.a ^= 'M3' and 050.b ^= '.M896'");
+        searchRequest.setFieldsSearchExpression("050.a ^= 'M3' and 050.b ^= '.M896'");
         // when
         ExtractableResponse<Response> response = RestAssured.given()
                 .spec(spec)
@@ -1459,8 +1458,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         postSnapshots(testContext, snapshot_2);
         postRecords(testContext, marc_bib_record_2);
         MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-        searchRequest.setFieldsSearchExpression(
-                "(050.a ^= 'M3' and 050.b ^= '.M896') and 240.a ^= 'Works'");
+        searchRequest.setFieldsSearchExpression("(050.a ^= 'M3' and 050.b ^= '.M896') and 240.a ^= 'Works'");
         // when
         ExtractableResponse<Response> response = RestAssured.given()
                 .spec(spec)
@@ -1476,6 +1474,44 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         assertEquals(1, responseBody.getInteger("totalCount").intValue());
         async.complete();
     }
+
+  @Test
+  @Ignore
+  public void shouldReturnRecordOnSearchMarcRecordWhithExampleRequest(TestContext testContext) {
+    // given
+    Async async = testContext.async();
+    Record suppressedRecord = new Record()
+      .withId(marc_bib_record_2.getId())
+      .withSnapshotId(snapshot_2.getJobExecutionId())
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(marc_bib_record_2.getRawRecord())
+      .withParsedRecord(marc_bib_record_2.getParsedRecord())
+      .withMatchedId(marc_bib_record_2.getMatchedId())
+      .withState(Record.State.ACTUAL)
+      .withAdditionalInfo(new AdditionalInfo().withSuppressDiscovery(true))
+      .withExternalIdsHolder(marc_bib_record_2.getExternalIdsHolder());
+    postSnapshots(testContext, snapshot_2);
+    postRecords(testContext, suppressedRecord);
+
+    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+    searchRequest.setLeaderSearchExpression("p_05 = 'c' and p_06 = 'c' and p_07 = 'm'");
+    searchRequest.setFieldsSearchExpression("((035.a = '(OCoLC)770') or (245.a ^= 'Semantic web' and 005.value ^= '20141107') or " +
+      "((035.a = '(OCoLC)7701' and 035.b = '(OCoLC)7702'))) and (035.a = '(OCoLC)7703')");
+    // when
+    ExtractableResponse<Response> response = RestAssured.given()
+      .spec(spec)
+      .body(searchRequest)
+      .when()
+      .post("/source-storage/stream/marc-record-identifiers")
+      .then()
+      .extract();
+    JsonObject responseBody = new JsonObject(response.body().asString());
+    // then
+    assertEquals(HttpStatus.SC_OK, response.statusCode());
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
+    async.complete();
+  }
 
   private Flowable<String> flowableInputStreamScanner(InputStream inputStream) {
     return Flowable.create(subscriber -> {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1565,7 +1565,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
 
     MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
     searchRequest.setLeaderSearchExpression("p_05 = 'c' and p_06 = 'c' and p_07 = 'm'");
-    searchRequest.setFieldsSearchExpression("(035.a = '(OCoLC)63611770' and 036.ind1 not= '1')");
+    searchRequest.setFieldsSearchExpression("(035.a = '(OCoLC)63611770' and 948.ind1 not= '5')");
     // when
     ExtractableResponse<Response> response = RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -187,7 +187,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '035' and id in (select marc_id from marc_indexers where subfield_no = 'a'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id in (select marc_id from marc_indexers_035 where subfield_no = 'a'))", result.getWhereExpression());
   }
 
   @Test
@@ -200,7 +200,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '035' and id not in (select marc_id from marc_indexers where subfield_no = 'z'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id not in (select marc_id from marc_indexers_035 where subfield_no = 'z'))", result.getWhereExpression());
   }
 
   @Test
@@ -291,7 +291,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '035' and id in (select marc_id from marc_indexers))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id in (select marc_id from marc_indexers_035))", result.getWhereExpression());
   }
 
   @Test
@@ -304,7 +304,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '035' and id not in (select marc_id from marc_indexers))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id not in (select marc_id from marc_indexers))", result.getWhereExpression());
   }
 
   @Test
@@ -491,7 +491,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '050' and id in (select marc_id from marc_indexers where ind1 <> '#'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '050' and marc_indexers.marc_id in (select marc_id from marc_indexers_050 where ind1 <> '#'))", result.getWhereExpression());
   }
 
   @Test
@@ -504,7 +504,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '050' and id in (select marc_id from marc_indexers where ind2 = '#'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '050' and marc_indexers.marc_id in (select marc_id from marc_indexers_050 where ind2 = '#'))", result.getWhereExpression());
   }
 
   @Test

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -304,7 +304,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id not in (select marc_id from marc_indexers))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and marc_indexers.marc_id not in (select marc_id from marc_indexers_035))", result.getWhereExpression());
   }
 
   @Test

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -148,7 +148,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)63611770"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -161,7 +161,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" like ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" <> ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -187,7 +187,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and id in (select marc_id from marc_indexers where subfield_no = 'a'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and id in (select marc_id from marc_indexers where subfield_no = 'a'))", result.getWhereExpression());
   }
 
   @Test
@@ -200,7 +200,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and id not in (select marc_id from marc_indexers where subfield_no = 'z'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and id not in (select marc_id from marc_indexers where subfield_no = 'z'))", result.getWhereExpression());
   }
 
   @Test
@@ -213,7 +213,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '036' and \"ind1\" = ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '036' and \"ind1\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -226,7 +226,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '036' and \"ind1\" like ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '036' and \"ind1\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -239,7 +239,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '036' and \"ind1\" <> ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '036' and \"ind1\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -252,7 +252,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107001016.0"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and \"value\" = ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and \"value\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -265,7 +265,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and \"value\" like ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and \"value\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -278,7 +278,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and \"value\" <> ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and \"value\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -291,7 +291,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and id in (select marc_id from marc_indexers))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and id in (select marc_id from marc_indexers))", result.getWhereExpression());
   }
 
   @Test
@@ -304,7 +304,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '035' and id not in (select marc_id from marc_indexers))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '035' and id not in (select marc_id from marc_indexers))", result.getWhereExpression());
   }
 
   @Test
@@ -345,7 +345,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("2014"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and substring(\"value\", 1, 4) = ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and substring(\"value\", 1, 4) = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -358,7 +358,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("2014"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and substring(\"value\", 1, 4) <> ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and substring(\"value\", 1, 4) <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -413,7 +413,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') = ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -426,7 +426,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <> ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -439,7 +439,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') >= ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') >= ?)", result.getWhereExpression());
   }
 
   @Test
@@ -452,7 +452,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <= ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <= ?)", result.getWhereExpression());
   }
 
   @Test
@@ -465,7 +465,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(Arrays.asList("201701025", "20200213"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?)", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?)", result.getWhereExpression());
   }
 
   @Test
@@ -478,7 +478,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(asList("(OCoLC)63611770", "1", "1%", "20141107%", "abc", "20171128", "20200114"), result.getBindingParams());
     assertEquals(new HashSet<>(asList("001", "035", "036", "005")), result.getFieldsToJoin());
-    assertEquals("((\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?) and (\"field_no\" = '036' and \"ind1\" <> ?)) or ((\"field_no\" = '036' and \"ind1\" like ?) and (\"field_no\" = '005' and \"value\" like ?)) or ((\"field_no\" = '001' and substring(\"value\", 2, 3) = ?) and (\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?))", result.getWhereExpression());
+    assertEquals("(( \"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?) and ( \"field_no\" = '036' and \"ind1\" <> ?)) or (( \"field_no\" = '036' and \"ind1\" like ?) and ( \"field_no\" = '005' and \"value\" like ?)) or (( \"field_no\" = '001' and substring(\"value\", 2, 3) = ?) and ( \"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?))", result.getWhereExpression());
   }
 
   @Test
@@ -491,7 +491,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '050' and id in (select marc_id from marc_indexers where ind1 <> '#'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '050' and id in (select marc_id from marc_indexers where ind1 <> '#'))", result.getWhereExpression());
   }
 
   @Test
@@ -504,7 +504,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(\"field_no\" = '050' and id in (select marc_id from marc_indexers where ind2 = '#'))", result.getWhereExpression());
+    assertEquals("( \"field_no\" = '050' and id in (select marc_id from marc_indexers where ind2 = '#'))", result.getWhereExpression());
   }
 
   @Test

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/SearchExpressionParserUnitTest.java
@@ -148,7 +148,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)63611770"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"i035\".\"subfield_no\" = 'a' and \"i035\".\"value\" = ?)", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -161,7 +161,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"i035\".\"subfield_no\" = 'a' and \"i035\".\"value\" like ?)", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("(OCoLC)"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("035")), result.getFieldsToJoin());
-    assertEquals("(\"i035\".\"subfield_no\" = 'a' and \"i035\".\"value\" <> ?)", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -187,7 +187,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id in (select marc_id from marc_indexers_035 where subfield_no = 'a')) ", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and id in (select marc_id from marc_indexers where subfield_no = 'a'))", result.getWhereExpression());
   }
 
   @Test
@@ -200,7 +200,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id not in (select marc_id from marc_indexers_035 where subfield_no = 'z')) ", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and id not in (select marc_id from marc_indexers where subfield_no = 'z'))", result.getWhereExpression());
   }
 
   @Test
@@ -213,7 +213,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("\"i036\".\"ind1\" = ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '036' and \"ind1\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -226,7 +226,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("\"i036\".\"ind1\" like ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '036' and \"ind1\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -239,7 +239,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("1"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("036")), result.getFieldsToJoin());
-    assertEquals("\"i036\".\"ind1\" <> ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '036' and \"ind1\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -252,7 +252,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107001016.0"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("\"i005\".\"value\" = ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and \"value\" = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -265,7 +265,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107%"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("\"i005\".\"value\" like ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and \"value\" like ?)", result.getWhereExpression());
   }
 
   @Test
@@ -278,7 +278,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("20141107"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("\"i005\".\"value\" <> ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and \"value\" <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -291,7 +291,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id in (select marc_id from marc_indexers_035))", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and id in (select marc_id from marc_indexers))", result.getWhereExpression());
   }
 
   @Test
@@ -304,7 +304,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id not in (select marc_id from marc_indexers_035))", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '035' and id not in (select marc_id from marc_indexers))", result.getWhereExpression());
   }
 
   @Test
@@ -345,7 +345,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("2014"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("substring(\"i005\".\"value\", 1, 4) = ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and substring(\"value\", 1, 4) = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -358,7 +358,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("2014"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("substring(\"i005\".\"value\", 1, 4) <> ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and substring(\"value\", 1, 4) <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -413,7 +413,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') = ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') = ?)", result.getWhereExpression());
   }
 
   @Test
@@ -426,7 +426,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') <> ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <> ?)", result.getWhereExpression());
   }
 
   @Test
@@ -439,7 +439,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') >= ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') >= ?)", result.getWhereExpression());
   }
 
   @Test
@@ -452,7 +452,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(singletonList("201701025"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') <= ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') <= ?)", result.getWhereExpression());
   }
 
   @Test
@@ -465,7 +465,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(Arrays.asList("201701025", "20200213"), result.getBindingParams());
     assertEquals(new HashSet<>(singletonList("005")), result.getFieldsToJoin());
-    assertEquals("to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') between ? and ?", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?)", result.getWhereExpression());
   }
 
   @Test
@@ -478,7 +478,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(asList("(OCoLC)63611770", "1", "1%", "20141107%", "abc", "20171128", "20200114"), result.getBindingParams());
     assertEquals(new HashSet<>(asList("001", "035", "036", "005")), result.getFieldsToJoin());
-    assertEquals("((\"i035\".\"subfield_no\" = 'a' and \"i035\".\"value\" = ?) and \"i036\".\"ind1\" <> ?) or (\"i036\".\"ind1\" like ? and \"i005\".\"value\" like ?) or (substring(\"i001\".\"value\", 2, 3) = ? and to_date(substring(\"i005\".\"value\", 1, 8), 'yyyymmdd') between ? and ?)", result.getWhereExpression());
+    assertEquals("((\"field_no\" = '035' and \"subfield_no\" = 'a' and \"value\" = ?) and (\"field_no\" = '036' and \"ind1\" <> ?)) or ((\"field_no\" = '036' and \"ind1\" like ?) and (\"field_no\" = '005' and \"value\" like ?)) or ((\"field_no\" = '001' and substring(\"value\", 2, 3) = ?) and (\"field_no\" = '005' and to_date(substring(value, 1, 8), 'yyyymmdd') between ? and ?))", result.getWhereExpression());
   }
 
   @Test
@@ -491,7 +491,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id in (select marc_id from marc_indexers_050 where ind1 <> '#')) ", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '050' and id in (select marc_id from marc_indexers where ind1 <> '#'))", result.getWhereExpression());
   }
 
   @Test
@@ -504,7 +504,7 @@ public class SearchExpressionParserUnitTest {
     assertTrue(result.isEnabled());
     assertEquals(emptyList(), result.getBindingParams());
     assertEquals(emptySet(), result.getFieldsToJoin());
-    assertEquals("(id in (select marc_id from marc_indexers_050 where ind2 = '#')) ", result.getWhereExpression());
+    assertEquals("(\"field_no\" = '050' and id in (select marc_id from marc_indexers where ind2 = '#'))", result.getWhereExpression());
   }
 
   @Test


### PR DESCRIPTION
## Introduced changes
- changed the approach to refer to marc_indexers table. Previously, there have been used partitions of the marc_indexers table, and not to boiler-plate script with joins, there is introduced field number conditioning inside of search criteria.
- Due to complex structure of the criteria search, there are numerous cases which need to be considered, such as parenthesis included search. E.g., (050.a ^= 'a' and 050.b ^= 'b') or 050.c ^= 'c', or search criteria relates date search.

## Actions to do
- Please notice TODO's in the java code.
- Main problem is to parse conditions with additional parenthesis to not break condition wholeness. There is a test which is ignored, due to the mentioned issue.
- Not added **marc_indexers** tracking, during the investigation no noticeable changes found after removing this join in the script.

## Learning
[MODSOURCE-763](https://folio-org.atlassian.net/browse/MODSOURCE-763)