### PR TITLE
MODSOURMAN-1200 Find record by match id instead record id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURCE-756](https://issues.folio.org/browse/MODSOURCE-756) After setting an instance as marked for deletion it is no longer editable in quickmarc
 * [MODSOURCE-753](https://folio-org.atlassian.net/browse/MODSOURCE-753) Change SQL query parameters for MARC Search
 * [MODSOURCE-773](https://folio-org.atlassian.net/browse/MODSOURCE-773) MARC Search omits suppressed from discovery records in default search
+* [MODSOURMAN-1200](https://folio-org.atlassian.net/browse/MODSOURMAN-1200) Find record by match id on update generation 
 
 ## 2024-03-20 5.8.0
 * [MODSOURCE-733](https://issues.folio.org/browse/MODSOURCE-733) Reduce Memory Allocation of Strings

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -182,7 +182,7 @@ public class RecordServiceImpl implements RecordService {
     }
     record.setId(UUID.randomUUID().toString());
 
-    return recordDao.getRecordById(matchedId, tenantId)
+    return recordDao.getRecordByMatchedId(matchedId, tenantId)
       .map(r -> r.orElseThrow(() -> new NotFoundException(format(RECORD_WITH_GIVEN_MATCHED_ID_NOT_FOUND, matchedId))))
       .compose(v -> saveRecord(record, tenantId))
       .recover(throwable -> {


### PR DESCRIPTION
## Purpose
The 'No action' status is displayed in the 'SRS Marc' and 'Instance' columns after importing file for updating record on member tenant

## Approach
Find record by match id instead record id

#### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.
- [x] Check logging.
## Learning
[MODSOURMAN-1200](https://folio-org.atlassian.net/browse/MODSOURMAN-1200)
