### PR TITLE
MODSOURCE-855: Error (No space left on device) during CALL delete_old_marc_indexers_versions

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -382,7 +382,7 @@ public interface RecordDao {
    *
    * @return boolean future
    */
-  Future<Boolean> deleteMarcIndexersOldVersions(String tenantId);
+  Future<Boolean> deleteMarcIndexersOldVersions(String tenantId, Integer oneTimeLimit);
 
   /**
    * Creates new Record and updates status of the "old" one,

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -33,7 +33,6 @@ import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.inline;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.name;
-import static org.jooq.impl.DSL.primaryKey;
 import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.selectDistinct;
 import static org.jooq.impl.DSL.table;
@@ -152,7 +151,6 @@ import org.jooq.UpdateSetMoreStep;
 import org.jooq.conf.ParamType;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
-import org.jooq.impl.SQLDataType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -215,15 +213,10 @@ public class RecordDaoImpl implements RecordDao {
     RECORDS_LB.EXTERNAL_HRID
   };
 
-  private static final String DELETE_MARC_INDEXERS_TEMP_TABLE = "marc_indexers_deleted_ids";
-
   public static final String OR = " or ";
   public static final String MARC_INDEXERS = "marc_indexers";
   public static final Field<UUID> MARC_INDEXERS_MARC_ID = field(TABLE_FIELD_TEMPLATE, UUID.class, field(MARC_INDEXERS), field(MARC_ID));
   public static final String CALL_DELETE_OLD_MARC_INDEXERS_VERSIONS_PROCEDURE = "call delete_old_marc_indexers_versions(?)";
-  public static final String OLD_RECORDS_TRACKING_TABLE = "old_records_tracking";
-  public static final String HAS_BEEN_PROCESSED_FLAG = "has_been_processed";
-  public static final String MARC_ID_COLUMN = "marc_id";
 
   private final PostgresClientFactory postgresClientFactory;
   private final RecordDomainEventPublisher recordDomainEventPublisher;

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -220,7 +220,7 @@ public class RecordDaoImpl implements RecordDao {
   public static final String OR = " or ";
   public static final String MARC_INDEXERS = "marc_indexers";
   public static final Field<UUID> MARC_INDEXERS_MARC_ID = field(TABLE_FIELD_TEMPLATE, UUID.class, field(MARC_INDEXERS), field(MARC_ID));
-  public static final String CALL_DELETE_OLD_MARC_INDEXERS_VERSIONS_PROCEDURE = "CALL delete_old_marc_indexers_versions()";
+  public static final String CALL_DELETE_OLD_MARC_INDEXERS_VERSIONS_PROCEDURE = "call delete_old_marc_indexers_versions(?)";
   public static final String OLD_RECORDS_TRACKING_TABLE = "old_records_tracking";
   public static final String HAS_BEEN_PROCESSED_FLAG = "has_been_processed";
   public static final String MARC_ID_COLUMN = "marc_id";
@@ -1570,54 +1570,23 @@ public class RecordDaoImpl implements RecordDao {
    * or 'false' if it was not.
    */
   @Override
-  public Future<Boolean> deleteMarcIndexersOldVersions(String tenantId) {
+  public Future<Boolean> deleteMarcIndexersOldVersions(String tenantId, Integer oneTimeLimit) {
     return executeInTransaction(txQE -> acquireLock(txQE, INDEXERS_DELETION_LOCK_NAMESPACE_ID, tenantId.hashCode())
       .compose(isLockAcquired -> {
         if (Boolean.FALSE.equals(isLockAcquired)) {
           LOG.info("deleteMarcIndexersOldVersions:: Previous marc_indexers old version deletion still ongoing, tenantId: '{}'", tenantId);
           return Future.succeededFuture(false);
         }
-        return deleteMarcIndexersOldVersions(txQE, tenantId);
+        return deleteMarcIndexersOldVersions(txQE, tenantId, oneTimeLimit);
       }), tenantId);
   }
 
-  private Future<Boolean> deleteMarcIndexersOldVersions(ReactiveClassicGenericQueryExecutor txQE, String tenantId) {
+  private Future<Boolean> deleteMarcIndexersOldVersions(ReactiveClassicGenericQueryExecutor txQE, String tenantId, Integer oneTimeLimit) {
     LOG.trace("deleteMarcIndexersOldVersions:: Deleting old marc indexers versions tenantId={}", tenantId);
     long startTime = System.nanoTime();
 
-
-    return txQE.execute(dsl ->
-        dsl.createTemporaryTableIfNotExists(DELETE_MARC_INDEXERS_TEMP_TABLE)
-          .column(MARC_ID, SQLDataType.UUID)
-          .constraint(primaryKey(MARC_ID))
-          .onCommitDrop()
-      )
-      .compose(ar -> txQE.execute(
-          dsl -> dsl.query(CALL_DELETE_OLD_MARC_INDEXERS_VERSIONS_PROCEDURE))
-        .onFailure(th -> LOG.error("Something happened while deleting old marc_indexers versions tenantId={}", tenantId, th))
-      )
-      .compose(res -> {
-        Table<Record1<UUID>> subquery = select(field(MARC_ID, SQLDataType.UUID))
-          .from(table(DELETE_MARC_INDEXERS_TEMP_TABLE)).asTable("subquery");
-
-        return txQE.execute(dsl ->
-            dsl.update(table(OLD_RECORDS_TRACKING_TABLE))
-              .set(field(HAS_BEEN_PROCESSED_FLAG), true)
-              .where(field(MARC_ID_COLUMN).in(select(subquery.field(MARC_ID, SQLDataType.UUID)).from(subquery)))
-          )
-          .compose(updateResult ->
-            txQE.execute(dsl ->
-              dsl.update(MARC_RECORDS_TRACKING)
-                .set(MARC_RECORDS_TRACKING.IS_DIRTY, false)
-                .where(MARC_RECORDS_TRACKING.MARC_ID
-                  .in(select(subquery.field(MARC_ID, SQLDataType.UUID)).from(subquery)))
-            )
-          )
-          .onFailure(th -> {
-            double durationSeconds = TenantUtil.calculateDurationSeconds(startTime);
-            LOG.error("Something happened while updating tracking tables tenantId={}. Duration= {}s", tenantId, durationSeconds, th);
-          });
-      })
+    return txQE.execute(dsl -> dsl.query(CALL_DELETE_OLD_MARC_INDEXERS_VERSIONS_PROCEDURE, oneTimeLimit))
+      .onFailure(th -> LOG.error("Something happened while deleting old marc_indexers versions tenantId={}", tenantId, th))
       .map(res -> {
         double durationSeconds = TenantUtil.calculateDurationSeconds(startTime);
         LOG.info("deleteMarcIndexersOldVersions:: Completed successfully for tenantId={}. Duration= {}s", tenantId, durationSeconds);

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -45,7 +45,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
   @Value("${srs.marcIndexers.delete.interval.seconds:1800}")
   private int interval;
 
-  @Value("${srs.marcIndexers.delete.plannedTime}")
+  @Value("${srs.marcIndexers.delete.plannedTime:}")
   private String plannedTime;
 
   @Value("${srs.marcIndexers.delete.dirtyBatchSize:100000}")

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -60,6 +60,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startFuture) {
+    LOGGER.info("Specified values: planned time: {}, interval: {}", plannedTime, interval);
     long intervalMillis = interval * 1000L;
 
     if (!"00:00".equals(plannedTime) && interval == 1800) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -65,15 +65,15 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
           try {
             return LocalTime.parse(time);
           } catch (DateTimeParseException e) {
-            LOGGER.error("Error parsing time: '{}'. Defaulting to 01:00", time, e);
-            return LocalTime.of(1, 0);
+            LOGGER.error("deleteOldMarcIndexerVersions:: Error parsing time: '{}'. Stopping processing and defaulting to 01:00", time, e);
+            throw new RuntimeException("Invalid time format encountered, defaulting to 01:00");
           }
         })
         .sorted()
         .collect(Collectors.toList());
-      LOGGER.info("Scheduled times: {}", scheduleTimes);
-    } catch (Exception e) {
-      LOGGER.error("Unexpected error occurred while setting up scheduled times, defaulting to 01:00", e);
+      LOGGER.info("deleteOldMarcIndexerVersions:: Scheduled times: {}", scheduleTimes);
+    } catch (RuntimeException e) {
+      LOGGER.error("deleteOldMarcIndexerVersions:: An error occurred while setting up scheduled times, defaulting to 01:00", e);
       scheduleTimes = Arrays.asList(LocalTime.of(1, 0));
     }
     scheduleNextTask(vertx, this::deleteTask);

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
@@ -63,7 +62,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
   @Override
   public void start(Promise<Void> startFuture) {
     LOGGER.info("Specified values:: planned time: {}, interval: {}",
-      isBlank(plannedTime) ? "not specified" : plannedTime, interval);
+      isBlank(plannedTime) ? "is not specified" : plannedTime, interval);
     long intervalMillis = interval * 1000L;
 
     if (isNotBlank(plannedTime)) {
@@ -88,8 +87,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
       scheduleTimes = Arrays.stream(_plannedTime.split(","))
         .map(String::trim)
         .map(LocalTime::parse)
-        .sorted()
-        .collect(Collectors.toList());
+        .sorted().toList();
       LOGGER.info("Scheduled times for deletion: {}", scheduleTimes);
       scheduleNextTask(vertx, () -> executeDeletionTask(batchSize));
     } catch (DateTimeParseException e) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 /**
@@ -44,7 +45,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
   @Value("${srs.marcIndexers.delete.interval.seconds:1800}")
   private int interval;
 
-  @Value("${srs.marcIndexers.delete.plannedTime:00:00}")
+  @Value("${srs.marcIndexers.delete.plannedTime}")
   private String plannedTime;
 
   @Value("${srs.marcIndexers.delete.dirtyBatchSize:100000}")
@@ -63,7 +64,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
     LOGGER.info("Specified values: planned time: {}, interval: {}", plannedTime, interval);
     long intervalMillis = interval * 1000L;
 
-    if (!"00:00".equals(plannedTime) && interval == 1800) {
+    if (isNotBlank(plannedTime)) {
       LOGGER.info("Using scheduler based on planned time: {}", plannedTime);
       setupTimedDeletion(plannedTime, dirtyBatchSize);
     } else {

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -62,7 +62,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startFuture) {
-    LOGGER.info("Specified values: planned time: {}, interval: {}",
+    LOGGER.info("Specified values:: planned time: {}, interval: {}",
       isBlank(plannedTime) ? "not specified" : plannedTime, interval);
     long intervalMillis = interval * 1000L;
 
@@ -77,12 +77,12 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
     startFuture.complete();
   }
 
-  private void setupPeriodicDeletion(long intervalMillis, Integer batchSize) {
+  void setupPeriodicDeletion(long intervalMillis, Integer batchSize) {
     LOGGER.info("Setting up periodic deletion every {}s", interval);
     vertx.setPeriodic(intervalMillis, id -> executeDeletionTask(batchSize));
   }
 
-  private void setupTimedDeletion(String _plannedTime, Integer batchSize) {
+  void setupTimedDeletion(String _plannedTime, Integer batchSize) {
     LOGGER.info("Setting up timed deletion based on planned times: {}", _plannedTime);
     try {
       scheduleTimes = Arrays.stream(_plannedTime.split(","))

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -74,15 +74,15 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
     startFuture.complete();
   }
 
-  private void setupPeriodicDeletion(long intervalMillis, Integer dirtyBatchSize) {
+  private void setupPeriodicDeletion(long intervalMillis, Integer batchSize) {
     LOGGER.info("Setting up periodic deletion every {}s", interval);
-    vertx.setPeriodic(intervalMillis, id -> executeDeletionTask(dirtyBatchSize));
+    vertx.setPeriodic(intervalMillis, id -> executeDeletionTask(batchSize));
   }
 
-  private void setupTimedDeletion(String plannedTime, Integer batchSize) {
-    LOGGER.info("Setting up timed deletion based on planned times: {}", plannedTime);
+  private void setupTimedDeletion(String _plannedTime, Integer batchSize) {
+    LOGGER.info("Setting up timed deletion based on planned times: {}", _plannedTime);
     try {
-      scheduleTimes = Arrays.stream(plannedTime.split(","))
+      scheduleTimes = Arrays.stream(_plannedTime.split(","))
         .map(String::trim)
         .map(LocalTime::parse)
         .sorted()

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/MarcIndexersVersionDeletionVerticle.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
@@ -45,7 +46,7 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
   @Value("${srs.marcIndexers.delete.interval.seconds:1800}")
   private int interval;
 
-  @Value("${srs.marcIndexers.delete.plannedTime:}")
+  @Value("${srs.marcIndexers.delete.plannedTime:#{null}}")
   private String plannedTime;
 
   @Value("${srs.marcIndexers.delete.dirtyBatchSize:100000}")
@@ -61,7 +62,8 @@ public class MarcIndexersVersionDeletionVerticle extends AbstractVerticle {
 
   @Override
   public void start(Promise<Void> startFuture) {
-    LOGGER.info("Specified values: planned time: {}, interval: {}", plannedTime, interval);
+    LOGGER.info("Specified values: planned time: {}, interval: {}",
+      isBlank(plannedTime) ? "not specified" : plannedTime, interval);
     long intervalMillis = interval * 1000L;
 
     if (isNotBlank(plannedTime)) {

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
@@ -31,44 +31,55 @@
     </sql>
   </changeSet>
 
-  <changeSet id="2024-12-10--17-00-create-delete-old-marc-indexers-versions" author="Volodymyr_Rohach">
+  <changeSet id="2024-12-10--17-00-create-delete-old-marc-indexers-versions" author="Aliaksandr_Fedasiuk">
+    <sql>
+      DROP PROCEDURE IF EXISTS ${database.defaultSchemaName}.delete_old_marc_indexers_versions;
+    </sql>
     <createProcedure>
-      CREATE OR REPLACE PROCEDURE ${database.defaultSchemaName}.delete_old_marc_indexers_versions() LANGUAGE plpgsql AS $$
+      CREATE OR REPLACE PROCEDURE ${database.defaultSchemaName}.delete_old_marc_indexers_versions(IN pLimit INTEGER) LANGUAGE plpgsql AS $$
       BEGIN
-      WITH dirty_records AS (
-        SELECT mrt.marc_id, mrt.version
-        FROM marc_records_tracking mrt
-        WHERE mrt.is_dirty = true
-      ),
-      deleted_dirty AS (
-      DELETE FROM marc_indexers mi
-        USING dirty_records dr
-      WHERE mi.marc_id = dr.marc_id AND dr.version > mi.version
-        RETURNING mi.marc_id
+        WITH dirty_records AS (
+          SELECT mrt.marc_id, mrt.version
+          FROM marc_records_tracking mrt
+          WHERE mrt.is_dirty = true
+          LIMIT pLimit
         ),
-      old_records AS (
-      SELECT ot.marc_id
-      FROM old_records_tracking ot
-      WHERE ot.has_been_processed = false
+        deleted_dirty AS (
+          DELETE FROM marc_indexers mi
+            USING dirty_records dr
+          WHERE mi.marc_id = dr.marc_id AND dr.version > mi.version
+          RETURNING mi.marc_id
         ),
-      deleted_old AS (
-      DELETE FROM marc_indexers mi
-        USING old_records ors
-      WHERE mi.marc_id = ors.marc_id
-        RETURNING mi.marc_id
+        old_records AS (
+          SELECT ot.marc_id
+          FROM old_records_tracking ot
+          WHERE ot.has_been_processed = false
+          LIMIT pLimit
         ),
-      combined_deletions AS (
-      SELECT marc_id FROM deleted_dirty
-      UNION
-      SELECT marc_id FROM deleted_old
+        deleted_old AS (
+          DELETE FROM marc_indexers mi
+            USING old_records ors
+          WHERE mi.marc_id = ors.marc_id
+          RETURNING mi.marc_id
+        ),
+        combined_deletions AS (
+          SELECT marc_id FROM dirty_records
+          UNION
+          SELECT marc_id FROM old_records
+        ),
+        update_old_records AS (
+          UPDATE old_records_tracking
+          SET has_been_processed = true
+          WHERE marc_id IN (SELECT marc_id FROM combined_deletions)
+          RETURNING marc_id
         )
-      INSERT INTO marc_indexers_deleted_ids (marc_id)
-      SELECT DISTINCT marc_id FROM combined_deletions
-        ON CONFLICT (marc_id) DO NOTHING;
+        UPDATE marc_records_tracking
+        SET is_dirty = false
+        WHERE marc_id IN (SELECT marc_id FROM combined_deletions);
+      RETURN;
       END $$;
     </createProcedure>
   </changeSet>
-
 
   <changeSet id="2024-12-10--17-00-create-index-on-is-dirty-true" author="Volodymyr_Rohach">
     <sql>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
@@ -38,7 +38,7 @@
     <createProcedure>
       CREATE OR REPLACE PROCEDURE ${database.defaultSchemaName}.delete_old_marc_indexers_versions(IN pLimit INTEGER) LANGUAGE plpgsql AS $$
       BEGIN
-        WITH dirty_records AS (
+        WITH dirty_records AS MATERIALIZED (
           SELECT mrt.marc_id, mrt.version
           FROM marc_records_tracking mrt
           WHERE mrt.is_dirty = true
@@ -50,7 +50,7 @@
           WHERE mi.marc_id = dr.marc_id AND dr.version > mi.version
           RETURNING mi.marc_id
         ),
-        old_records AS (
+        old_records AS MATERIALIZED (
           SELECT ot.marc_id
           FROM old_records_tracking ot
           WHERE ot.has_been_processed = false
@@ -62,7 +62,7 @@
           WHERE mi.marc_id = ors.marc_id
           RETURNING mi.marc_id
         ),
-        combined_deletions AS (
+        combined_deletions AS MATERIALIZED (
           SELECT marc_id FROM dirty_records
           UNION
           SELECT marc_id FROM old_records

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml
@@ -31,7 +31,7 @@
     </sql>
   </changeSet>
 
-  <changeSet id="2024-12-10--17-00-create-delete-old-marc-indexers-versions" author="Aliaksandr_Fedasiuk">
+  <changeSet id="2024-12-10--17-00-create-delete-old-marc-indexers-versions-v2" author="Aliaksandr_Fedasiuk">
     <sql>
       DROP PROCEDURE IF EXISTS ${database.defaultSchemaName}.delete_old_marc_indexers_versions;
     </sql>

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -238,7 +238,7 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     Future<Boolean> future = postgresClientFactory.getQueryExecutor(TENANT_ID)
     // gets lock on DB in same way as deleteMarcIndexersOldVersions() method to model indexers deletion being in progress
       .transaction(txQE -> AdvisoryLockUtil.acquireLock(txQE, INDEXERS_DELETION_LOCK_NAMESPACE_ID, TENANT_ID.hashCode())
-        .compose(v -> recordDao.deleteMarcIndexersOldVersions(TENANT_ID)));
+        .compose(v -> recordDao.deleteMarcIndexersOldVersions(TENANT_ID, 2)));
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleMockTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleMockTest.java
@@ -1,0 +1,107 @@
+package org.folio.verticle;
+
+import io.vertx.core.*;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.dao.RecordDao;
+import org.folio.services.TenantDataProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(VertxUnitRunner.class)
+public class MarcIndexersVersionDeletionVerticleMockTest {
+
+  @Mock
+  private RecordDao recordDao;
+  @Mock
+  private TenantDataProvider tenantDataProvider;
+  private MarcIndexersVersionDeletionVerticle verticle;
+
+  private Vertx vertx;
+  private Promise<Void> promise;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    vertx = mock(Vertx.class);
+    AtomicInteger counter = new AtomicInteger(0);
+    when(vertx.setTimer(anyLong(), any())).thenAnswer(invocation -> {
+      if (counter.getAndIncrement() < 10) {  // Ограничиваем количество вызовов
+        Handler<Long> handler = invocation.getArgument(1);
+        handler.handle(1L);
+      }
+      return 1L;
+    });
+
+    when(tenantDataProvider.getModuleTenants(anyString()))
+      .thenReturn(Future.succeededFuture(Collections.emptyList()));
+
+    verticle = spy(new MarcIndexersVersionDeletionVerticle(recordDao, tenantDataProvider));
+    verticle.init(vertx, mock(Context.class));
+    promise = Promise.promise();
+  }
+
+  @Test
+  public void testStartWithPlannedTimeCallsTimedDeletion() throws IllegalAccessException, NoSuchFieldException {
+
+    // Use reflection to set plannedTime to a non-blank value
+    Field plannedTimeField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("plannedTime");
+    plannedTimeField.setAccessible(true);
+    plannedTimeField.set(verticle, "12:00,15:00");
+
+    Field dirtyBatchSizeField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("dirtyBatchSize");
+    dirtyBatchSizeField.setAccessible(true);
+    dirtyBatchSizeField.set(verticle, 100);
+
+    verticle.start(promise);
+
+    // Verify that setupTimedDeletion is called with the correct parameters
+    verify(verticle).setupTimedDeletion("12:00,15:00", 100);
+    verify(verticle, never()).setupPeriodicDeletion(anyLong(), anyInt());
+  }
+
+  @Test
+  public void testStartWithoutPlannedTimeCallsPeriodicDeletion() throws IllegalAccessException, NoSuchFieldException {
+
+    // Use reflection to set intervalField to a non-blank value
+    Field intervalField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("interval");
+    intervalField.setAccessible(true);
+    intervalField.set(verticle, 1800);
+
+    Field dirtyBatchSizeField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("dirtyBatchSize");
+    dirtyBatchSizeField.setAccessible(true);
+    dirtyBatchSizeField.set(verticle, 100);
+
+    verticle.start(promise);
+
+    // Verify that setupPeriodicDeletion is called with the correct parameters
+    verify(verticle).setupPeriodicDeletion(1800 * 1000L, 100);
+    verify(verticle, never()).setupTimedDeletion(anyString(), anyInt());
+  }
+
+  @Test
+  public void testStartWithInvalidPlannedTimeFallsBackToPeriodicDeletion() throws IllegalAccessException, NoSuchFieldException {
+    // Use reflection to set incorrect value to plannedTime value
+    Field plannedTimeField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("plannedTime");
+    plannedTimeField.setAccessible(true);
+    plannedTimeField.set(verticle, "invalid-time-format");
+
+    Field dirtyBatchSizeField = MarcIndexersVersionDeletionVerticle.class.getDeclaredField("dirtyBatchSize");
+    dirtyBatchSizeField.setAccessible(true);
+    dirtyBatchSizeField.set(verticle, 100);
+
+    verticle.start(promise);
+
+    //Check that setupPeriodicDeletion should be executed
+    verify(verticle).setupPeriodicDeletion(1800 * 1000L, 100);
+    verify(verticle, times(1)).setupTimedDeletion("invalid-time-format", 100);
+  }
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleMockTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleMockTest.java
@@ -34,7 +34,7 @@ public class MarcIndexersVersionDeletionVerticleMockTest {
     vertx = mock(Vertx.class);
     AtomicInteger counter = new AtomicInteger(0);
     when(vertx.setTimer(anyLong(), any())).thenAnswer(invocation -> {
-      if (counter.getAndIncrement() < 10) {  // Ограничиваем количество вызовов
+      if (counter.getAndIncrement() < 10) {
         Handler<Long> handler = invocation.getArgument(1);
         handler.handle(1L);
       }

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleTest.java
@@ -108,7 +108,7 @@ public class MarcIndexersVersionDeletionVerticleTest extends AbstractLBServiceTe
     Future<Boolean> future = recordService.updateRecord(record, okapiHeaders)
       .compose(v -> existOldMarcIndexersVersions())
       .onSuccess(context::assertTrue)
-      .compose(v -> marcIndexersVersionDeletionVerticle.deleteOldMarcIndexerVersions())
+      .compose(v -> marcIndexersVersionDeletionVerticle.deleteOldMarcIndexerVersions(2))
       .compose(deleteRes -> existOldMarcIndexersVersions());
 
     future.onComplete(ar -> {
@@ -126,7 +126,7 @@ public class MarcIndexersVersionDeletionVerticleTest extends AbstractLBServiceTe
     Future<Boolean> future = recordService.updateRecord(record.withState(OLD), okapiHeaders)
       .compose(v -> existMarcIndexersByRecordId(record.getId()))
       .onSuccess(context::assertTrue)
-      .compose(v -> marcIndexersVersionDeletionVerticle.deleteOldMarcIndexerVersions())
+      .compose(v -> marcIndexersVersionDeletionVerticle.deleteOldMarcIndexerVersions(2))
       .compose(deleteRes -> existMarcIndexersByRecordId(record.getId()));
 
     future.onComplete(ar -> {


### PR DESCRIPTION
## Purpose
The first run of the process takes a very long time, and frequent startup puts a heavy load on the processor.

## Approach
- The scheduled start parameter has been added: srs.marcIndexers.delete.plannedTime
- Periodic start parameter: srs.marcIndexers.delete.interval.seconds = 1800
- Added parameter to limit the number of records deleted at a time: srs.marcIndexers.delete.dirtyBatchSize = 100`000
To start a scheduled execution, specify plannedTime like 00:00 or a comma-separated list of values is supported: 01:00,02:30

## Learning
[MODSOURCE-855](https://folio-org.atlassian.net/browse/MODSOURCE-855)
