### PR TITLE
MODSOURCE-832: In Handling Authority-Instance links events, make updating Bib fields consistent for having two or more event consumers.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODSOURCE-821](https://folio-org.atlassian.net/browse/MODSOURCE-821) Add System User Support for Eureka env
 * [MODSOURCE-834](https://folio-org.atlassian.net/browse/MODSOURCE-834) MARC Indexers Clean up is Taking Too Long
 * [MODDATAIMP-1133](https://folio-org.atlassian.net/browse/MODDATAIMP-1133) Second update of the same MARC authority / MARC holdings record completes with errors
+* [MODSOURCE-832](https://folio-org.atlassian.net/browse/MODSOURCE-832) Add consistent handling and updating for same Marc Bib records linked to Authority by two or more consumers 
 
 ## 2024-10-28 5.9.0
 * [MODSOURCE-767](https://folio-org.atlassian.net/browse/MODSOURCE-767) Single record overlay creates duplicate OCLC#/035

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After setup, it is good to check logs in all related modules for errors. Data im
 
 **Environment variables** that can be adjusted for this module and default values:
 * Relevant from the **Ramsons** release, module versions from 5.9.0:
-  * "AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT": 3 
+  * "AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT": 5 
 * Relevant from the **Iris** release, module versions from 5.0.0:
   * "_srs.kafka.ParsedMarcChunkConsumer.instancesNumber_": 1
   * "_srs.kafka.DataImportConsumer.instancesNumber_": 1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * [Docker](#docker)
 * [Installing the module](#installing-the-module)
 * [Deploying the module](#deploying-the-module)
+* [Interaction with Kafka](#interaction-with-kafka)
 * [Database schemas](#database-schemas)
 * [How to fill module with data for testing purposes](https://wiki.folio.org/x/G6bc)
 
@@ -98,11 +99,12 @@ curl -w '\n' -X POST -D -   \
 
 ## Interaction with Kafka
 
-
 There are several properties that should be set for modules that interact with Kafka: **KAFKA_HOST, KAFKA_PORT, OKAPI_URL, ENV**(unique env ID).
 After setup, it is good to check logs in all related modules for errors. Data import consumers and producers work in separate verticles that are set up in RMB's InitAPI for each module. That would be the first place to check deploy/install logs.
 
 **Environment variables** that can be adjusted for this module and default values:
+* Relevant from the **Ramsons** release, module versions from 5.9.0:
+  * "AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT": 3 
 * Relevant from the **Iris** release, module versions from 5.0.0:
   * "_srs.kafka.ParsedMarcChunkConsumer.instancesNumber_": 1
   * "_srs.kafka.DataImportConsumer.instancesNumber_": 1

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -20,11 +20,13 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -98,8 +100,12 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         return recordService.saveRecordsByExternalIds(instanceIds, RecordType.MARC_BIB, recordsModifier, okapiHeaders)
           .compose(recordsBatchResponse -> {
             sendReports(recordsBatchResponse, linksUpdate, consumerRecord.headers());
-            var marcBibUpdateStats = mapRecordsToBibUpdateEvents(recordsBatchResponse, linksUpdate);
-            return sendEvents(marcBibUpdateStats, linksUpdate, consumerRecord);
+            var marcBibUpdateStats = mapRecordsToBibUpdateEventsByInstanceId(recordsBatchResponse, linksUpdate);
+            return Future.all(marcBibUpdateStats.entrySet().stream()
+                .map(entry -> sendEvents(entry.getValue(), linksUpdate, entry.getKey(), consumerRecord))
+                .toList()
+              )
+              .map(unused -> consumerRecord.key());
           });
       });
 
@@ -228,8 +234,8 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .toList();
   }
 
-  private List<MarcBibUpdate> mapRecordsToBibUpdateEvents(RecordsBatchResponse batchResponse,
-                                                          BibAuthorityLinksUpdate event) {
+  private Map<String, List<MarcBibUpdate>> mapRecordsToBibUpdateEventsByInstanceId(RecordsBatchResponse batchResponse,
+                                                                                   BibAuthorityLinksUpdate event) {
     LOGGER.debug("Updated {} bibs for jobId {}, authorityId {}",
       batchResponse.getTotalRecords(), event.getJobId(), event.getAuthorityId());
 
@@ -241,11 +247,11 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         batchResponse.getTotalRecords(), batchResponse.getRecords().size(), errors);
     }
 
-    return toMarcBibUpdateEvents(batchResponse, event);
+    return toMarcBibUpdateEventsByInstanceId(batchResponse, event);
   }
 
-  private List<MarcBibUpdate> toMarcBibUpdateEvents(RecordsBatchResponse batchResponse,
-                                                    BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+  private Map<String, List<MarcBibUpdate>> toMarcBibUpdateEventsByInstanceId(RecordsBatchResponse batchResponse,
+                                                                             BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
     var instanceIdToLinkIds = bibAuthorityLinksUpdate.getUpdateTargets().stream()
       .flatMap(updateTarget -> updateTarget.getLinks().stream())
       .collect(Collectors.groupingBy(Link::getInstanceId, Collectors.mapping(Link::getLinkId, Collectors.toList())));
@@ -253,15 +259,24 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     return batchResponse.getRecords().stream()
       .map(bibRecord -> {
         var instanceId = bibRecord.getExternalIdsHolder().getInstanceId();
-        return new MarcBibUpdate()
+        var marcBibUpdate = new MarcBibUpdate()
           .withJobId(bibAuthorityLinksUpdate.getJobId())
           .withLinkIds(instanceIdToLinkIds.get(instanceId))
           .withTenant(bibAuthorityLinksUpdate.getTenant())
           .withType(MarcBibUpdate.Type.UPDATE)
           .withTs(bibAuthorityLinksUpdate.getTs())
           .withRecord(bibRecord);
+        return Map.entry(instanceId, marcBibUpdate);
       })
-      .toList();
+      .collect(Collectors.groupingBy(this::entryKey, Collectors.mapping(this::entryValue, Collectors.toList())));
+  }
+
+  private String entryKey(Map.Entry<String, MarcBibUpdate> entry) {
+    return entry.getKey();
+  }
+
+  private MarcBibUpdate entryValue(Map.Entry<String, MarcBibUpdate> entry) {
+    return entry.getValue();
   }
 
   private List<LinkUpdateReport> toFailedLinkUpdateReports(List<Record> errorRecords,
@@ -303,11 +318,13 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         errorRecords.size(), event.getJobId(), event.getAuthorityId());
 
       toFailedLinkUpdateReports(errorRecords, event).forEach(report ->
-        sendEventToKafka(LINKS_STATS, report.getTenant(), report.getJobId(), report, headers));
+        sendEventToKafka(LINKS_STATS, report.getTenant(), report.getJobId(), null, report, headers));
     }
   }
 
-  private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents, BibAuthorityLinksUpdate event,
+  private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents,
+                                    BibAuthorityLinksUpdate event,
+                                    String instanceId,
                                     KafkaConsumerRecord<String, String> consumerRecord) {
     LOGGER.info("Sending {} bib update events for jobId {}, authorityId {}",
       marcBibUpdateEvents.size(), event.getJobId(), event.getAuthorityId());
@@ -315,8 +332,8 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     return Future.fromCompletionStage(
       CompletableFuture.allOf(
         marcBibUpdateEvents.stream()
-          .map(marcBibUpdate -> sendEventToKafka(MARC_BIB, marcBibUpdate.getTenant(), marcBibUpdate.getJobId(),
-            marcBibUpdate, consumerRecord.headers()))
+          .map(bibUpdateEvent -> sendEventToKafka(MARC_BIB, bibUpdateEvent.getTenant(), bibUpdateEvent.getJobId(),
+            instanceId, bibUpdateEvent, consumerRecord.headers()))
           .map(Future::toCompletionStage)
           .map(CompletionStage::toCompletableFuture)
           .toArray(CompletableFuture[]::new)
@@ -324,11 +341,11 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     ).map(unused -> consumerRecord.key());
   }
 
-  private Future<Boolean> sendEventToKafka(KafkaTopic topic, String tenant, String jobId, Object marcRecord,
-                                           List<KafkaHeader> kafkaHeaders) {
+  private Future<Boolean> sendEventToKafka(KafkaTopic topic, String tenant, String jobId, String recordKey,
+                                           Object marcRecord, List<KafkaHeader> kafkaHeaders) {
     var promise = Promise.<Boolean>promise();
     try {
-      var kafkaRecord = createKafkaProducerRecord(topic, tenant, marcRecord, kafkaHeaders);
+      var kafkaRecord = createKafkaProducerRecord(topic, tenant, recordKey, marcRecord, kafkaHeaders);
       producers.get(topic).write(kafkaRecord, ar -> {
         if (ar.succeeded()) {
           LOGGER.debug("Event with type {}, jobId {} was sent to kafka", topic.topicName(), jobId);
@@ -348,10 +365,10 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   }
 
   private KafkaProducerRecord<String, String> createKafkaProducerRecord(KafkaTopic topic, String tenant,
-                                                                        Object marcRecord,
+                                                                        String recordKey, Object marcRecord,
                                                                         List<KafkaHeader> kafkaHeaders) {
     var topicName = topic.fullTopicName(kafkaConfig, tenant);
-    var key = String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum);
+    var key = Optional.ofNullable(recordKey).orElse(String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum));
     var kafkaRecord = KafkaProducerRecord.create(topicName, key, Json.encode(marcRecord));
     kafkaHeaders.removeIf(kafkaHeader -> !StringUtils.startsWithIgnoreCase(kafkaHeader.key(), "x-okapi-"));
     kafkaRecord.addHeaders(kafkaHeaders);

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -73,6 +73,9 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
 
+  @Value("${AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT:3}")
+  private int maxBibSaveRetryCount;
+
   public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig,
                                         SnapshotService snapshotService) {
     this.kafkaConfig = kafkaConfig;
@@ -97,7 +100,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         RecordsModifierOperator recordsModifier = recordsCollection ->
           this.mapRecordFieldsChanges(linksUpdate, recordsCollection, userId);
 
-        return recordService.saveRecordsByExternalIds(instanceIds, RecordType.MARC_BIB, recordsModifier, okapiHeaders)
+        return recordService.saveRecordsByExternalIds(instanceIds, RecordType.MARC_BIB, recordsModifier, okapiHeaders, maxBibSaveRetryCount)
           .compose(recordsBatchResponse -> {
             sendReports(recordsBatchResponse, linksUpdate, consumerRecord.headers());
             var marcBibUpdateStats = mapRecordsToBibUpdateEventsByInstanceId(recordsBatchResponse, linksUpdate);

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -73,7 +73,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
 
-  @Value("${AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT:3}")
+  @Value("${AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT:5}")
   private int maxBibSaveRetryCount;
 
   public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig,

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1018,9 +1018,9 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert records updating generation if required
     var recordsLoadingErrors = dsl.loadInto(RECORDS_LB)
-      //.batchAfter(1000)
-      //.bulkAfter(500)
-      //.commitAfter(1000)
+      .batchAfter(1000)
+      .bulkAfter(500)
+      .commitAfter(1000)
       .onErrorAbort()
       .loadRecords(dbRecords)
 //      .loadRecords(dbRecords.stream()
@@ -1046,8 +1046,8 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert raw records
     dsl.loadInto(RAW_RECORDS_LB)
-      //.batchAfter(250)
-      //.commitAfter(1000)
+      .batchAfter(250)
+      .commitAfter(1000)
       .onDuplicateKeyUpdate()
       .onErrorAbort()
       .loadRecords(dbRawRecords)
@@ -1056,8 +1056,8 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert parsed records
     recordType.toLoaderOptionsStep(dsl)
-      //.batchAfter(250)
-      //.commitAfter(1000)
+      .batchAfter(250)
+      .commitAfter(1000)
       .onDuplicateKeyUpdate()
       .onErrorAbort()
       .loadRecords(dbParsedRecords)
@@ -1067,8 +1067,8 @@ public class RecordDaoImpl implements RecordDao {
     if (!dbErrorRecords.isEmpty()) {
       // batch insert error records
       dsl.loadInto(ERROR_RECORDS_LB)
-        //.batchAfter(250)
-        //.commitAfter(1000)
+        .batchAfter(250)
+        .commitAfter(1000)
         .onDuplicateKeyUpdate()
         .onErrorAbort()
         .loadRecords(dbErrorRecords)

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -856,9 +856,11 @@ public class RecordDaoImpl implements RecordDao {
 
             // return result
             List<String> errorMessages = getErrorMessages(dbErrorRecords);
+            queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
+            records = queryResult.fetch(this::toRecord);
             return new RecordsBatchResponse()
-              .withRecords(modifiedRecords.getRecords())
-              .withTotalRecords(modifiedRecords.getRecords().size())
+              .withRecords(records)
+              .withTotalRecords(records.size())
               .withErrorMessages(errorMessages);
           });
         } catch (DuplicateEventException e) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1018,9 +1018,9 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert records updating generation if required
     var recordsLoadingErrors = dsl.loadInto(RECORDS_LB)
-      .batchAfter(1000)
-      .bulkAfter(500)
-      .commitAfter(1000)
+      //.batchAfter(1000)
+      //.bulkAfter(500)
+      //.commitAfter(1000)
       .onErrorAbort()
       .loadRecords(dbRecords)
 //      .loadRecords(dbRecords.stream()
@@ -1046,8 +1046,8 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert raw records
     dsl.loadInto(RAW_RECORDS_LB)
-      .batchAfter(250)
-      .commitAfter(1000)
+      //.batchAfter(250)
+      //.commitAfter(1000)
       .onDuplicateKeyUpdate()
       .onErrorAbort()
       .loadRecords(dbRawRecords)
@@ -1056,8 +1056,8 @@ public class RecordDaoImpl implements RecordDao {
 
     // batch insert parsed records
     recordType.toLoaderOptionsStep(dsl)
-      .batchAfter(250)
-      .commitAfter(1000)
+      //.batchAfter(250)
+      //.commitAfter(1000)
       .onDuplicateKeyUpdate()
       .onErrorAbort()
       .loadRecords(dbParsedRecords)
@@ -1067,8 +1067,8 @@ public class RecordDaoImpl implements RecordDao {
     if (!dbErrorRecords.isEmpty()) {
       // batch insert error records
       dsl.loadInto(ERROR_RECORDS_LB)
-        .batchAfter(250)
-        .commitAfter(1000)
+        //.batchAfter(250)
+        //.commitAfter(1000)
         .onDuplicateKeyUpdate()
         .onErrorAbort()
         .loadRecords(dbErrorRecords)

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
@@ -31,6 +33,8 @@ import io.vertx.sqlclient.Row;
  * Utility class for managing {@link ParsedRecord}
  */
 public final class ParsedRecordDaoUtil {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private static final String ID = "id";
   private static final String CONTENT = "content";
@@ -153,6 +157,7 @@ public final class ParsedRecordDaoUtil {
   public static ParsedRecord toJoinedParsedRecord(org.jooq.Record dbRecord) {
     UUID id = dbRecord.get(ID_FIELD);
     Object content = dbRecord.get(PARSED_RECORD_CONTENT, String.class);
+    LOG.info("parsed record id: {}, content: {}", id, content);
 
     return asParsedRecord(id, content);
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/ParsedRecordDaoUtil.java
@@ -12,8 +12,6 @@ import java.util.UUID;
 import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.ErrorRecord;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.Record;
@@ -33,8 +31,6 @@ import io.vertx.sqlclient.Row;
  * Utility class for managing {@link ParsedRecord}
  */
 public final class ParsedRecordDaoUtil {
-
-  private static final Logger LOG = LogManager.getLogger();
 
   private static final String ID = "id";
   private static final String CONTENT = "content";
@@ -157,7 +153,6 @@ public final class ParsedRecordDaoUtil {
   public static ParsedRecord toJoinedParsedRecord(org.jooq.Record dbRecord) {
     UUID id = dbRecord.get(ID_FIELD);
     Object content = dbRecord.get(PARSED_RECORD_CONTENT, String.class);
-    LOG.info("parsed record id: {}, content: {}", id, content);
 
     return asParsedRecord(id, content);
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -89,11 +89,13 @@ public interface RecordService {
    * @param recordType  record type
    * @param recordsModifier records collection modifier operator
    * @param okapiHeaders okapi headers
+   * @param maxSaveRetryCount max count of retries to save records
    * @return future with response containing list of successfully saved records and error messages for records that were not saved
    */
   Future<RecordsBatchResponse> saveRecordsByExternalIds(List<String> externalIds, RecordType recordType,
                                                         RecordsModifierOperator recordsModifier,
-                                                        Map<String, String> okapiHeaders);
+                                                        Map<String, String> okapiHeaders,
+                                                        int maxSaveRetryCount);
 
   /**
    * Updates record with given id


### PR DESCRIPTION
## Purpose
Handling Authority-Instance links event works well when having one consumer (module instance) of the event. 
When there are many events being received at the same time for the same instance and they are handled by two or more consumers / (running module instances) then one _silently_ overwrites the changes of another causing the updates being lost.

## Approach
1. Change `srs.marc-bib` event's key from serial integer value to the instance id, so that in consuming side of this event (mod-inventory) only one consumer would be responsible to handle events for the same instance.
2. Do not make separate query to get value for `generation` column from `records_lb` as we have just made records read query and have `generation`'s value at the time of query. Having the separate query prevents to detect the error called `DuplicateEventException` which acts like `Optimistic Locking` as some other event consumer may have done already the changes for the same bib

#### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.
- [x] Check logging.

## Learning
[MODSOURCE-832](https://folio-org.atlassian.net/browse/MODSOURCE-832)
[MODINV-1125](https://folio-org.atlassian.net/browse/MODINV-1125)
[MODELINKS-286](https://folio-org.atlassian.net/browse/MODELINKS-286)
