### PR TITLE
MODSOURCE-796 Cleanup permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * [MODSOURCE-752](https://folio-org.atlassian.net/browse/MODSOURCE-752) Emit Domain Events For Source Records
 * [MODSOURCE-795](https://folio-org.atlassian.net/browse/MODSOURCE-795) Upgrade Spring 5 to 6 by 2024-08-31
 * [MODSOURMAN-1203](https://folio-org.atlassian.net/browse/MODSOURMAN-1203) Add validation on MARC_BIB record save
+* [MODSOURCE-796](https://folio-org.atlassian.net/browse/MODSOURCE-796) Fix inconsistencies in permission namings
 
 ## 2024-03-20 5.8.0
 * [MODSOURCE-733](https://issues.folio.org/browse/MODSOURCE-733) Reduce Memory Allocation of Strings

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -354,8 +354,7 @@
     {
       "permissionName": "source-storage.records.generation.item.put",
       "displayName": "Source Storage - update record's generation",
-      "description": "Update record's generation",
-      "replaces": ["source-storage.records.put"]
+      "description": "Update record's generation"
     },
     {
       "permissionName": "source-storage.parsed-records.collection.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,7 @@
           ],
           "pathPattern": "/source-storage/snapshots",
           "permissionsRequired": [
-            "source-storage.snapshots.get"
+            "source-storage.snapshots.collection.get"
           ]
         },
         {
@@ -30,7 +30,7 @@
           ],
           "pathPattern": "/source-storage/snapshots/{jobExecutionId}",
           "permissionsRequired": [
-            "source-storage.snapshots.get"
+            "source-storage.snapshots.item.get"
           ]
         },
         {
@@ -62,7 +62,7 @@
           ],
           "pathPattern": "/source-storage/records",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.records.collection.get"
           ]
         },
         {
@@ -80,7 +80,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.records.item.get"
           ]
         },
         {
@@ -98,7 +98,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}/generation",
           "permissionsRequired": [
-            "source-storage.records.put"
+            "source-storage.records.item.generation.put"
           ]
         },
         {
@@ -116,7 +116,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}/formatted",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.records.item.formatted.get"
           ]
         },
         {
@@ -134,7 +134,7 @@
           ],
           "pathPattern": "/source-storage/records/matching",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.records.collection.matching.post"
           ]
         }
       ]
@@ -149,7 +149,7 @@
           ],
           "pathPattern": "/source-storage/source-records",
           "permissionsRequired": [
-            "source-storage.sourceRecords.get"
+            "source-storage.source-records.collection.get"
           ]
         },
         {
@@ -158,7 +158,7 @@
           ],
           "pathPattern": "/source-storage/source-records/{id}",
           "permissionsRequired": [
-            "source-storage.sourceRecords.get"
+            "source-storage.source-records.item.get"
           ]
         }
       ]
@@ -173,7 +173,7 @@
           ],
           "pathPattern": "/source-storage/populate-test-marc-records",
           "permissionsRequired": [
-            "source-storage.populate.records"
+            "source-storage.records.collection.populate.post"
           ]
         }
       ]
@@ -188,7 +188,7 @@
           ],
           "pathPattern": "/source-storage/stream/records",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.stream.records.get"
           ]
         },
         {
@@ -197,7 +197,7 @@
           ],
           "pathPattern": "/source-storage/stream/source-records",
           "permissionsRequired": [
-            "source-storage.sourceRecords.get"
+            "source-storage.stream.source-records.get"
           ]
         },
         {
@@ -206,7 +206,7 @@
           ],
           "pathPattern": "/source-storage/stream/marc-record-identifiers",
           "permissionsRequired": [
-            "source-storage.records.get"
+            "source-storage.stream.marc-record-identifiers.post"
           ]
         }
       ]
@@ -221,7 +221,7 @@
           ],
           "pathPattern": "/source-storage/batch/records",
           "permissionsRequired": [
-            "source-storage.records.post"
+            "source-storage.batch.records.collection.post"
           ]
         },
         {
@@ -230,7 +230,7 @@
           ],
           "pathPattern": "/source-storage/batch/parsed-records",
           "permissionsRequired": [
-            "source-storage.records.put"
+            "source-storage.parsed-records.collection.put"
           ]
         },
         {
@@ -239,7 +239,7 @@
           ],
           "pathPattern": "/source-storage/batch/parsed-records/fetch",
           "permissionsRequired": [
-            "source-storage.records.fetch"
+            "source-storage.parsed-records.collection.fetch.post"
           ]
         },
         {
@@ -248,7 +248,7 @@
           ],
           "pathPattern": "/source-storage/batch/verified-records",
           "permissionsRequired": [
-            "source-storage.verified.records"
+            "source-storage.verified-records.collection.post"
           ]
         }
       ]
@@ -309,14 +309,19 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "source-storage.populate.records",
+      "permissionName": "source-storage.records.collection.populate.post",
       "displayName": "Source Storage - populate storage with test records",
       "description": "Populate storage with test records"
     },
     {
-      "permissionName": "source-storage.snapshots.get",
-      "displayName": "Source Storage - get snapshot(s)",
-      "description": "Get Snapshot(s)"
+      "permissionName": "source-storage.snapshots.item.get",
+      "displayName": "Source Storage - get snapshot",
+      "description": "Get Snapshot"
+    },
+    {
+      "permissionName": "source-storage.snapshots.collection.get",
+      "displayName": "Source Storage - get snapshots",
+      "description": "Get Snapshots"
     },
     {
       "permissionName": "source-storage.snapshots.post",
@@ -334,11 +339,6 @@
       "description": "Delete Snapshot and all related Records"
     },
     {
-      "permissionName": "source-storage.records.get",
-      "displayName": "Source Storage - get record(s)",
-      "description": "Get Record(s)"
-    },
-    {
       "permissionName": "source-storage.records.post",
       "displayName": "Source Storage - create new record",
       "description": "Post Record"
@@ -349,9 +349,34 @@
       "description": "Put Record"
     },
     {
-      "permissionName": "source-storage.records.fetch",
-      "displayName": "Source Storage - fetch record",
-      "description": "Fetch Record"
+      "permissionName": "source-storage.records.item.generation.put",
+      "displayName": "Source Storage - update record's generation",
+      "description": "Update record's generation"
+    },
+    {
+      "permissionName": "source-storage.parsed-records.collection.put",
+      "displayName": "Source Storage - update records",
+      "description": "Update records"
+    },
+    {
+      "permissionName": "source-storage.parsed-records.collection.fetch.post",
+      "displayName": "Source Storage - fetch records",
+      "description": "Fetch Records"
+    },
+    {
+      "permissionName": "source-storage.batch.records.collection.post",
+      "displayName": "Source Storage - stream collection of records",
+      "description": "Stream collection of records"
+    },
+    {
+      "permissionName": "source-storage.stream.source-records.get",
+      "displayName": "Source Storage - get results",
+      "description": "Source Storage - get results"
+    },
+    {
+      "permissionName": "source-storage.stream.marc-record-identifiers.post",
+      "displayName": "Source Storage - post record's identifiers",
+      "description": "Post record's identifiers"
     },
     {
       "permissionName": "source-storage.records.update",
@@ -364,12 +389,42 @@
       "description": "Delete Record"
     },
     {
-      "permissionName": "source-storage.sourceRecords.get",
-      "displayName": "Source Storage - get results",
-      "description": "Get Results"
+      "permissionName": "source-storage.source-records.item.get",
+      "displayName": "Source Storage - get source record",
+      "description": "Get Source Record"
     },
     {
-      "permissionName": "source-storage.verified.records",
+      "permissionName": "source-storage.records.collection.get",
+      "displayName": "Source Storage - get records",
+      "description": "Get Records"
+    },
+    {
+      "permissionName": "source-storage.records.item.get",
+      "displayName": "Source Storage - get record",
+      "description": "Get Record"
+    },
+    {
+      "permissionName": "source-storage.source-records.collection.get",
+      "displayName": "Source Storage - get source record collection",
+      "description": "Get Source Records"
+    },
+    {
+      "permissionName": "source-storage.records.item.formatted.get",
+      "displayName": "Source Storage - get formatter record",
+      "description": "Get formatted Record"
+    },
+    {
+      "permissionName": "source-storage.stream.records.get",
+      "displayName": "Source Storage - stream record",
+      "description": "Stream record"
+    },
+    {
+      "permissionName": "source-storage.records.collection.matching.post",
+      "displayName": "Source Storage - get pairs of marc record ID to external entity ID",
+      "description": "Get pairs of marc record ID to external entity ID"
+    },
+    {
+      "permissionName": "source-storage.verified-records.collection.post",
       "displayName": "Source Storage - validate marc bib ids in the system",
       "description": "Return marc bib ids, which doesn't exist in the system"
     },
@@ -388,21 +443,33 @@
       "displayName": "Source Record Storage - all permissions",
       "description": "Entire set of permissions needed to manage snapshots and records",
       "subPermissions": [
-        "source-storage.populate.records",
-        "source-storage.snapshots.get",
+        "source-storage.records.collection.populate.post",
+        "source-storage.snapshots.item.get",
+        "source-storage.snapshots.collection.get",
         "source-storage.snapshots.post",
         "source-storage.snapshots.put",
         "source-storage.snapshots.delete",
-        "source-storage.records.get",
         "source-storage.records.post",
         "source-storage.records.put",
-        "source-storage.records.fetch",
+        "source-storage.parsed-records.collection.fetch.post",
         "source-storage.records.delete",
         "source-storage.records.update",
-        "source-storage.sourceRecords.get",
-        "source-storage.verified.records",
+        "source-storage.source-records.item.get",
+        "source-storage.source-records.collection.get",
+        "source-storage.verified-records.collection.post",
         "source-storage.migrations.post",
-        "source-storage.migrations.get"
+        "source-storage.migrations.get",
+        "source-storage.records.item.generation.put",
+        "source-storage.parsed-records.collection.put",
+        "source-storage.batch-records.collection.post",
+        "source-storage.batch.records.collection.post",
+        "source-storage.stream.source-records.get",
+        "source-storage.records.item.formatted.get",
+        "source-storage.stream.marc-record-identifiers.post",
+        "source-storage.records.item.get",
+        "source-storage.records.collection.get",
+        "source-storage.stream.records.get",
+        "source-storage.records.collection.matching.post"
       ],
       "visible": false
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "source-storage-snapshots",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [
@@ -54,7 +54,7 @@
     },
     {
       "id": "source-storage-records",
-      "version": "3.2",
+      "version": "3.3",
       "handlers": [
         {
           "methods": [
@@ -141,7 +141,7 @@
     },
     {
       "id": "source-storage-source-records",
-      "version": "3.1",
+      "version": "3.2",
       "handlers": [
         {
           "methods": [
@@ -165,7 +165,7 @@
     },
     {
       "id": "source-storage-test-records",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [
@@ -180,7 +180,7 @@
     },
     {
       "id": "source-storage-stream",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": [
@@ -213,7 +213,7 @@
     },
     {
       "id": "source-storage-batch",
-      "version": "1.2",
+      "version": "1.3",
       "handlers": [
         {
           "methods": [
@@ -255,7 +255,7 @@
     },
     {
       "id": "source-storage-async-migrations",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -365,7 +365,7 @@
       "permissionName": "source-storage.parsed-records.fetch.collection.post",
       "displayName": "Source Storage - fetch records",
       "description": "Fetch Records",
-      "replaces": ["source-storage.parsed-records.collection.fetch.post"]
+      "replaces": ["source-storage.records.fetch"]
     },
     {
       "permissionName": "source-storage.batch.records.collection.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -382,7 +382,7 @@
       "permissionName": "source-storage.stream.marc-record-identifiers.collection.post",
       "displayName": "Source Storage - post record's identifiers",
       "description": "Post record's identifiers",
-      "replaces": ["source-storage.stream.marc-record-identifiers.post"]
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.records.update",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -311,17 +311,20 @@
     {
       "permissionName": "source-storage.records.populate.collection.post",
       "displayName": "Source Storage - populate storage with test records",
-      "description": "Populate storage with test records"
+      "description": "Populate storage with test records",
+      "replaces": ["source-storage.records.collection.populate.post"]
     },
     {
       "permissionName": "source-storage.snapshots.item.get",
       "displayName": "Source Storage - get snapshot",
-      "description": "Get Snapshot"
+      "description": "Get Snapshot",
+      "replaces": ["source-storage.snapshots.get"]
     },
     {
       "permissionName": "source-storage.snapshots.collection.get",
       "displayName": "Source Storage - get snapshots",
-      "description": "Get Snapshots"
+      "description": "Get Snapshots",
+      "replaces": ["source-storage.snapshots.get"]
     },
     {
       "permissionName": "source-storage.snapshots.post",
@@ -351,7 +354,8 @@
     {
       "permissionName": "source-storage.records.generation.item.put",
       "displayName": "Source Storage - update record's generation",
-      "description": "Update record's generation"
+      "description": "Update record's generation",
+      "replaces": ["source-storage.records.item.generation.put"]
     },
     {
       "permissionName": "source-storage.parsed-records.collection.put",
@@ -361,7 +365,8 @@
     {
       "permissionName": "source-storage.parsed-records.fetch.collection.post",
       "displayName": "Source Storage - fetch records",
-      "description": "Fetch Records"
+      "description": "Fetch Records",
+      "replaces": ["source-storage.parsed-records.collection.fetch.post"]
     },
     {
       "permissionName": "source-storage.batch.records.collection.post",
@@ -371,12 +376,14 @@
     {
       "permissionName": "source-storage.stream.source-records.collection.get",
       "displayName": "Source Storage - get results",
-      "description": "Source Storage - get results"
+      "description": "Source Storage - get results",
+      "replaces": ["source-storage.stream.source-records.get"]
     },
     {
       "permissionName": "source-storage.stream.marc-record-identifiers.collection.post",
       "displayName": "Source Storage - post record's identifiers",
-      "description": "Post record's identifiers"
+      "description": "Post record's identifiers",
+      "replaces": ["source-storage.stream.marc-record-identifiers.post"]
     },
     {
       "permissionName": "source-storage.records.update",
@@ -391,37 +398,44 @@
     {
       "permissionName": "source-storage.source-records.item.get",
       "displayName": "Source Storage - get source record",
-      "description": "Get Source Record"
+      "description": "Get Source Record",
+      "replaces": ["source-storage.sourceRecords.get"]
     },
     {
       "permissionName": "source-storage.records.collection.get",
       "displayName": "Source Storage - get records",
-      "description": "Get Records"
+      "description": "Get Records",
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.records.item.get",
       "displayName": "Source Storage - get record",
-      "description": "Get Record"
+      "description": "Get Record",
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.source-records.collection.get",
       "displayName": "Source Storage - get source record collection",
-      "description": "Get Source Records"
+      "description": "Get Source Records",
+      "replaces": ["source-storage.sourceRecords.get"]
     },
     {
       "permissionName": "source-storage.records.formatted.item.get",
       "displayName": "Source Storage - get formatter record",
-      "description": "Get formatted Record"
+      "description": "Get formatted Record",
+      "replaces": ["source-storage.records.item.formatted.get"]
     },
     {
       "permissionName": "source-storage.stream.records.collection.get",
       "displayName": "Source Storage - stream record",
-      "description": "Stream record"
+      "description": "Stream record",
+      "replaces": ["source-storage.stream.records.get"]
     },
     {
       "permissionName": "source-storage.records.matching.collection.post",
       "displayName": "Source Storage - get pairs of marc record ID to external entity ID",
-      "description": "Get pairs of marc record ID to external entity ID"
+      "description": "Get pairs of marc record ID to external entity ID",
+      "replaces": ["source-storage.records.collection.matching.post"]
     },
     {
       "permissionName": "source-storage.verified-records.collection.post",
@@ -436,7 +450,8 @@
     {
       "permissionName": "source-storage.migrations.item.get",
       "displayName": "Source Storage - get migration job(s)",
-      "description": "Get migration job(s)"
+      "description": "Get migration job(s)",
+      "replaces": ["source-storage.migrations.get"]
     },
     {
       "permissionName": "source-storage.all",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -98,7 +98,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}/generation",
           "permissionsRequired": [
-            "source-storage.records.item.generation.put"
+            "source-storage.records.generation.item.put"
           ]
         },
         {
@@ -116,7 +116,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}/formatted",
           "permissionsRequired": [
-            "source-storage.records.item.formatted.get"
+            "source-storage.records.formatted.item.get"
           ]
         },
         {
@@ -134,7 +134,7 @@
           ],
           "pathPattern": "/source-storage/records/matching",
           "permissionsRequired": [
-            "source-storage.records.collection.matching.post"
+            "source-storage.records.matching.collection.post"
           ]
         }
       ]
@@ -173,7 +173,7 @@
           ],
           "pathPattern": "/source-storage/populate-test-marc-records",
           "permissionsRequired": [
-            "source-storage.records.collection.populate.post"
+            "source-storage.records.populate.collection.post"
           ]
         }
       ]
@@ -188,7 +188,7 @@
           ],
           "pathPattern": "/source-storage/stream/records",
           "permissionsRequired": [
-            "source-storage.stream.records.get"
+            "source-storage.stream.records.collection.get"
           ]
         },
         {
@@ -197,7 +197,7 @@
           ],
           "pathPattern": "/source-storage/stream/source-records",
           "permissionsRequired": [
-            "source-storage.stream.source-records.get"
+            "source-storage.stream.source-records.collection.get"
           ]
         },
         {
@@ -206,7 +206,7 @@
           ],
           "pathPattern": "/source-storage/stream/marc-record-identifiers",
           "permissionsRequired": [
-            "source-storage.stream.marc-record-identifiers.post"
+            "source-storage.stream.marc-record-identifiers.collection.post"
           ]
         }
       ]
@@ -239,7 +239,7 @@
           ],
           "pathPattern": "/source-storage/batch/parsed-records/fetch",
           "permissionsRequired": [
-            "source-storage.parsed-records.collection.fetch.post"
+            "source-storage.parsed-records.fetch.collection.post"
           ]
         },
         {
@@ -265,7 +265,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/source-storage/migrations/jobs/{id}",
-          "permissionsRequired": ["source-storage.migrations.get"]
+          "permissionsRequired": ["source-storage.migrations.item.get"]
         }
       ]
     },
@@ -309,7 +309,7 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "source-storage.records.collection.populate.post",
+      "permissionName": "source-storage.records.populate.collection.post",
       "displayName": "Source Storage - populate storage with test records",
       "description": "Populate storage with test records"
     },
@@ -349,7 +349,7 @@
       "description": "Put Record"
     },
     {
-      "permissionName": "source-storage.records.item.generation.put",
+      "permissionName": "source-storage.records.generation.item.put",
       "displayName": "Source Storage - update record's generation",
       "description": "Update record's generation"
     },
@@ -359,7 +359,7 @@
       "description": "Update records"
     },
     {
-      "permissionName": "source-storage.parsed-records.collection.fetch.post",
+      "permissionName": "source-storage.parsed-records.fetch.collection.post",
       "displayName": "Source Storage - fetch records",
       "description": "Fetch Records"
     },
@@ -369,12 +369,12 @@
       "description": "Stream collection of records"
     },
     {
-      "permissionName": "source-storage.stream.source-records.get",
+      "permissionName": "source-storage.stream.source-records.collection.get",
       "displayName": "Source Storage - get results",
       "description": "Source Storage - get results"
     },
     {
-      "permissionName": "source-storage.stream.marc-record-identifiers.post",
+      "permissionName": "source-storage.stream.marc-record-identifiers.collection.post",
       "displayName": "Source Storage - post record's identifiers",
       "description": "Post record's identifiers"
     },
@@ -409,17 +409,17 @@
       "description": "Get Source Records"
     },
     {
-      "permissionName": "source-storage.records.item.formatted.get",
+      "permissionName": "source-storage.records.formatted.item.get",
       "displayName": "Source Storage - get formatter record",
       "description": "Get formatted Record"
     },
     {
-      "permissionName": "source-storage.stream.records.get",
+      "permissionName": "source-storage.stream.records.collection.get",
       "displayName": "Source Storage - stream record",
       "description": "Stream record"
     },
     {
-      "permissionName": "source-storage.records.collection.matching.post",
+      "permissionName": "source-storage.records.matching.collection.post",
       "displayName": "Source Storage - get pairs of marc record ID to external entity ID",
       "description": "Get pairs of marc record ID to external entity ID"
     },
@@ -434,7 +434,7 @@
       "description": "Initiate asynchronous migration job"
     },
     {
-      "permissionName": "source-storage.migrations.get",
+      "permissionName": "source-storage.migrations.item.get",
       "displayName": "Source Storage - get migration job(s)",
       "description": "Get migration job(s)"
     },
@@ -443,7 +443,7 @@
       "displayName": "Source Record Storage - all permissions",
       "description": "Entire set of permissions needed to manage snapshots and records",
       "subPermissions": [
-        "source-storage.records.collection.populate.post",
+        "source-storage.records.populate.collection.post",
         "source-storage.snapshots.item.get",
         "source-storage.snapshots.collection.get",
         "source-storage.snapshots.post",
@@ -451,25 +451,25 @@
         "source-storage.snapshots.delete",
         "source-storage.records.post",
         "source-storage.records.put",
-        "source-storage.parsed-records.collection.fetch.post",
+        "source-storage.parsed-records.fetch.collection.post",
         "source-storage.records.delete",
         "source-storage.records.update",
         "source-storage.source-records.item.get",
         "source-storage.source-records.collection.get",
         "source-storage.verified-records.collection.post",
         "source-storage.migrations.post",
-        "source-storage.migrations.get",
-        "source-storage.records.item.generation.put",
+        "source-storage.migrations.item.get",
+        "source-storage.records.generation.item.put",
         "source-storage.parsed-records.collection.put",
         "source-storage.batch-records.collection.post",
         "source-storage.batch.records.collection.post",
-        "source-storage.stream.source-records.get",
-        "source-storage.records.item.formatted.get",
-        "source-storage.stream.marc-record-identifiers.post",
+        "source-storage.stream.source-records.collection.get",
+        "source-storage.records.formatted.item.get",
+        "source-storage.stream.marc-record-identifiers.collection.post",
         "source-storage.records.item.get",
         "source-storage.records.collection.get",
-        "source-storage.stream.records.get",
-        "source-storage.records.collection.matching.post"
+        "source-storage.stream.records.collection.get",
+        "source-storage.records.matching.collection.post"
       ],
       "visible": false
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -376,7 +376,7 @@
       "permissionName": "source-storage.stream.source-records.collection.get",
       "displayName": "Source Storage - get results",
       "description": "Source Storage - get results",
-      "replaces": ["source-storage.stream.source-records.get"]
+      "replaces": ["source-storage.sourceRecords.get"]
     },
     {
       "permissionName": "source-storage.stream.marc-record-identifiers.collection.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -312,7 +312,7 @@
       "permissionName": "source-storage.records.populate.collection.post",
       "displayName": "Source Storage - populate storage with test records",
       "description": "Populate storage with test records",
-      "replaces": ["source-storage.records.collection.populate.post"]
+      "replaces": ["source-storage.populate.records"]
     },
     {
       "permissionName": "source-storage.snapshots.item.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -434,7 +434,7 @@
       "permissionName": "source-storage.records.matching.collection.post",
       "displayName": "Source Storage - get pairs of marc record ID to external entity ID",
       "description": "Get pairs of marc record ID to external entity ID",
-      "replaces": ["source-storage.records.collection.matching.post"]
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.verified-records.collection.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -355,7 +355,7 @@
       "permissionName": "source-storage.records.generation.item.put",
       "displayName": "Source Storage - update record's generation",
       "description": "Update record's generation",
-      "replaces": ["source-storage.records.item.generation.put"]
+      "replaces": ["source-storage.records.put"]
     },
     {
       "permissionName": "source-storage.parsed-records.collection.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -422,13 +422,13 @@
       "permissionName": "source-storage.records.formatted.item.get",
       "displayName": "Source Storage - get formatter record",
       "description": "Get formatted Record",
-      "replaces": ["source-storage.records.item.formatted.get"]
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.stream.records.collection.get",
       "displayName": "Source Storage - stream record",
       "description": "Stream record",
-      "replaces": ["source-storage.stream.records.get"]
+      "replaces": ["source-storage.records.get"]
     },
     {
       "permissionName": "source-storage.records.matching.collection.post",

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <kafkaclients.version>3.6.0</kafkaclients.version>
     <kafkajunit.version>3.5.1</kafkajunit.version>
     <spring.version>6.1.12</spring.version>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>
   </properties>
 
@@ -78,6 +79,19 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>


### PR DESCRIPTION
## Purpose
Permission refactoring

## TODOs
For each renamed permissions: Search for all `**/ModuleDescriptor*` and all `package.json` of other modules that contain them and ensure that a pull request exists that changes the name.

* "source-storage.snapshots.get" -> "source-storage.snapshots.collection.get", "source-storage.snapshots.item.get"
  * [x] https://github.com/search?q=org%3Afolio-org+NOT+is%3Aarchived+source-storage.snapshots.get+path%3A**%2FModuleDescriptor*&type=code
    * [ ] https://github.com/folio-org/mod-data-import/blob/6254919d30c540f9b9d2013f6cc491bfe91c77fe/descriptors/ModuleDescriptor-template.json#L154
   * [x] https://github.com/search?q=org%3Afolio-org+NOT+is%3Aarchived+source-storage.snapshots.get+path%3Apackage.json&type=code
* "source-storage.records.get" -> "source-storage.records.collection.get", "source-storage.records.item.get", "source-storage.records.formatted.item.get", "source-storage.records.matching.collection.post", "source-storage.stream.records.collection.get",             "source-storage.stream.marc-record-identifiers.collection.post"
  * [x] https://github.com/search?q=org%3Afolio-org+NOT+is%3Aarchived+source-storage.records.get+path%3A**%2FModuleDescriptor*&type=code
    * [x] https://github.com/folio-org/mod-oai-pmh/blob/8648543b7aae0951b53098db1c66b2fbca04d690/descriptors/ModuleDescriptor-template.json#L37
    * [x] https://github.com/folio-org/mod-source-record-manager/blob/d754b45bfd89d64297fa50bff8be4509ea30a6b5/descriptors/ModuleDescriptor-template.json#L317
    * [x] https://github.com/folio-org/mod-dcb/blob/768a1ad571bb0060e9efedc2af34d42d00cac6f2/descriptors/ModuleDescriptor-template.json#L247
    * [x] https://github.com/folio-org/mod-inn-reach/blob/a54481f2b0ecfdea82065ff0b7fd886e713f2f63/descriptors/ModuleDescriptor-template.json#L286
    * [ ] https://github.com/folio-org/mod-data-import/blob/6254919d30c540f9b9d2013f6cc491bfe91c77fe/descriptors/ModuleDescriptor-template.json#L153
   * [x] https://github.com/search?q=org%3Afolio-org+NOT+is%3Aarchived+source-storage.records.get+path%3Apackage.json&type=code
     * [ ] https://github.com/folio-org/ui-data-import/blob/d708d8c49c8d328ea8375880643223d3ed0b79b4/package.json#L209
     * [ ] https://github.com/folio-org/ui-data-import/blob/d708d8c49c8d328ea8375880643223d3ed0b79b4/package.json#L228
     * [ ] https://github.com/folio-org/ui-inventory/blob/3599c0396366fd62af5e16613808026d592c7b80/package.json#L554
     * [ ] https://github.com/folio-org/ui-inventory/blob/3599c0396366fd62af5e16613808026d592c7b80/package.json#L794 
     * [ ] https://github.com/folio-org/ui-marc-authorities/blob/41970833fb60c7ec6fa753bbb5ff3e013be88702/package.json#L112
* "source-storage.records.put" ->             "source-storage.records.generation.item.put",             "source-storage.parsed-records.collection.put"
  * …
* "source-storage.sourceRecords.get" -> "source-storage.source-records.collection.get", "source-storage.source-records.item.get",  "source-storage.stream.source-records.collection.get"
  * …
* "source-storage.populate.records" -> "source-storage.records.populate.collection.post"
  * …
* "source-storage.records.post" ->             "source-storage.batch.records.collection.post"
  * …
*  "source-storage.records.fetch" -> "source-storage.parsed-records.fetch.collection.post"
  * …
* "source-storage.verified.records" -> "source-storage.verified-records.collection.post"
  * …

## Learning:
[MODSOURCE-796](https://folio-org.atlassian.net/browse/MODSOURCE-796)
[Naming convention](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/156368925/Permissions+naming+convention)

Progress table for renaming permissions for Folijet team modules:
https://docs.google.com/spreadsheets/d/1PFnPx-nrslchWuYFvcB95wyIBdMwUdUcTnpErPc3uG4/edit?usp=sharing

