### PR TITLE
[MODSOURCE-854] Use deleteRecordBy id for soft delete of authority

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityDomainKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/AuthorityDomainKafkaHandler.java
@@ -1,16 +1,19 @@
 package org.folio.consumers;
 
 import static org.folio.dao.util.RecordDaoUtil.filterRecordByExternalId;
+import static org.folio.services.util.EventHandlingUtil.toOkapiHeaders;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import java.util.Collections;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.dao.util.IdType;
 import org.folio.dao.util.RecordType;
 import org.folio.kafka.AsyncRecordHandler;
-import org.folio.rest.jooq.enums.RecordState;
 import org.folio.services.RecordService;
 import org.folio.services.util.KafkaUtil;
 import org.springframework.stereotype.Component;
@@ -34,6 +37,10 @@ public class AuthorityDomainKafkaHandler implements AsyncRecordHandler<String, S
   @Override
   public Future<String> handle(KafkaConsumerRecord<String, String> consumerRecord) {
     log.trace("handle:: Handling kafka record: '{}'", consumerRecord);
+
+    var kafkaHeaders = consumerRecord.headers();
+    var okapiHeaders = toOkapiHeaders(kafkaHeaders);
+
     String authorityId = consumerRecord.key();
     if (isUnexpectedDomainEvent(consumerRecord)) {
       log.trace("handle:: Expected only {} domain type. Skipping authority domain kafka record [ID: '{}']",
@@ -47,12 +54,12 @@ public class AuthorityDomainKafkaHandler implements AsyncRecordHandler<String, S
 
     logInput(authorityId, eventSubType, tenantId);
     return (switch (eventSubType) {
-      case SOFT_DELETE -> performSoftDelete(authorityId, tenantId);
+      case SOFT_DELETE -> performSoftDelete(authorityId, tenantId, okapiHeaders);
       case HARD_DELETE -> performHardDelete(authorityId, tenantId);
     }).onFailure(throwable -> logError(authorityId, eventSubType, tenantId));
   }
 
-  private Future<String> performSoftDelete(String authorityId, String tenantId) {
+  private Future<String> performSoftDelete(String authorityId, String tenantId, Map<String, String> okapiHeaders) {
     var condition = filterRecordByExternalId(authorityId);
     return recordService.getRecords(condition, RecordType.MARC_AUTHORITY, Collections.emptyList(), 0, 1, tenantId)
       .compose(recordCollection -> {
@@ -62,7 +69,7 @@ public class AuthorityDomainKafkaHandler implements AsyncRecordHandler<String, S
         }
         var matchedId = recordCollection.getRecords().get(0).getMatchedId();
 
-        return recordService.updateRecordsState(matchedId, RecordState.DELETED, RecordType.MARC_AUTHORITY, tenantId);
+        return recordService.deleteRecordById(matchedId, IdType.RECORD, okapiHeaders);
       }).map(authorityId);
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/consumers/AuthorityDomainKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/consumers/AuthorityDomainKafkaHandlerTest.java
@@ -29,6 +29,7 @@ import org.folio.rest.jaxrs.model.Record;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.rest.jaxrs.model.SourceRecord;
 import org.folio.rest.jooq.enums.RecordState;
+import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.AbstractLBServiceTest;
 import org.folio.services.RecordService;
 import org.folio.services.RecordServiceImpl;
@@ -156,6 +157,9 @@ public class AuthorityDomainKafkaHandlerTest extends AbstractLBServiceTest {
   private ConsumerRecord<String, String> getConsumerRecord(HashMap<String, String> payload) {
     ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("topic", 1, 1, recordId, Json.encode(payload));
     consumerRecord.headers().add(new RecordHeader("domain-event-type", "DELETE".getBytes(StandardCharsets.UTF_8)));
+    consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_URL_HEADER, OKAPI_URL.getBytes(StandardCharsets.UTF_8)));
+    consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TENANT_HEADER, TENANT_ID.getBytes(StandardCharsets.UTF_8)));
+    consumerRecord.headers().add(new RecordHeader(OkapiConnectionParams.OKAPI_TOKEN_HEADER, TOKEN.getBytes(StandardCharsets.UTF_8)));
     return consumerRecord;
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/consumers/AuthorityDomainKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/consumers/AuthorityDomainKafkaHandlerTest.java
@@ -5,14 +5,18 @@ import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -21,6 +25,7 @@ import org.folio.TestUtil;
 import org.folio.dao.RecordDao;
 import org.folio.dao.RecordDaoImpl;
 import org.folio.dao.util.IdType;
+import org.folio.dao.util.ParsedRecordDaoUtil;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.ParsedRecord;
@@ -55,6 +60,7 @@ public class AuthorityDomainKafkaHandlerTest extends AbstractLBServiceTest {
   private RecordService recordService;
   private Record record;
   private AuthorityDomainKafkaHandler handler;
+  private static final String currentDate = "20240718132044.6";
 
   @BeforeClass
   public static void setUpClass() throws IOException {
@@ -62,7 +68,10 @@ public class AuthorityDomainKafkaHandlerTest extends AbstractLBServiceTest {
       .withContent(
         new ObjectMapper().readValue(TestUtil.readFileFromPath(RAW_MARC_RECORD_CONTENT_SAMPLE_PATH), String.class));
     parsedRecord = new ParsedRecord().withId(recordId)
-      .withContent(TestUtil.readFileFromPath(PARSED_MARC_RECORD_CONTENT_SAMPLE_PATH));
+      .withContent(
+        new JsonObject().put("leader", "01542ccm a2200361   4500")
+        .put("fields", new JsonArray()
+          .add(new JsonObject().put("005", currentDate))));
   }
 
   @Before
@@ -124,6 +133,16 @@ public class AuthorityDomainKafkaHandlerTest extends AbstractLBServiceTest {
             context.assertTrue(result.result().isPresent());
             SourceRecord updatedRecord = result.result().get();
             context.assertTrue(updatedRecord.getDeleted());
+            context.assertTrue(updatedRecord.getAdditionalInfo().getSuppressDiscovery());
+            context.assertEquals("d", ParsedRecordDaoUtil.getLeaderStatus(updatedRecord.getParsedRecord()));
+
+            //Complex verifying "005" field is NOT empty inside parsed record.
+            LinkedHashMap<String, ArrayList<LinkedHashMap<String, String>>> content = (LinkedHashMap<String, ArrayList<LinkedHashMap<String, String>>>) updatedRecord.getParsedRecord().getContent();
+            LinkedHashMap<String, String> map = content.get("fields").get(0);
+            String resulted005FieldValue = map.get("005");
+            context.assertNotNull(resulted005FieldValue);
+            context.assertNotEquals(currentDate, resulted005FieldValue);
+
             async.complete();
           });
       });


### PR DESCRIPTION
## Purpose
Update soft delete logic for Marc Authority

## Approach
Use deleteRecordBy id for soft delete of authority

#### Jira
https://folio-org.atlassian.net/browse/MODSOURCE-854
