### PR TITLE
Release v5.8.10: MODSOURCE-817 - In Handling Authority-Instance links events, make updating Bib fields consistent for having two or more event consumers.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 2025-01-27 v5.8.10
-* [MODSOURCE-832](https://folio-org.atlassian.net/browse/MODSOURCE-832) Add consistent handling and updating for same Marc Bib records linked to Authority by two or more consumers
+* [MODSOURCE-817](https://folio-org.atlassian.net/browse/MODSOURCE-817) Add consistent handling and updating for same Marc Bib records linked to Authority by two or more consumers
 
 ## 2025-01-16 v5.8.9
 * [MODSOURCE-849](https://folio-org.atlassian.net/browse/MODSOURCE-849) Optimize process of clean up marc indexers table
@@ -33,20 +33,6 @@
 * [MODSOURCE-742](https://folio-org.atlassian.net/browse/MODSOURCE-742) PostgreSQL SSL connection does not work
 * [MODSOURCE-758](https://folio-org.atlassian.net/browse/MODSOURCE-758) Alleviate Blocking of Eventloop During New Tenant Initialization
 * [MODSOURCE-756](https://issues.folio.org/browse/MODSOURCE-756) After setting an instance as marked for deletion it is no longer editable in quickmarc
-* [MODSOURCE-753](https://folio-org.atlassian.net/browse/MODSOURCE-753) Change SQL query parameters for MARC Search
-* [MODSOURCE-773](https://folio-org.atlassian.net/browse/MODSOURCE-773) MARC Search omits suppressed from discovery records in default search
-* [MODINV-1044](https://folio-org.atlassian.net/browse/MODINV-1044) Additional Requirements - Update Data Import logic to normalize OCLC 035 values
-* [MODSOURMAN-1200](https://folio-org.atlassian.net/browse/MODSOURMAN-1200) Find record by match id on update generation 
-* [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049) Existing "035" field is not retained the original position in imported record 
-* [MODSOURCE-785](https://folio-org.atlassian.net/browse/MODSOURCE-785) Update 005 field when set MARC for deletion
-* [MODSOURMAN-783](https://folio-org.atlassian.net/browse/MODSOURCE-783) Extend MARC-MARC search query to account for qualifiers
-* [MODSOURCE-752](https://folio-org.atlassian.net/browse/MODSOURCE-752) Emit Domain Events For Source Records
-* [MODSOURCE-795](https://folio-org.atlassian.net/browse/MODSOURCE-795) Upgrade Spring 5 to 6 by 2024-08-31
-* [MODSOURMAN-1203](https://folio-org.atlassian.net/browse/MODSOURMAN-1203) Add validation on MARC_BIB record save
-* [MODSOURCE-796](https://folio-org.atlassian.net/browse/MODSOURCE-796) Fix inconsistencies in permission namings
-* [MODSOURCE-809](https://folio-org.atlassian.net/browse/MODSOURCE-809) mod-source-record-storage Ramsons 2024 R2 - RMB v35.3.x update
-* [MODSOURCE-787](https://folio-org.atlassian.net/browse/MODSOURCE-787) Extend MARC-MARC search query to account for comparison part
-* [MODSOURCE-791](https://folio-org.atlassian.net/browse/MODSOURCE-791) Fix Timeout exception during postSourceStorageStreamMarcRecordIdentifiers
 
 ## 2024-03-20 5.8.0
 * [MODSOURCE-733](https://issues.folio.org/browse/MODSOURCE-733) Reduce Memory Allocation of Strings

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2025-01-27 v5.8.10
+* [MODSOURCE-832](https://folio-org.atlassian.net/browse/MODSOURCE-832) Add consistent handling and updating for same Marc Bib records linked to Authority by two or more consumers
+
 ## 2025-01-16 v5.8.9
 * [MODSOURCE-849](https://folio-org.atlassian.net/browse/MODSOURCE-849) Optimize process of clean up marc indexers table
 
@@ -30,6 +33,20 @@
 * [MODSOURCE-742](https://folio-org.atlassian.net/browse/MODSOURCE-742) PostgreSQL SSL connection does not work
 * [MODSOURCE-758](https://folio-org.atlassian.net/browse/MODSOURCE-758) Alleviate Blocking of Eventloop During New Tenant Initialization
 * [MODSOURCE-756](https://issues.folio.org/browse/MODSOURCE-756) After setting an instance as marked for deletion it is no longer editable in quickmarc
+* [MODSOURCE-753](https://folio-org.atlassian.net/browse/MODSOURCE-753) Change SQL query parameters for MARC Search
+* [MODSOURCE-773](https://folio-org.atlassian.net/browse/MODSOURCE-773) MARC Search omits suppressed from discovery records in default search
+* [MODINV-1044](https://folio-org.atlassian.net/browse/MODINV-1044) Additional Requirements - Update Data Import logic to normalize OCLC 035 values
+* [MODSOURMAN-1200](https://folio-org.atlassian.net/browse/MODSOURMAN-1200) Find record by match id on update generation 
+* [MODINV-1049](https://folio-org.atlassian.net/browse/MODINV-1049) Existing "035" field is not retained the original position in imported record 
+* [MODSOURCE-785](https://folio-org.atlassian.net/browse/MODSOURCE-785) Update 005 field when set MARC for deletion
+* [MODSOURMAN-783](https://folio-org.atlassian.net/browse/MODSOURCE-783) Extend MARC-MARC search query to account for qualifiers
+* [MODSOURCE-752](https://folio-org.atlassian.net/browse/MODSOURCE-752) Emit Domain Events For Source Records
+* [MODSOURCE-795](https://folio-org.atlassian.net/browse/MODSOURCE-795) Upgrade Spring 5 to 6 by 2024-08-31
+* [MODSOURMAN-1203](https://folio-org.atlassian.net/browse/MODSOURMAN-1203) Add validation on MARC_BIB record save
+* [MODSOURCE-796](https://folio-org.atlassian.net/browse/MODSOURCE-796) Fix inconsistencies in permission namings
+* [MODSOURCE-809](https://folio-org.atlassian.net/browse/MODSOURCE-809) mod-source-record-storage Ramsons 2024 R2 - RMB v35.3.x update
+* [MODSOURCE-787](https://folio-org.atlassian.net/browse/MODSOURCE-787) Extend MARC-MARC search query to account for comparison part
+* [MODSOURCE-791](https://folio-org.atlassian.net/browse/MODSOURCE-791) Fix Timeout exception during postSourceStorageStreamMarcRecordIdentifiers
 
 ## 2024-03-20 5.8.0
 * [MODSOURCE-733](https://issues.folio.org/browse/MODSOURCE-733) Reduce Memory Allocation of Strings

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * [Docker](#docker)
 * [Installing the module](#installing-the-module)
 * [Deploying the module](#deploying-the-module)
+* [Interaction with Kafka](#interaction-with-kafka)
 * [Database schemas](#database-schemas)
 * [How to fill module with data for testing purposes](https://wiki.folio.org/x/G6bc)
 
@@ -98,11 +99,12 @@ curl -w '\n' -X POST -D -   \
 
 ## Interaction with Kafka
 
-
 There are several properties that should be set for modules that interact with Kafka: **KAFKA_HOST, KAFKA_PORT, OKAPI_URL, ENV**(unique env ID).
 After setup, it is good to check logs in all related modules for errors. Data import consumers and producers work in separate verticles that are set up in RMB's InitAPI for each module. That would be the first place to check deploy/install logs.
 
 **Environment variables** that can be adjusted for this module and default values:
+* Relevant from the **Quesnelia** release, module versions from 5.8.10:
+  * "AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT": 5 
 * Relevant from the **Iris** release, module versions from 5.0.0:
   * "_srs.kafka.ParsedMarcChunkConsumer.instancesNumber_": 1
   * "_srs.kafka.DataImportConsumer.instancesNumber_": 1

--- a/mod-source-record-storage-client/pom.xml
+++ b/mod-source-record-storage-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.8.10</version>
+    <version>5.8.11-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-source-record-storage-client/pom.xml
+++ b/mod-source-record-storage-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.8.10-SNAPSHOT</version>
+    <version>5.8.10</version>
   </parent>
 
   <properties>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.8.10</version>
+    <version>5.8.11-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-source-record-storage</artifactId>
-    <version>5.8.10-SNAPSHOT</version>
+    <version>5.8.10</version>
   </parent>
 
   <dependencies>

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityLinkChunkKafkaHandler.java
@@ -20,11 +20,13 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -71,6 +73,9 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   @Value("${srs.kafka.AuthorityLinkChunkKafkaHandler.maxDistributionNum:100}")
   private int maxDistributionNum;
 
+  @Value("${AUTHORITY_TO_BIB_LINK_CHANGE_HANDLER_RETRY_COUNT:5}")
+  private int maxBibSaveRetryCount;
+
   public AuthorityLinkChunkKafkaHandler(RecordService recordService, KafkaConfig kafkaConfig,
                                         SnapshotService snapshotService) {
     this.kafkaConfig = kafkaConfig;
@@ -95,11 +100,15 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         RecordsModifierOperator recordsModifier = recordsCollection ->
           this.mapRecordFieldsChanges(linksUpdate, recordsCollection, userId);
 
-        return recordService.saveRecordsByExternalIds(instanceIds, RecordType.MARC_BIB, recordsModifier, okapiHeaders)
+        return recordService.saveRecordsByExternalIds(instanceIds, RecordType.MARC_BIB, recordsModifier, okapiHeaders, maxBibSaveRetryCount)
           .compose(recordsBatchResponse -> {
             sendReports(recordsBatchResponse, linksUpdate, consumerRecord.headers());
-            var marcBibUpdateStats = mapRecordsToBibUpdateEvents(recordsBatchResponse, linksUpdate);
-            return sendEvents(marcBibUpdateStats, linksUpdate, consumerRecord);
+            var marcBibUpdateStats = mapRecordsToBibUpdateEventsByInstanceId(recordsBatchResponse, linksUpdate);
+            return Future.all(marcBibUpdateStats.entrySet().stream()
+                .map(entry -> sendEvents(entry.getValue(), linksUpdate, entry.getKey(), consumerRecord))
+                .toList()
+              )
+              .map(unused -> consumerRecord.key());
           });
       });
 
@@ -119,14 +128,6 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     }
   }
 
-  private List<String> getBibRecordExternalIds(BibAuthorityLinksUpdate linksUpdate) {
-    return linksUpdate.getUpdateTargets().stream()
-      .flatMap(updateTarget -> updateTarget.getLinks().stream()
-        .map(Link::getInstanceId))
-      .distinct()
-      .toList();
-  }
-
   private Future<BibAuthorityLinksUpdate> createSnapshot(BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
     var now = new Date();
     var snapshot = new Snapshot()
@@ -141,6 +142,13 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .map(result -> bibAuthorityLinksUpdate);
   }
 
+  private List<String> getBibRecordExternalIds(BibAuthorityLinksUpdate linksUpdate) {
+    return linksUpdate.getUpdateTargets().stream()
+      .flatMap(updateTarget -> updateTarget.getLinks().stream()
+        .map(Link::getInstanceId))
+      .distinct()
+      .toList();
+  }
 
   private RecordCollection mapRecordFieldsChanges(BibAuthorityLinksUpdate bibAuthorityLinksUpdate,
                                                   RecordCollection recordCollection, String userId) {
@@ -226,11 +234,11 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
       .filter(updateTarget -> updateTarget.getLinks().stream()
         .anyMatch(link -> link.getInstanceId().equals(instanceId)))
       .map(UpdateTarget::getField)
-      .collect(Collectors.toList());
+      .toList();
   }
 
-  private List<MarcBibUpdate> mapRecordsToBibUpdateEvents(RecordsBatchResponse batchResponse,
-                                                          BibAuthorityLinksUpdate event) {
+  private Map<String, List<MarcBibUpdate>> mapRecordsToBibUpdateEventsByInstanceId(RecordsBatchResponse batchResponse,
+                                                                                   BibAuthorityLinksUpdate event) {
     LOGGER.debug("Updated {} bibs for jobId {}, authorityId {}",
       batchResponse.getTotalRecords(), event.getJobId(), event.getAuthorityId());
 
@@ -242,11 +250,11 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
         batchResponse.getTotalRecords(), batchResponse.getRecords().size(), errors);
     }
 
-    return toMarcBibUpdateEvents(batchResponse, event);
+    return toMarcBibUpdateEventsByInstanceId(batchResponse, event);
   }
 
-  private List<MarcBibUpdate> toMarcBibUpdateEvents(RecordsBatchResponse batchResponse,
-                                                    BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
+  private Map<String, List<MarcBibUpdate>> toMarcBibUpdateEventsByInstanceId(RecordsBatchResponse batchResponse,
+                                                                             BibAuthorityLinksUpdate bibAuthorityLinksUpdate) {
     var instanceIdToLinkIds = bibAuthorityLinksUpdate.getUpdateTargets().stream()
       .flatMap(updateTarget -> updateTarget.getLinks().stream())
       .collect(Collectors.groupingBy(Link::getInstanceId, Collectors.mapping(Link::getLinkId, Collectors.toList())));
@@ -254,15 +262,24 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     return batchResponse.getRecords().stream()
       .map(bibRecord -> {
         var instanceId = bibRecord.getExternalIdsHolder().getInstanceId();
-        return new MarcBibUpdate()
+        var marcBibUpdate = new MarcBibUpdate()
           .withJobId(bibAuthorityLinksUpdate.getJobId())
           .withLinkIds(instanceIdToLinkIds.get(instanceId))
           .withTenant(bibAuthorityLinksUpdate.getTenant())
           .withType(MarcBibUpdate.Type.UPDATE)
           .withTs(bibAuthorityLinksUpdate.getTs())
           .withRecord(bibRecord);
+        return Map.entry(instanceId, marcBibUpdate);
       })
-      .collect(Collectors.toList());
+      .collect(Collectors.groupingBy(this::entryKey, Collectors.mapping(this::entryValue, Collectors.toList())));
+  }
+
+  private String entryKey(Map.Entry<String, MarcBibUpdate> entry) {
+    return entry.getKey();
+  }
+
+  private MarcBibUpdate entryValue(Map.Entry<String, MarcBibUpdate> entry) {
+    return entry.getValue();
   }
 
   private List<LinkUpdateReport> toFailedLinkUpdateReports(List<Record> errorRecords,
@@ -283,7 +300,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
           .withFailCause(bibRecord.getErrorRecord().getDescription())
           .withStatus(FAIL);
       })
-      .collect(Collectors.toList());
+      .toList();
   }
 
   private void setUpdatedBy(Record changedRecord, String userId) {
@@ -296,20 +313,21 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     }
   }
 
-  private RecordsBatchResponse sendReports(RecordsBatchResponse batchResponse, BibAuthorityLinksUpdate event,
-                                           List<KafkaHeader> headers) {
+  private void sendReports(RecordsBatchResponse batchResponse, BibAuthorityLinksUpdate event,
+                           List<KafkaHeader> headers) {
     var errorRecords = getErrorRecords(batchResponse);
     if (!errorRecords.isEmpty()) {
       LOGGER.info("Errors detected. Sending {} linking reports for jobId {}, authorityId {}",
         errorRecords.size(), event.getJobId(), event.getAuthorityId());
 
       toFailedLinkUpdateReports(errorRecords, event).forEach(report ->
-        sendEventToKafka(LINKS_STATS, report.getTenant(), report.getJobId(), report, headers));
+        sendEventToKafka(LINKS_STATS, report.getTenant(), report.getJobId(), null, report, headers));
     }
-    return batchResponse;
   }
 
-  private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents, BibAuthorityLinksUpdate event,
+  private Future<String> sendEvents(List<MarcBibUpdate> marcBibUpdateEvents,
+                                    BibAuthorityLinksUpdate event,
+                                    String instanceId,
                                     KafkaConsumerRecord<String, String> consumerRecord) {
     LOGGER.info("Sending {} bib update events for jobId {}, authorityId {}",
       marcBibUpdateEvents.size(), event.getJobId(), event.getAuthorityId());
@@ -317,8 +335,8 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     return Future.fromCompletionStage(
       CompletableFuture.allOf(
         marcBibUpdateEvents.stream()
-          .map(marcBibUpdate -> sendEventToKafka(MARC_BIB, marcBibUpdate.getTenant(), marcBibUpdate.getJobId(),
-            marcBibUpdate, consumerRecord.headers()))
+          .map(bibUpdateEvent -> sendEventToKafka(MARC_BIB, bibUpdateEvent.getTenant(), bibUpdateEvent.getJobId(),
+            instanceId, bibUpdateEvent, consumerRecord.headers()))
           .map(Future::toCompletionStage)
           .map(CompletionStage::toCompletableFuture)
           .toArray(CompletableFuture[]::new)
@@ -326,11 +344,11 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
     ).map(unused -> consumerRecord.key());
   }
 
-  private Future<Boolean> sendEventToKafka(KafkaTopic topic, String tenant, String jobId, Object marcRecord,
-                                           List<KafkaHeader> kafkaHeaders) {
+  private Future<Boolean> sendEventToKafka(KafkaTopic topic, String tenant, String jobId, String recordKey,
+                                           Object marcRecord, List<KafkaHeader> kafkaHeaders) {
     var promise = Promise.<Boolean>promise();
     try {
-      var kafkaRecord = createKafkaProducerRecord(topic, tenant, marcRecord, kafkaHeaders);
+      var kafkaRecord = createKafkaProducerRecord(topic, tenant, recordKey, marcRecord, kafkaHeaders);
       producers.get(topic).write(kafkaRecord, ar -> {
         if (ar.succeeded()) {
           LOGGER.debug("Event with type {}, jobId {} was sent to kafka", topic.topicName(), jobId);
@@ -350,10 +368,10 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   }
 
   private KafkaProducerRecord<String, String> createKafkaProducerRecord(KafkaTopic topic, String tenant,
-                                                                        Object marcRecord,
+                                                                        String recordKey, Object marcRecord,
                                                                         List<KafkaHeader> kafkaHeaders) {
     var topicName = topic.fullTopicName(kafkaConfig, tenant);
-    var key = String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum);
+    var key = Optional.ofNullable(recordKey).orElse(String.valueOf(INDEXER.incrementAndGet() % maxDistributionNum));
     var kafkaRecord = KafkaProducerRecord.create(topicName, key, Json.encode(marcRecord));
     kafkaHeaders.removeIf(kafkaHeader -> !StringUtils.startsWithIgnoreCase(kafkaHeader.key(), "x-okapi-"));
     kafkaRecord.addHeaders(kafkaHeaders);
@@ -364,7 +382,7 @@ public class AuthorityLinkChunkKafkaHandler implements AsyncRecordHandler<String
   private List<Record> getErrorRecords(RecordsBatchResponse batchResponse) {
     return batchResponse.getRecords().stream()
       .filter(marcRecord -> nonNull(marcRecord.getErrorRecord()))
-      .collect(Collectors.toList());
+      .toList();
   }
 
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -47,6 +47,8 @@ import io.vertx.core.Vertx;
 import io.vertx.reactivex.pgclient.PgPool;
 import io.vertx.reactivex.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Row;
+
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
@@ -120,6 +122,7 @@ import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.JSONB;
+import org.jooq.LoaderError;
 import org.jooq.Name;
 import org.jooq.OrderField;
 import org.jooq.Record1;
@@ -614,10 +617,10 @@ public class RecordDaoImpl implements RecordDao {
       false,
       r -> {
         if (r.failed()) {
-          LOG.warn("saveRecords:: Error during batch record save", r.cause());
+          LOG.warn("saveRecords :: Error during batch record save", r.cause());
           finalPromise.fail(r.cause());
         } else {
-          LOG.debug("saveRecords:: batch record save was successful");
+          LOG.debug("saveRecords :: batch record save was successful");
           finalPromise.complete(r.result());
         }
       });
@@ -638,32 +641,61 @@ public class RecordDaoImpl implements RecordDao {
     Promise<RecordsBatchResponse> finalPromise = Promise.promise();
     Context context = Vertx.currentContext();
     if(context == null) {
-      return Future.failedFuture("saveRecordsByExternalIds:: operation must be executed by a Vertx thread");
+      return Future.failedFuture("saveRecordsByExternalIds :: operation must be executed by a Vertx thread");
     }
 
     context.owner().executeBlocking(
       () -> {
-        final RecordCollection recordCollection;
         try (Connection connection = getConnection(tenantId)) {
-          recordCollection = DSL.using(connection).transactionResult(ctx -> {
+          return DSL.using(connection).transactionResult(ctx -> {
             DSLContext dsl = DSL.using(ctx);
             var queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
             var records = queryResult.fetch(this::toRecord);
-            return new RecordCollection().withRecords(records).withTotalRecords(records.size());
+
+            if (CollectionUtils.isEmpty(records)) {
+              LOG.warn("saveRecordsByExternalIds :: No records returned from the fetch query");
+              return new RecordsBatchResponse().withTotalRecords(0);
+            }
+            var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());
+            var modifiedRecords = recordsModifier.apply(existingRecordsCollection);
+
+            // validate snapshot
+            var snapshotId = modifiedRecords.getRecords().iterator().next().getSnapshotId();
+            var snapshotIdsAreDifferent = records.stream().anyMatch(r -> !Objects.equals(snapshotId, r.getSnapshotId()));
+            if (snapshotIdsAreDifferent) {
+              throw new BadRequestException("Batch record collection only supports single snapshot");
+            }
+            validateSnapshot(UUID.fromString(snapshotId), ctx);
+
+            // extract db records to save
+            Set<UUID> matchedIds = new HashSet<>();
+            List<RecordsLbRecord> dbRecords = new ArrayList<>();
+            List<RawRecordsLbRecord> dbRawRecords = new ArrayList<>();
+            List<Record2<UUID, JSONB>> dbParsedRecords = new ArrayList<>();
+            List<ErrorRecordsLbRecord> dbErrorRecords = new ArrayList<>();
+
+            List<String> errorMessages = validateAndExtractDatabasePersistRecords(modifiedRecords.getRecords(), recordType,
+              matchedIds, dbRecords, dbRawRecords, dbParsedRecords, dbErrorRecords);
+
+            // save records
+            LOG.info("saveRecordsByExternalIds :: recordCollection: {}", modifiedRecords.getTotalRecords());
+            persistDatabaseRecords(dsl, recordType, matchedIds, dbRecords, dbRawRecords, dbParsedRecords, dbErrorRecords);
+
+            // return result
+            queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
+            records = queryResult.fetch(this::toRecord);
+            return new RecordsBatchResponse()
+              .withRecords(records)
+              .withTotalRecords(records.size())
+              .withErrorMessages(errorMessages);
           });
+        } catch (DuplicateEventException e) {
+          LOG.info("saveRecordsByExternalIds :: Skipped saving records due to duplicate event: {}", e.getMessage());
+          throw e;
         } catch (SQLException | DataAccessException e) {
-          LOG.warn("saveRecordsByExternalIds:: Failed to read records", e);
+          LOG.warn("saveRecordsByExternalIds :: Failed to read and save modified records", e);
           throw e;
         }
-
-        if (recordCollection == null || CollectionUtils.isEmpty(recordCollection.getRecords())) {
-          LOG.warn("saveRecordsByExternalIds:: No records returned from the fetch query");
-          return new RecordsBatchResponse().withTotalRecords(0);
-        }
-
-        var modifiedRecords = recordsModifier.apply(recordCollection);
-        var snapshotId = modifiedRecords.getRecords().iterator().next().getSnapshotId();
-        return saveRecords(modifiedRecords, snapshotId, recordType, tenantId);
       },
       r -> {
         if (r.failed()) {
@@ -708,6 +740,81 @@ public class RecordDaoImpl implements RecordDao {
       .limit(limit > 0 ? limit : DEFAULT_LIMIT_FOR_GET_RECORDS);
   }
 
+  private void persistDatabaseRecords(DSLContext dsl,
+                                      RecordType recordType,
+                                      Set<UUID> matchedIds,
+                                      List<RecordsLbRecord> dbRecords,
+                                      List<RawRecordsLbRecord> dbRawRecords,
+                                      List<Record2<UUID, JSONB>> dbParsedRecords,
+                                      List<ErrorRecordsLbRecord> dbErrorRecords) throws IOException {
+    LOG.info("persistDatabaseRecords :: dbRecords: {}", dbRecords.size());
+    List<UUID> ids = new ArrayList<>();
+
+    // lookup the latest generation by matched id and committed snapshot updated before current snapshot
+    dsl.select(RECORDS_LB.MATCHED_ID, RECORDS_LB.ID, RECORDS_LB.GENERATION)
+      .distinctOn(RECORDS_LB.MATCHED_ID)
+      .from(RECORDS_LB)
+      .innerJoin(SNAPSHOTS_LB).on(RECORDS_LB.SNAPSHOT_ID.eq(SNAPSHOTS_LB.ID))
+      .where(RECORDS_LB.MATCHED_ID.in(matchedIds)
+        .and(SNAPSHOTS_LB.STATUS.in(JobExecutionStatus.COMMITTED, JobExecutionStatus.ERROR, JobExecutionStatus.CANCELLED))
+      )
+      .orderBy(RECORDS_LB.MATCHED_ID.asc(), RECORDS_LB.GENERATION.desc())
+      .fetchStream().forEach(r -> ids.add(r.get(RECORDS_LB.ID)));
+
+    dbRecords.forEach(dbRecord -> {
+      var generation = Optional.ofNullable(dbRecord.getGeneration())
+        .map(g -> ++g)
+        .orElse(0);
+      LOG.debug("persistDatabaseRecords :: matchedId: {}, set new generation: {}", dbRecord.getMatchedId(), generation);
+      dbRecord.setGeneration(generation);
+    });
+
+    // update matching records state
+    if(CollectionUtils.isNotEmpty(ids)) {
+      LOG.debug("persistDatabaseRecords :: set ids: {} state to OLD", ids.size());
+      dsl.update(RECORDS_LB)
+        .set(RECORDS_LB.STATE, RecordState.OLD)
+        .where(RECORDS_LB.ID.in(ids))
+        .execute();
+    }
+
+    // batch insert records updating generation if required
+    var recordsLoadingErrors = dsl.loadInto(RECORDS_LB)
+      .onErrorAbort()
+      .loadRecords(dbRecords)
+      .fieldsCorresponding()
+      .execute()
+      .errors();
+
+    validateRecordsPersist(recordsLoadingErrors);
+
+    // batch insert raw records
+    dsl.loadInto(RAW_RECORDS_LB)
+      .onDuplicateKeyUpdate()
+      .onErrorAbort()
+      .loadRecords(dbRawRecords)
+      .fieldsCorresponding()
+      .execute();
+
+    // batch insert parsed records
+    recordType.toLoaderOptionsStep(dsl)
+      .onDuplicateKeyUpdate()
+      .onErrorAbort()
+      .loadRecords(dbParsedRecords)
+      .fieldsCorresponding()
+      .execute();
+
+    if (!dbErrorRecords.isEmpty()) {
+      // batch insert error records
+      dsl.loadInto(ERROR_RECORDS_LB)
+        .onDuplicateKeyUpdate()
+        .onErrorAbort()
+        .loadRecords(dbErrorRecords)
+        .fieldsCorresponding()
+        .execute();
+    }
+  }
+
   private RecordsBatchResponse saveRecords(RecordCollection recordCollection, String snapshotId, RecordType recordType,
                                            String tenantId) {
     Set<UUID> matchedIds = new HashSet<>();
@@ -716,56 +823,15 @@ public class RecordDaoImpl implements RecordDao {
     List<Record2<UUID, JSONB>> dbParsedRecords = new ArrayList<>();
     List<ErrorRecordsLbRecord> dbErrorRecords = new ArrayList<>();
 
-    List<String> errorMessages = new ArrayList<>();
+    // make sure only one snapshot id
+    var snapshotIdsAreDifferent = recordCollection.getRecords().stream()
+      .anyMatch(r -> !Objects.equals(snapshotId, r.getSnapshotId()));
+    if (snapshotIdsAreDifferent) {
+      throw new BadRequestException("Batch record collection only supports single snapshot");
+    }
 
-    recordCollection.getRecords()
-      .stream()
-      .map(RecordDaoUtil::ensureRecordHasId)
-      .map(RecordDaoUtil::ensureRecordHasMatchedId)
-      .map(RecordDaoUtil::ensureRecordHasSuppressDiscovery)
-      .map(RecordDaoUtil::ensureRecordForeignKeys)
-      .forEach(record -> {
-        // collect unique matched ids to query to determine generation
-        matchedIds.add(UUID.fromString(record.getMatchedId()));
-
-        // make sure only one snapshot id
-        if (!Objects.equals(snapshotId, record.getSnapshotId())) {
-          throw new BadRequestException("Batch record collection only supports single snapshot");
-        }
-        validateRecordType(record, recordType);
-
-        // if record has parsed record, validate by attempting format
-        if (Objects.nonNull(record.getParsedRecord())) {
-          try {
-            recordType.formatRecord(record);
-            Record2<UUID, JSONB> dbParsedRecord = recordType.toDatabaseRecord2(record.getParsedRecord());
-            dbParsedRecords.add(dbParsedRecord);
-          } catch (Exception e) {
-            // create error record and remove from record
-            Object content = Optional.ofNullable(record.getParsedRecord())
-              .map(ParsedRecord::getContent)
-              .orElse(null);
-            var errorRecord = new ErrorRecord()
-              .withId(record.getId())
-              .withDescription(e.getMessage())
-              .withContent(content);
-            errorMessages.add(format(INVALID_PARSED_RECORD_MESSAGE_TEMPLATE, record.getId(), e.getMessage()));
-            record.withErrorRecord(errorRecord)
-              .withParsedRecord(null)
-              .withLeaderRecordStatus(null);
-          }
-        }
-
-        if (Objects.nonNull(record.getRawRecord())) {
-          dbRawRecords.add(RawRecordDaoUtil.toDatabaseRawRecord(record.getRawRecord()));
-        }
-
-        if (Objects.nonNull(record.getErrorRecord())) {
-          dbErrorRecords.add(ErrorRecordDaoUtil.toDatabaseErrorRecord(record.getErrorRecord()));
-        }
-
-        dbRecords.add(RecordDaoUtil.toDatabaseRecord(record));
-      });
+    List<String> errorMessages = validateAndExtractDatabasePersistRecords(recordCollection.getRecords(), recordType,
+      matchedIds, dbRecords, dbRawRecords, dbParsedRecords, dbErrorRecords);
 
     try (Connection connection = getConnection(tenantId)) {
       return DSL.using(connection).transactionResult(ctx -> {
@@ -824,13 +890,7 @@ public class RecordDaoImpl implements RecordDao {
           .execute()
           .errors();
 
-        recordsLoadingErrors.forEach(error -> {
-          if (error.exception().sqlState().equals(UNIQUE_VIOLATION_SQL_STATE)) {
-            throw new DuplicateEventException("SQL Unique constraint violation prevented repeatedly saving the record");
-          }
-          LOG.warn("saveRecords:: Error occurred on batch execution: {}", error.exception().getCause().getMessage());
-          LOG.debug("saveRecords:: Failed to execute statement from batch: {}", error.query());
-        });
+        validateRecordsPersist(recordsLoadingErrors);
 
         // batch insert raw records
         dsl.loadInto(RAW_RECORDS_LB)
@@ -877,6 +937,71 @@ public class RecordDaoImpl implements RecordDao {
       Throwable throwable = ex.getCause() != null ? ex.getCause() : ex;
       throw new RecordUpdateException(throwable);
     }
+  }
+
+  private List<String> validateAndExtractDatabasePersistRecords(List<Record> records,
+                                                                RecordType recordType,
+                                                                Set<UUID> matchedIds,
+                                                                List<RecordsLbRecord> dbRecords,
+                                                                List<RawRecordsLbRecord> dbRawRecords,
+                                                                List<Record2<UUID, JSONB>> dbParsedRecords,
+                                                                List<ErrorRecordsLbRecord> dbErrorRecords) {
+    List<String> errorMessages = new ArrayList<>();
+    records.stream()
+      .map(RecordDaoUtil::ensureRecordHasId)
+      .map(RecordDaoUtil::ensureRecordHasMatchedId)
+      .map(RecordDaoUtil::ensureRecordHasSuppressDiscovery)
+      .map(RecordDaoUtil::ensureRecordForeignKeys)
+      .forEach(record -> {
+        // collect unique matched ids to query to determine generation
+        matchedIds.add(UUID.fromString(record.getMatchedId()));
+
+        validateRecordType(record, recordType);
+
+        // if record has parsed record, validate by attempting format
+        if (Objects.nonNull(record.getParsedRecord())) {
+          try {
+            recordType.formatRecord(record);
+            Record2<UUID, JSONB> dbParsedRecord = recordType.toDatabaseRecord2(record.getParsedRecord());
+            dbParsedRecords.add(dbParsedRecord);
+          } catch (Exception e) {
+            // create error record and remove from record
+            Object content = Optional.ofNullable(record.getParsedRecord())
+              .map(ParsedRecord::getContent)
+              .orElse(null);
+            var errorRecord = new ErrorRecord()
+              .withId(record.getId())
+              .withDescription(e.getMessage())
+              .withContent(content);
+            errorMessages.add(format(INVALID_PARSED_RECORD_MESSAGE_TEMPLATE, record.getId(), e.getMessage()));
+            record.withErrorRecord(errorRecord)
+              .withParsedRecord(null)
+              .withLeaderRecordStatus(null);
+          }
+        }
+
+        if (Objects.nonNull(record.getRawRecord())) {
+          dbRawRecords.add(RawRecordDaoUtil.toDatabaseRawRecord(record.getRawRecord()));
+        }
+
+        if (Objects.nonNull(record.getErrorRecord())) {
+          dbErrorRecords.add(ErrorRecordDaoUtil.toDatabaseErrorRecord(record.getErrorRecord()));
+        }
+
+        dbRecords.add(RecordDaoUtil.toDatabaseRecord(record));
+      });
+
+    return errorMessages;
+  }
+
+  private void validateRecordsPersist(List<LoaderError> recordsLoadingErrors) {
+    recordsLoadingErrors.forEach(error -> {
+      if (error.exception().sqlState().equals(UNIQUE_VIOLATION_SQL_STATE)) {
+        throw new DuplicateEventException("SQL Unique constraint violation prevented repeatedly saving the record");
+      }
+      LOG.warn("validateRecordsPersist :: Error occurred on batch execution: {}", error.exception().getCause().getMessage());
+      LOG.debug("validateRecordsPersist :: Failed to execute statement from batch: {}", error.query());
+    });
   }
 
   private void validateRecordType(Record recordDto, RecordType recordType) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordService.java
@@ -89,11 +89,13 @@ public interface RecordService {
    * @param recordType  record type
    * @param recordsModifier records collection modifier operator
    * @param okapiHeaders okapi headers
+   * @param maxSaveRetryCount max count of retries to save records
    * @return future with response containing list of successfully saved records and error messages for records that were not saved
    */
   Future<RecordsBatchResponse> saveRecordsByExternalIds(List<String> externalIds, RecordType recordType,
                                                         RecordsModifierOperator recordsModifier,
-                                                        Map<String, String> okapiHeaders);
+                                                        Map<String, String> okapiHeaders,
+                                                        int maxSaveRetryCount);
 
   /**
    * Updates record with given id

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -180,7 +180,8 @@ public class RecordServiceImpl implements RecordService {
   public Future<RecordsBatchResponse> saveRecordsByExternalIds(List<String> externalIds,
                                                                RecordType recordType,
                                                                RecordsModifierOperator recordsModifier,
-                                                               Map<String, String> okapiHeaders) {
+                                                               Map<String, String> okapiHeaders,
+                                                               int maxSaveRetryCount) {
     if (CollectionUtils.isEmpty(externalIds)) {
       LOG.warn("saveRecordsByExternalIds:: Skipping the records save, no external IDs are provided");
       return Future.succeededFuture(new RecordsBatchResponse().withTotalRecords(0));
@@ -192,7 +193,6 @@ public class RecordServiceImpl implements RecordService {
     }
 
     AtomicInteger retryCount = new AtomicInteger(0);
-    final int maxRetryCount = 3;
 
     RecordsModifierOperator recordsMatchedIdsSetter = recordCollection -> {
       try {
@@ -212,7 +212,7 @@ public class RecordServiceImpl implements RecordService {
     };
 
     RecordsModifierOperator recordsModifierWithMatchedIdsSetter = recordsModifier.andThen(recordsMatchedIdsSetter);
-    return retrySave(externalIds, recordType, recordsModifierWithMatchedIdsSetter, okapiHeaders, retryCount, maxRetryCount);
+    return retrySave(externalIds, recordType, recordsModifierWithMatchedIdsSetter, okapiHeaders, retryCount, maxSaveRetryCount);
   }
 
   private Future<RecordsBatchResponse> retrySave(List<String> externalIds, RecordType recordType,

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-source-record-storage</artifactId>
-  <version>5.8.10-SNAPSHOT</version>
+  <version>5.8.10</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -215,7 +215,7 @@
     <url>https://github.com/folio-org/mod-source-record-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-source-record-storage</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-source-record-storage.git</developerConnection>
-    <tag>v5.8.0</tag>
+    <tag>v5.8.10</tag>
   </scm>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-source-record-storage</artifactId>
-  <version>5.8.10</version>
+  <version>5.8.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -215,7 +215,7 @@
     <url>https://github.com/folio-org/mod-source-record-storage</url>
     <connection>scm:git:git://github.com/folio-org/mod-source-record-storage</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-source-record-storage.git</developerConnection>
-    <tag>v5.8.10</tag>
+    <tag>v5.8.0</tag>
   </scm>
 
   <pluginRepositories>


### PR DESCRIPTION
## Purpose
Handling Authority-Instance links event works well when having one consumer (module instance) of the event.
When there are many events being received at the same time for the same instance and they are handled by two or more consumers / (running module instances) then one silently overwrites the changes of another causing the updates being lost.

## Approach
Change srs.marc-bib event's key from serial integer value to the instance id, so that in consuming side of this event (mod-inventory) only one consumer would be responsible to handle events for the same instance.
Do not make separate query to get value for generation column from records_lb as we have just made records read query and have generation's value at the time of query. Having the separate query prevents to detect the error called DuplicateEventException which acts like Optimistic Locking as some other event consumer may have done already the changes for the same bib

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.

## Learning
[MODSOURCE-817](https://folio-org.atlassian.net/browse/MODSOURCE-817)
[MODINV-1100](https://folio-org.atlassian.net/browse/MODINV-1100)
[MODELINKS-115](https://folio-org.atlassian.net/browse/MODELINKS-115)