### PR TITLE
 MODSOURCE-787: Extend MARC-MARC search query to account for comparison part

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -79,6 +79,7 @@ public interface RecordDao {
    *  Searches for {@link Record} by {@link MatchField}  with offset and limit
    *
    * @param matchField          Marc field that needs to be matched
+   * @param comparisonPartType  describes type of comparison part
    * @param recordType          record type
    * @param externalIdRequired  specifies whether necessary not to consider records with {@code externalId == null} while searching
    * @param offset              starting index in a list of results
@@ -86,7 +87,9 @@ public interface RecordDao {
    * @param tenantId            tenant id
    * @return  {@link Future} of {@link RecordCollection}
    */
-  Future<List<Record>> getMatchedRecords(MatchField matchField, Filter.ComparisonPartType comparisonPartType, TypeConnection recordType, boolean externalIdRequired, int offset, int limit, String tenantId);
+  Future<List<Record>> getMatchedRecords(MatchField matchField, Filter.ComparisonPartType comparisonPartType,
+                                         TypeConnection recordType, boolean externalIdRequired,
+                                         int offset, int limit, String tenantId);
 
   /**
    * Searches for {@link Record} by {@link MatchField} with offset and limit,

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -13,6 +13,7 @@ import net.sf.jsqlparser.JSQLParserException;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.MatchField;
 import org.folio.dao.util.RecordType;
+import org.folio.rest.jaxrs.model.Filter;
 import org.folio.rest.jaxrs.model.MarcBibCollection;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.ParsedRecordsBatchResponse;
@@ -85,13 +86,14 @@ public interface RecordDao {
    * @param tenantId            tenant id
    * @return  {@link Future} of {@link RecordCollection}
    */
-  Future<List<Record>> getMatchedRecords(MatchField matchField, TypeConnection recordType, boolean externalIdRequired, int offset, int limit, String tenantId);
+  Future<List<Record>> getMatchedRecords(MatchField matchField, Filter.ComparisonPartType comparisonPartType, TypeConnection recordType, boolean externalIdRequired, int offset, int limit, String tenantId);
 
   /**
    * Searches for {@link Record} by {@link MatchField} with offset and limit,
    * and returns {@link RecordsIdentifiersCollection} representing list of pairs of recordId and externalId
    *
    * @param matchedField        describes searching condition
+   * @param comparisonPartType  describes type of comparison part
    * @param returnTotalRecords  indicates that amount of total records should/shouldn't be calculated
    *                            and populated into {@link RecordsIdentifiersCollection#totalRecords}
    * @param typeConnection      record type
@@ -101,9 +103,9 @@ public interface RecordDao {
    * @param tenantId            tenant id
    * @return {@link Future} of {@link RecordsIdentifiersCollection}
    */
-  Future<RecordsIdentifiersCollection> getMatchedRecordsIdentifiers(MatchField matchedField, boolean returnTotalRecords,
-                                                                    TypeConnection typeConnection, boolean externalIdRequired,
-                                                                    int offset, int limit, String tenantId);
+  Future<RecordsIdentifiersCollection> getMatchedRecordsIdentifiers(MatchField matchedField, Filter.ComparisonPartType comparisonPartType,
+                                                                    boolean returnTotalRecords, TypeConnection typeConnection,
+                                                                    boolean externalIdRequired, int offset, int limit, String tenantId);
 
   /**
    * Streams {@link Record} by {@link Condition} and ordered by collection of {@link OrderField}

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -413,7 +413,8 @@ public class RecordDaoImpl implements RecordDao {
     }
 
     return switch (comparisonPartType) {
-      case ALPHANUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^[:alnum:]]', '', 'g')";
+      //case ALPHANUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^[:alnum:]]', '', 'g')";
+      case ALPHANUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^\\w]|_', '', 'g')";
       case NUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^[:digit:]]', '', 'g')";
       default -> DEFAULT_VALUE;
     };

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -411,7 +411,7 @@ public class RecordDaoImpl implements RecordDao {
       return "\"{partition}\".\"value\"";
     } else {
       if (comparisonPartType == ALPHANUMERICS_ONLY) {
-        return "regexp_replace(\"{partition}\".\"value\", '[^a-zA-Z0-9]', '', 'g')";
+        return "regexp_replace(\"{partition}\".\"value\", '[^[:alnum:]]', '', 'g')";
       } else {
         return "regexp_replace(\"{partition}\".\"value\", '[^0-9]', '', 'g')";
       }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -15,7 +15,6 @@ import static org.folio.dao.util.RecordDaoUtil.getExternalHrid;
 import static org.folio.dao.util.RecordDaoUtil.getExternalId;
 import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_FOUND_TEMPLATE;
 import static org.folio.dao.util.SnapshotDaoUtil.SNAPSHOT_NOT_STARTED_MESSAGE_TEMPLATE;
-import static org.folio.rest.jaxrs.model.Filter.ComparisonPartType.ALPHANUMERICS_ONLY;
 import static org.folio.rest.jooq.Tables.ERROR_RECORDS_LB;
 import static org.folio.rest.jooq.Tables.MARC_RECORDS_LB;
 import static org.folio.rest.jooq.Tables.MARC_RECORDS_TRACKING;
@@ -407,15 +406,17 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   private static String getComparisonValue(Filter.ComparisonPartType comparisonPartType) {
+
+    String DEFAULT_VALUE = "\"{partition}\".\"value\"";
     if (comparisonPartType == null) {
-      return "\"{partition}\".\"value\"";
-    } else {
-      if (comparisonPartType == ALPHANUMERICS_ONLY) {
-        return "regexp_replace(\"{partition}\".\"value\", '[^[:alnum:]]', '', 'g')";
-      } else {
-        return "regexp_replace(\"{partition}\".\"value\", '[^0-9]', '', 'g')";
-      }
+      return DEFAULT_VALUE;
     }
+
+    return switch (comparisonPartType) {
+      case ALPHANUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^[:alnum:]]', '', 'g')";
+      case NUMERICS_ONLY -> "regexp_replace(\"{partition}\".\"value\", '[^[:digit:]]', '', 'g')";
+      default -> DEFAULT_VALUE;
+    };
   }
 
   private String getSqlInd(String ind) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -94,6 +94,7 @@ import org.folio.processing.value.Value;
 import org.folio.rest.jaxrs.model.AdditionalInfo;
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
+import org.folio.rest.jaxrs.model.Filter;
 import org.folio.rest.jaxrs.model.MarcBibCollection;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.model.ParsedRecord;
@@ -170,7 +171,12 @@ public class RecordDaoImpl implements RecordDao {
   public static final String CONTROL_FIELD_CONDITION_TEMPLATE = "\"{partition}\".\"value\" in ({value})";
   public static final String CONTROL_FIELD_CONDITION_TEMPLATE_WITH_QUALIFIER = "\"{partition}\".\"value\" IN ({value}) AND \"{partition}\".\"value\" LIKE {qualifier}";
   public static final String DATA_FIELD_CONDITION_TEMPLATE = "\"{partition}\".\"value\" in ({value}) and \"{partition}\".\"ind1\" LIKE '{ind1}' and \"{partition}\".\"ind2\" LIKE '{ind2}' and \"{partition}\".\"subfield_no\" = '{subfield}'";
-  public static final String DATA_FIELD_CONDITION_TEMPLATE_WITH_QUALIFIER = "\"{partition}\".\"value\" IN ({value}) AND \"{partition}\".\"value\" LIKE {qualifier} AND \"{partition}\".\"ind1\" LIKE '{ind1}' AND \"{partition}\".\"ind2\" LIKE '{ind2}' AND \"{partition}\".\"subfield_no\" = '{subfield}'";
+  public static final String DATA_FIELD_CONDITION_TEMPLATE_WITH_QUALIFIER =
+    "\"{partition}\".\"value\" LIKE {qualifier} " +
+      "AND {comparisonValue} IN ({value}) " +
+      "AND \"{partition}\".\"ind1\" LIKE '{ind1}' " +
+      "AND \"{partition}\".\"ind2\" LIKE '{ind2}' " +
+      "AND \"{partition}\".\"subfield_no\" = '{subfield}'";
   private static final String VALUE_IN_SINGLE_QUOTES = "'%s'";
   private static final String RECORD_NOT_FOUND_BY_ID_TYPE = "Record with %s id: %s was not found";
   private static final String INVALID_PARSED_RECORD_MESSAGE_TEMPLATE = "Record %s has invalid parsed record; %s";
@@ -301,7 +307,9 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<List<Record>> getMatchedRecords(MatchField matchedField, TypeConnection typeConnection, boolean externalIdRequired, int offset, int limit, String tenantId) {
+  public Future<List<Record>> getMatchedRecords(MatchField matchedField, Filter.ComparisonPartType comparisonPartType,
+                                                TypeConnection typeConnection, boolean externalIdRequired,
+                                                int offset, int limit, String tenantId) {
     Name prt = name(typeConnection.getDbType().getTableName());
     Table<org.jooq.Record> marcIndexersPartitionTable = table(name(MARC_INDEXERS_PARTITION_PREFIX + matchedField.getTag()));
     if (matchedField.getValue() instanceof MissingValue)
@@ -329,23 +337,26 @@ public class RecordDaoImpl implements RecordDao {
             filterRecordByType(typeConnection.getRecordType().value())
               .and(filterRecordByState(Record.State.ACTUAL.value()))
               .and(externalIdRequired ? filterRecordByExternalIdNonNull() : DSL.noCondition())
-              .and(getMatchedFieldCondition(matchedField, marcIndexersPartitionTable.getName()))
+              .and(getMatchedFieldCondition(matchedField, comparisonPartType, marcIndexersPartitionTable.getName()))
           )
           .offset(offset)
           .limit(limit > 0 ? limit : DEFAULT_LIMIT_FOR_GET_RECORDS);
       }
-    )).compose(queryResult -> handleMatchedRecordsSearchResult(queryResult, matchedField, typeConnection, externalIdRequired, offset, limit, tenantId));
+    )).compose(queryResult -> handleMatchedRecordsSearchResult(queryResult, matchedField, comparisonPartType, typeConnection, externalIdRequired, offset, limit, tenantId));
   }
 
-  private Future<List<Record>> handleMatchedRecordsSearchResult(QueryResult queryResult, MatchField matchedField, TypeConnection typeConnection,
+  private Future<List<Record>> handleMatchedRecordsSearchResult(QueryResult queryResult, MatchField matchedField, Filter.ComparisonPartType comparisonPartType,
+                                                                TypeConnection typeConnection,
                                                                 boolean externalIdRequired, int offset, int limit, String tenantId) {
     if (enableFallbackQuery && !queryResult.hasResults()) {
-      return getMatchedRecordsWithoutIndexersVersionUsage(matchedField, typeConnection, externalIdRequired, offset, limit, tenantId);
+      return getMatchedRecordsWithoutIndexersVersionUsage(matchedField, comparisonPartType, typeConnection, externalIdRequired, offset, limit, tenantId);
     }
     return Future.succeededFuture(queryResult.stream().map(res -> asRow(res.unwrap())).map(this::toRecord).toList());
   }
 
-  public Future<List<Record>> getMatchedRecordsWithoutIndexersVersionUsage(MatchField matchedField, TypeConnection typeConnection, boolean externalIdRequired, int offset, int limit, String tenantId) {
+  public Future<List<Record>> getMatchedRecordsWithoutIndexersVersionUsage(MatchField matchedField, Filter.ComparisonPartType comparisonPartType,
+                                                                           TypeConnection typeConnection, boolean externalIdRequired,
+                                                                           int offset, int limit, String tenantId) {
     Name prt = name(typeConnection.getDbType().getTableName());
     Table<org.jooq.Record> marcIndexersPartitionTable = table(name(MARC_INDEXERS_PARTITION_PREFIX + matchedField.getTag()));
     return getQueryExecutor(tenantId).transaction(txQE -> txQE.query(dsl -> dsl
@@ -360,14 +371,14 @@ public class RecordDaoImpl implements RecordDao {
         filterRecordByType(typeConnection.getRecordType().value())
           .and(filterRecordByState(Record.State.ACTUAL.value()))
           .and(externalIdRequired ? filterRecordByExternalIdNonNull() : DSL.noCondition())
-          .and(getMatchedFieldCondition(matchedField, marcIndexersPartitionTable.getName()))
+          .and(getMatchedFieldCondition(matchedField, comparisonPartType, marcIndexersPartitionTable.getName()))
       )
       .offset(offset)
       .limit(limit > 0 ? limit : DEFAULT_LIMIT_FOR_GET_RECORDS)
     )).map(queryResult -> queryResult.stream().map(res -> asRow(res.unwrap())).map(this::toRecord).collect(Collectors.toList()));
   }
 
-  private Condition getMatchedFieldCondition(MatchField matchedField, String partition) {
+  private Condition getMatchedFieldCondition(MatchField matchedField, Filter.ComparisonPartType comparisonPartType, String partition) {
     Map<String, String> params = new HashMap<>();
     var qualifierSearch = false;
     params.put("partition", partition);
@@ -376,6 +387,14 @@ public class RecordDaoImpl implements RecordDao {
       qualifierSearch = true;
       params.put("qualifier", getSqlQualifier(matchedField.getQualifierMatch()));
     }
+    if (comparisonPartType != null) {
+      params.put("comparisonValue",  comparisonPartType == Filter.ComparisonPartType.ALPHANUMERICS_ONLY ?
+        "regexp_replace(\"{partition}\".\"value\", '[^a-zA-Z0-9]', '', 'g')"
+        : "regexp_replace(\"{partition}\".\"value\", '[^0-9]', '', 'g')");
+    } else {
+      params.put("comparisonValue", "\"{partition}\".\"value\"");
+    }
+
     String sql;
     if (matchedField.isControlField()) {
       sql = qualifierSearch ? StrSubstitutor.replace(CONTROL_FIELD_CONDITION_TEMPLATE_WITH_QUALIFIER, params, "{", "}")
@@ -629,9 +648,9 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
-  public Future<RecordsIdentifiersCollection> getMatchedRecordsIdentifiers(MatchField matchedField, boolean returnTotalRecords,
-                                                                           TypeConnection typeConnection, boolean externalIdRequired,
-                                                                           int offset, int limit, String tenantId) {
+  public Future<RecordsIdentifiersCollection> getMatchedRecordsIdentifiers(MatchField matchedField, Filter.ComparisonPartType comparisonPartType,
+                                                                           boolean returnTotalRecords, TypeConnection typeConnection,
+                                                                           boolean externalIdRequired, int offset, int limit, String tenantId) {
     Table<org.jooq.Record> marcIndexersPartitionTable = table(name(MARC_INDEXERS_PARTITION_PREFIX + matchedField.getTag()));
     if (matchedField.getValue() instanceof MissingValue) {
       return Future.succeededFuture(new RecordsIdentifiersCollection().withTotalRecords(0));
@@ -650,7 +669,7 @@ public class RecordDaoImpl implements RecordDao {
           .where(filterRecordByType(typeConnection.getRecordType().value())
             .and(filterRecordByState(Record.State.ACTUAL.value()))
             .and(externalIdRequired ? filterRecordByExternalIdNonNull() : DSL.noCondition())
-            .and(getMatchedFieldCondition(matchedField, marcIndexersPartitionTable.getName())));
+            .and(getMatchedFieldCondition(matchedField, comparisonPartType, marcIndexersPartitionTable.getName())));
       } else {
         countQuery = select(inline(null, Integer.class).as(COUNT));
       }
@@ -667,7 +686,7 @@ public class RecordDaoImpl implements RecordDao {
         .where(filterRecordByType(typeConnection.getRecordType().value())
           .and(filterRecordByState(Record.State.ACTUAL.value()))
           .and(externalIdRequired ? filterRecordByExternalIdNonNull() : DSL.noCondition())
-          .and(getMatchedFieldCondition(matchedField, marcIndexersPartitionTable.getName())));
+          .and(getMatchedFieldCondition(matchedField, comparisonPartType, marcIndexersPartitionTable.getName())));
 
       return DSL.select()
         .from(searchQuery)

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -493,6 +493,8 @@ public class RecordServiceImpl implements RecordService {
     List<String> values = ((ListValue) matchField.getValue()).getValue();
     var qualifier = matchField.getQualifierMatch();
 
+    //ComparationPartType is not used in this case because it is illogical to apply filters of this type to UUID values.
+
     if (matchField.isMatchedId()) {
       condition = condition.and(getExternalIdsConditionWithQualifier(values, IdType.RECORD, qualifier));
     } else if (matchField.isExternalId()) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -336,10 +336,12 @@ public class RecordServiceImpl implements RecordService {
     MatchField matchField = prepareMatchField(recordMatchingDto);
     TypeConnection typeConnection = getTypeConnection(recordMatchingDto.getRecordType());
 
+    Filter.ComparisonPartType comparisonPartType = recordMatchingDto.getFilters().get(0).getComparisonPartType();
+
     if (matchField.isDefaultField()) {
       return processDefaultMatchField(matchField, typeConnection, recordMatchingDto, tenantId);
     }
-    return recordDao.getMatchedRecordsIdentifiers(matchField, recordMatchingDto.getReturnTotalRecordsCount(), typeConnection,
+    return recordDao.getMatchedRecordsIdentifiers(matchField, comparisonPartType, recordMatchingDto.getReturnTotalRecordsCount(), typeConnection,
       true, recordMatchingDto.getOffset(), recordMatchingDto.getLimit(), tenantId);
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
@@ -20,7 +20,9 @@ import org.folio.processing.matching.reader.util.MarcValueReaderUtil;
 import org.folio.processing.value.Value;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.Field;
+import org.folio.rest.jaxrs.model.Filter;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.Qualifier;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;
 import org.folio.services.caches.ConsortiumConfigurationCache;
@@ -91,10 +93,11 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
       MatchDetail matchDetail = retrieveMatchDetail(payload);
       if (isValidMatchDetail(matchDetail)) {
         MatchField matchField = prepareMatchField(record, matchDetail);
-        return retrieveMarcRecords(matchField, payload.getTenant())
+        Filter.ComparisonPartType comparisonPartType = prepareComparisonPartType(matchDetail);
+        return retrieveMarcRecords(matchField, comparisonPartType, payload.getTenant())
           .compose(localMatchedRecords -> {
             if (isConsortiumAvailable()) {
-              return matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords(payload, matchField, localMatchedRecords);
+              return matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords(payload, matchField, comparisonPartType, localMatchedRecords);
             }
             return Future.succeededFuture(localMatchedRecords);
           })
@@ -110,14 +113,16 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
     }
   }
 
-  private Future<List<Record>> matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords(DataImportEventPayload payload, MatchField matchField,
+  private Future<List<Record>> matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords(DataImportEventPayload payload,
+                                                                                           MatchField matchField,
+                                                                                           Filter.ComparisonPartType comparisonPartType,
                                                                                            List<Record> recordList) {
     return consortiumConfigurationCache.get(RestUtil.retrieveOkapiConnectionParams(payload, vertx))
       .compose(consortiumConfigurationOptional -> {
         if (consortiumConfigurationOptional.isPresent() && !consortiumConfigurationOptional.get().getCentralTenantId().equals(payload.getTenant())) {
           LOG.debug("matchCentralTenantIfNeededAndCombineWithLocalMatchedRecords:: Matching on centralTenant with id: {}",
             consortiumConfigurationOptional.get().getCentralTenantId());
-          return retrieveMarcRecords(matchField, consortiumConfigurationOptional.get().getCentralTenantId())
+          return retrieveMarcRecords(matchField, comparisonPartType, consortiumConfigurationOptional.get().getCentralTenantId())
             .onSuccess(result -> {
               if (!result.isEmpty()) {
                 payload.getContext().put(CENTRAL_TENANT_ID, consortiumConfigurationOptional.get().getCentralTenantId());
@@ -133,14 +138,14 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
     return throwable instanceof MatchingException ? throwable : new MatchingException(throwable);
   }
 
-  private Future<List<Record>> retrieveMarcRecords(MatchField matchField, String tenant) {
+  private Future<List<Record>> retrieveMarcRecords(MatchField matchField, Filter.ComparisonPartType comparisonPartType, String tenant) {
     if (matchField.isDefaultField()) {
       LOG.debug("retrieveMarcRecords:: Process default field matching, matchField {}, tenant {}", matchField, tenant);
       return processDefaultMatchField(matchField, tenant).map(RecordCollection::getRecords);
     }
-    //TODO is Filter.ComparisonPartType needed?
+
     LOG.debug("retrieveMarcRecords:: Process matched field matching, matchField {}, tenant {}", matchField, tenant);
-    return recordDao.getMatchedRecords(matchField, null, typeConnection, isNonNullExternalIdRequired(), 0, 2, tenant);
+    return recordDao.getMatchedRecords(matchField, comparisonPartType, typeConnection, isNonNullExternalIdRequired(), 0, 2, tenant);
   }
 
   abstract boolean isConsortiumAvailable();
@@ -154,6 +159,11 @@ public abstract class AbstractMarcMatchEventHandler implements EventHandler {
     String subfield = matchDetailFields.get(3).getValue();
     Value value = MarcValueReaderUtil.readValueFromRecord(record, matchDetail.getIncomingMatchExpression());
     return new MatchField(field, ind1, ind2, subfield, value);
+  }
+
+  private Filter.ComparisonPartType prepareComparisonPartType(MatchDetail matchDetail) {
+    Qualifier qualifier = matchDetail.getExistingMatchExpression().getQualifier();
+    return (qualifier != null) ? Filter.ComparisonPartType.valueOf(qualifier.getComparisonPart().toString()) : null;
   }
 
   /* Searches for {@link MatchField} in a separate record properties considering it is matched_id, external_id, or external_hrid */

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/match/AbstractMarcMatchEventHandler.java
@@ -20,7 +20,6 @@ import org.folio.processing.matching.reader.util.MarcValueReaderUtil;
 import org.folio.processing.value.Value;
 import org.folio.rest.jaxrs.model.DataImportEventTypes;
 import org.folio.rest.jaxrs.model.Field;
-import org.folio.rest.jaxrs.model.Filter;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.RecordCollection;

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -119,7 +119,7 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     ReflectionTestUtils.setField(recordDao, ENABLE_FALLBACK_QUERY_FIELD, true);
     MatchField matchField = new MatchField("100", "1", "", "a", StringValue.of("Mozart, Wolfgang Amadeus,"));
 
-    //TODO: Filter.ComparisonPartType comparisonPartType = ?
+    //TODO is Filter.ComparisonPartType needed?
     Future<List<Record>> future = deleteTrackingRecordById(record.getId())
       .compose(v -> recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID));
 
@@ -150,7 +150,7 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     var async = context.async();
     var matchField = new MatchField("010", "1", "", "a", MissingValue.getInstance());
 
-    //TODO: Filter.ComparisonPartType comparisonPartType = ?
+    //TODO is Filter.ComparisonPartType needed?
     var future = recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID);
 
     future.onComplete(ar -> {

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -119,8 +119,9 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     ReflectionTestUtils.setField(recordDao, ENABLE_FALLBACK_QUERY_FIELD, true);
     MatchField matchField = new MatchField("100", "1", "", "a", StringValue.of("Mozart, Wolfgang Amadeus,"));
 
+    //TODO: Filter.ComparisonPartType comparisonPartType = ?
     Future<List<Record>> future = deleteTrackingRecordById(record.getId())
-      .compose(v -> recordDao.getMatchedRecords(matchField, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID));
+      .compose(v -> recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -149,7 +150,8 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     var async = context.async();
     var matchField = new MatchField("010", "1", "", "a", MissingValue.getInstance());
 
-    var future = recordDao.getMatchedRecords(matchField, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID);
+    //TODO: Filter.ComparisonPartType comparisonPartType = ?
+    var future = recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID);
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -119,7 +119,6 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     ReflectionTestUtils.setField(recordDao, ENABLE_FALLBACK_QUERY_FIELD, true);
     MatchField matchField = new MatchField("100", "1", "", "a", StringValue.of("Mozart, Wolfgang Amadeus,"));
 
-    //TODO is Filter.ComparisonPartType needed?
     Future<List<Record>> future = deleteTrackingRecordById(record.getId())
       .compose(v -> recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID));
 
@@ -150,7 +149,6 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     var async = context.async();
     var matchField = new MatchField("010", "1", "", "a", MissingValue.getInstance());
 
-    //TODO is Filter.ComparisonPartType needed?
     var future = recordDao.getMatchedRecords(matchField, null, TypeConnection.MARC_BIB, true, 0, 10, TENANT_ID);
 
     future.onComplete(ar -> {

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -12,7 +13,6 @@ import org.folio.dao.util.RecordDaoUtil;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.Filter;
-import org.folio.rest.jaxrs.model.Filter.Qualifier;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.RecordMatchingDto;
@@ -29,6 +29,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import org.folio.rest.jaxrs.model.Filter.ComparisonPartType;
+import static org.folio.rest.jaxrs.model.Filter.ComparisonPartType.ALPHANUMERICS_ONLY;
+import static org.folio.rest.jaxrs.model.Filter.ComparisonPartType.NUMERICS_ONLY;
+import static org.folio.rest.jaxrs.model.Filter.Qualifier.BEGINS_WITH;
+import static org.folio.rest.jaxrs.model.Filter.Qualifier.CONTAINS;
+import static org.folio.rest.jaxrs.model.Filter.Qualifier.ENDS_WITH;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_AUTHORITY;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_HOLDING;
@@ -105,7 +111,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
           .withIndicator1("f")
           .withIndicator2("f")
           .withSubfield("s")
-          .withQualifier(Qualifier.BEGINS_WITH)
+          .withQualifier(BEGINS_WITH)
           .withQualifierValue("TEST"))))
       .post(RECORDS_MATCHING_PATH)
       .then()
@@ -122,7 +128,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
       .body(new RecordMatchingDto()
         .withRecordType(RecordMatchingDto.RecordType.MARC_BIB)
         .withFilters(List.of(new Filter()
-            .withQualifier(Qualifier.BEGINS_WITH)
+            .withQualifier(BEGINS_WITH)
             .withQualifierValue("acf")
         .withValues(List.of(existingRecord.getMatchedId()))
         .withField("999")
@@ -146,9 +152,9 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
   @Test
   public void shouldMatchMarcBibRecordByInstanceIdFieldAndQualifier() {
     var instanceId = existingRecord.getExternalIdsHolder().getInstanceId();
-    var beginWith = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, instanceId.substring(0, SPLIT_INDEX));
-    var endWith =  new MatchField.QualifierMatch(Qualifier.ENDS_WITH, instanceId.substring(SPLIT_INDEX));
-    var contains = new MatchField.QualifierMatch(Qualifier.CONTAINS, instanceId.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWith = new MatchField.QualifierMatch(BEGINS_WITH, instanceId.substring(0, SPLIT_INDEX));
+    var endWith =  new MatchField.QualifierMatch(ENDS_WITH, instanceId.substring(SPLIT_INDEX));
+    var contains = new MatchField.QualifierMatch(CONTAINS, instanceId.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
     shouldMatchRecordByExternalIdField(existingRecord, beginWith);
     shouldMatchRecordByExternalIdField(existingRecord, endWith);
     shouldMatchRecordByExternalIdField(existingRecord, contains);
@@ -254,28 +260,28 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
     postRecords(context, record);
 
     var incomingValueNumeric = "393893";
-    var beginWith = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, incomingValueNumeric.substring(0, SPLIT_INDEX));
-    var endWith =  new MatchField.QualifierMatch(Qualifier.ENDS_WITH, incomingValueNumeric.substring(SPLIT_INDEX));
-    var contains = new MatchField.QualifierMatch(Qualifier.CONTAINS, incomingValueNumeric.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWith = new MatchField.QualifierMatch(BEGINS_WITH, incomingValueNumeric.substring(0, SPLIT_INDEX));
+    var endWith =  new MatchField.QualifierMatch(ENDS_WITH, incomingValueNumeric.substring(SPLIT_INDEX));
+    var contains = new MatchField.QualifierMatch(CONTAINS, incomingValueNumeric.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
 
-    shouldMatchRecordByExternalIdField(record, beginWith, Filter.ComparisonPartType.NUMERICS_ONLY);
-    shouldMatchRecordByExternalIdField(record, endWith, Filter.ComparisonPartType.NUMERICS_ONLY);
-    shouldMatchRecordByExternalIdField(record, contains, Filter.ComparisonPartType.NUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, beginWith, NUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, endWith, NUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, contains, NUMERICS_ONLY);
 
     var incomingValueAlphaNumeric = "(OCoLC)63611770";
-    var beginWithAlphaNumeric = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, incomingValueNumeric.substring(0, SPLIT_INDEX));
-    var endWithAlphaNumeric =  new MatchField.QualifierMatch(Qualifier.ENDS_WITH, incomingValueAlphaNumeric.substring(SPLIT_INDEX));
-    var containsAlphaNumeric = new MatchField.QualifierMatch(Qualifier.CONTAINS, incomingValueAlphaNumeric.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWithAlphaNumeric = new MatchField.QualifierMatch(BEGINS_WITH, incomingValueAlphaNumeric.substring(0, SPLIT_INDEX));
+    var endWithAlphaNumeric =  new MatchField.QualifierMatch(ENDS_WITH, incomingValueAlphaNumeric.substring(SPLIT_INDEX));
+    var containsAlphaNumeric = new MatchField.QualifierMatch(CONTAINS, incomingValueAlphaNumeric.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
 
-    shouldMatchRecordByExternalIdField(record, beginWithAlphaNumeric, Filter.ComparisonPartType.ALPHANUMERICS_ONLY);
-    shouldMatchRecordByExternalIdField(record, endWithAlphaNumeric, Filter.ComparisonPartType.ALPHANUMERICS_ONLY);
-    shouldMatchRecordByExternalIdField(record, containsAlphaNumeric, Filter.ComparisonPartType.ALPHANUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, beginWithAlphaNumeric, ALPHANUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, endWithAlphaNumeric, ALPHANUMERICS_ONLY);
+    shouldMatchRecordByExternalIdField(record, containsAlphaNumeric, ALPHANUMERICS_ONLY);
   }
 
   private void shouldMatchRecordByExternalIdField(Record sourceRecord, MatchField.QualifierMatch qualifier,
-                                                  Filter.ComparisonPartType comparisonPartType) {
+                                                  ComparisonPartType comparisonPartType) {
     var externalId = RecordDaoUtil.getExternalId(sourceRecord.getExternalIdsHolder(), sourceRecord.getRecordType());
-    RestAssured.given()
+    Response response = RestAssured.given()
       .spec(spec)
       .when()
       .body(new RecordMatchingDto()
@@ -289,8 +295,9 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
           .withQualifier(qualifier.qualifier())
           .withQualifierValue(qualifier.value())
           .withComparisonPartType(comparisonPartType))))
-      .post(RECORDS_MATCHING_PATH)
-      .then()
+      .post(RECORDS_MATCHING_PATH);
+
+    response.then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(1))
       .body("identifiers.size()", is(1))
@@ -340,9 +347,9 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
   @Test
   public void shouldMatchRecordByInstanceHridFieldAndQualifier() {
     var hrId = existingRecord.getExternalIdsHolder().getInstanceHrid();
-    var beginWith = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, hrId.substring(0, SPLIT_INDEX));
-    var endWith =  new MatchField.QualifierMatch(Qualifier.ENDS_WITH, hrId.substring(SPLIT_INDEX));
-    var contains = new MatchField.QualifierMatch(Qualifier.CONTAINS, hrId.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWith = new MatchField.QualifierMatch(BEGINS_WITH, hrId.substring(0, SPLIT_INDEX));
+    var endWith =  new MatchField.QualifierMatch(ENDS_WITH, hrId.substring(SPLIT_INDEX));
+    var contains = new MatchField.QualifierMatch(CONTAINS, hrId.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
     shouldMatchRecordByInstanceHridFieldAndQualifier(beginWith);
     shouldMatchRecordByInstanceHridFieldAndQualifier(endWith);
     shouldMatchRecordByInstanceHridFieldAndQualifier(contains);
@@ -351,7 +358,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
   @Test
   public void shouldNotMatchMarcBibRecordByInstanceIdFieldAndQualifier(){
     var externalId = RecordDaoUtil.getExternalId(existingRecord.getExternalIdsHolder(), existingRecord.getRecordType());
-    var qualifier = new MatchField.QualifierMatch(Qualifier.CONTAINS, "ABC");
+    var qualifier = new MatchField.QualifierMatch(CONTAINS, "ABC");
     RestAssured.given()
       .spec(spec)
       .when()
@@ -438,9 +445,9 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
 
   @Test
   public void shouldMatchRecordByMultipleDataFieldsAndQualifier() {
-    var beginWith = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, FIELD_007.substring(0, SPLIT_INDEX));
-    var endWith = new MatchField.QualifierMatch(Qualifier.ENDS_WITH, FIELD_007.substring(SPLIT_INDEX));
-    var contains = new MatchField.QualifierMatch(Qualifier.CONTAINS, FIELD_007.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWith = new MatchField.QualifierMatch(BEGINS_WITH, FIELD_007.substring(0, SPLIT_INDEX));
+    var endWith = new MatchField.QualifierMatch(ENDS_WITH, FIELD_007.substring(SPLIT_INDEX));
+    var contains = new MatchField.QualifierMatch(CONTAINS, FIELD_007.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
     shouldMatchRecordByMultipleDataFieldsAndQualifier(beginWith);
     shouldMatchRecordByMultipleDataFieldsAndQualifier(endWith);
     shouldMatchRecordByMultipleDataFieldsAndQualifier(contains);
@@ -455,7 +462,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
         .withRecordType(RecordMatchingDto.RecordType.MARC_BIB)
         .withFilters(List.of(new Filter()
           .withValues(List.of("12345", "oclc1234567"))
-          .withQualifier(Qualifier.BEGINS_WITH)
+          .withQualifier(BEGINS_WITH)
           .withQualifierValue("ABC")
           .withField("035")
           .withIndicator1("")
@@ -490,9 +497,9 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
 
   @Test
   public void shouldMatchRecordByMultipleControlledFieldsAndQualifier() {
-    var beginWith = new MatchField.QualifierMatch(Qualifier.BEGINS_WITH, FIELD_035.substring(0, SPLIT_INDEX));
-    var endWith = new MatchField.QualifierMatch(Qualifier.ENDS_WITH, FIELD_035.substring(SPLIT_INDEX));
-    var contains = new MatchField.QualifierMatch(Qualifier.CONTAINS, FIELD_035.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
+    var beginWith = new MatchField.QualifierMatch(BEGINS_WITH, FIELD_035.substring(0, SPLIT_INDEX));
+    var endWith = new MatchField.QualifierMatch(ENDS_WITH, FIELD_035.substring(SPLIT_INDEX));
+    var contains = new MatchField.QualifierMatch(CONTAINS, FIELD_035.substring(SPLIT_INDEX, SPLIT_INDEX + SPLIT_INDEX));
     shouldMatchRecordByMultipleControlledFieldsAndQualifier(beginWith);
     shouldMatchRecordByMultipleControlledFieldsAndQualifier(endWith);
     shouldMatchRecordByMultipleControlledFieldsAndQualifier(contains);
@@ -507,7 +514,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
         .withRecordType(RecordMatchingDto.RecordType.MARC_BIB)
         .withFilters(List.of(new Filter()
           .withValues(List.of("12569", "364345"))
-          .withQualifier(Qualifier.BEGINS_WITH)
+          .withQualifier(BEGINS_WITH)
           .withQualifierValue("ABC")
           .withField("007"))))
       .post(RECORDS_MATCHING_PATH)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
@@ -25,7 +25,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;


### PR DESCRIPTION
## Purpose
Enhance implementation of /source-storage/records/matching endpoint to account for comparison part when building a search query to get the record for matching.

## Approach
SQL query generation has been changed to take into account the new conditions

## Learning
[MODSOURCE-787](https://folio-org.atlassian.net/browse/MODSOURCE-787)
