### PR TITLE
[MODSOURCE-871] Optimize stream marc records id query

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.5.0-SNAPSHOT</version>
+      <version>4.4.1</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -540,7 +540,7 @@ public class RecordDaoImpl implements RecordDao {
     Condition leaderCondition = parseLeaderResult.isEnabled()
       ? condition(parseLeaderResult.getWhereExpression(), parseLeaderResult.getBindingParams().toArray())
       : noCondition();
-    Condition parseFieldCondition = parseLeaderResult.isEnabled()
+    Condition parseFieldCondition = parseFieldsResult.isEnabled()
       ? buildParseFieldCondition(parseFieldsResult)
       : noCondition();
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -561,7 +561,9 @@ public class RecordDaoImpl implements RecordDao {
     int i = 1;
     for (Expression expression : expressions) {
       cteWhereCondition.append(expression.toString());
-      if (i < expressions.size()) cteWhereCondition.append(OR);
+      if (i < expressions.size()) {
+        cteWhereCondition.append(OR);
+      }
       i++;
     }
     return condition(cteWhereCondition.toString(), parseFieldsResult.getBindingParams().toArray());

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/util/RecordDaoUtil.java
@@ -639,20 +639,16 @@ public final class RecordDaoUtil {
   }
 
   /**
-   * Get {@link Condition} to filter by state ACTUAL or DELETED or ACTUAL and leader record status d, s, or x
+   * Get {@link Condition} to filter by state ACTUAL or DELETED
    *
    * @param deleted deleted flag
    * @return condition
    */
   public static Condition filterRecordByDeleted(Boolean deleted) {
-    Condition condition = filterRecordByState(RecordState.ACTUAL.name());
     if (deleted == null) {
-      condition = RECORDS_LB.STATE.in(RecordState.ACTUAL, RecordState.DELETED);
-    } else if (Boolean.TRUE.equals(deleted)) {
-      condition = condition.or(filterRecordByState(RecordState.DELETED.name()))
-        .or(filterRecordByState(RecordState.ACTUAL.name()).and(filterRecordByLeaderRecordStatus(DELETED_LEADER_RECORD_STATUS)));
+      return RECORDS_LB.STATE.in(RecordState.ACTUAL, RecordState.DELETED);
     }
-    return condition;
+    return filterRecordByState(deleted ? RecordState.DELETED.name() : RecordState.ACTUAL.name()) ;
   }
 
   /**

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/changelog.xml
@@ -77,5 +77,6 @@
   <include file="scripts/v-5.10.0/2024-12-10--20-00-create-delete-old-marc-indexers-versions.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.10.0/2025-02-07--15-00-create-composite-records-index.xml" relativeToChangelogFile="true"/>
   <include file="scripts/v-5.10.0/2025-12-03--15-00-create-composite-index-and-update-immutable-to-date-function.xml" relativeToChangelogFile="true"/>
+  <include file="scripts/v-5.10.0/2025-22-04--15-00-update-composite-index-immutable-to-date-with-marc-id.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2025-22-04--15-00-update-composite-index-immutable-to-date-with-marc-id.xml
+++ b/mod-source-record-storage-server/src/main/resources/liquibase/tenant/scripts/v-5.10.0/2025-22-04--15-00-update-composite-index-immutable-to-date-with-marc-id.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+  <changeSet id="2025-22-04--15-00-update-composite-index-immutable-to-date-with-marc-id-and-version" author="Roman_Chernetskyi">
+    <sql>
+      DROP INDEX IF EXISTS idx_marc_indexers_005_field_no_and_immutable_to_date;
+      CREATE INDEX IF NOT EXISTS idx_marc_indexers_005_immutable_to_date_composite ON ${database.defaultSchemaName}.marc_indexers_005 (marc_id, field_no, version, ${database.defaultSchemaName}.immutable_to_date(value));
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -576,7 +576,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withParsedRecord(marcRecord)
       .withMatchedId(FIRST_UUID)
       .withOrder(11)
-      .withState(Record.State.ACTUAL)
+      .withState(Record.State.DELETED)
       .withLeaderRecordStatus("d")
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(SECOND_UUID).withInstanceHrid(SECOND_HRID));
 
@@ -982,7 +982,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(firstSrsId)
       .withLeaderRecordStatus("d")
       .withOrder(11)
-      .withState(Record.State.ACTUAL)
+      .withState(Record.State.DELETED)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(firstInstanceId)
        .withInstanceHrid(firstHrId));
@@ -1019,8 +1019,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD&deleted=false")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(6))
-      .body("totalRecords", is(6))
+      .body("sourceRecords.size()", is(5))
+      .body("totalRecords", is(5))
       .body("sourceRecords*.deleted", everyItem(is(false)));
     async.complete();
 
@@ -1032,8 +1032,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD&deleted=true")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(7))
-      .body("totalRecords", is(7));
+      .body("sourceRecords.size()", is(2))
+      .body("totalRecords", is(2));
     async.complete();
 
     List<String> externalIds = Arrays.stream(records)
@@ -1048,8 +1048,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=INSTANCE&deleted=false")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(6))
-      .body("totalRecords", is(6))
+      .body("sourceRecords.size()", is(5))
+      .body("totalRecords", is(5))
       .body("sourceRecords*.deleted", everyItem(is(false)));
     async.complete();
 
@@ -1061,8 +1061,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=INSTANCE&deleted=true")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(7))
-      .body("totalRecords", is(7));
+      .body("sourceRecords.size()", is(2))
+      .body("totalRecords", is(2));
     async.complete();
 
     async = testContext.async();
@@ -1073,8 +1073,8 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .post(SOURCE_STORAGE_SOURCE_RECORDS_PATH + "?idType=RECORD")
       .then()
       .statusCode(HttpStatus.SC_OK)
-      .body("sourceRecords.size()", is(6))
-      .body("totalRecords", is(6));
+      .body("sourceRecords.size()", is(5))
+      .body("totalRecords", is(5));
     async.complete();
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -1435,7 +1435,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(UUID.randomUUID().toString())
       .withLeaderRecordStatus("d")
       .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(SECOND_UUID).withInstanceHrid(SECOND_HRID))
-      .withState(Record.State.ACTUAL);
+      .withState(Record.State.DELETED);
 
     Record record3 = new Record()
       .withId(UUID.randomUUID().toString())

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1108,46 +1108,6 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
   }
 
   @Test
-  public void shouldReturnIdOnSearchMarcRecordIdsWhenLeaderDeleted(TestContext testContext) {
-    // given
-    postSnapshots(testContext, snapshot_2);
-    Response createParsed = RestAssured.given()
-      .spec(spec)
-      .body(marc_bib_record_2)
-      .when()
-      .post(SOURCE_STORAGE_RECORDS_PATH);
-    assertThat(createParsed.statusCode(), is(HttpStatus.SC_CREATED));
-    Record parsed = createParsed.body().as(Record.class);
-    Async async = testContext.async();
-    RestAssured.given()
-      .spec(spec)
-      .when()
-      .delete(SOURCE_STORAGE_RECORDS_PATH + "/" + parsed.getId())
-      .then()
-      .statusCode(HttpStatus.SC_NO_CONTENT);
-    async.complete();
-    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
-    searchRequest.setLeaderSearchExpression("p_05 = 'd'");
-    searchRequest.setFieldsSearchExpression("005.date to '20250401'");
-    searchRequest.setDeleted(true);
-    // when
-    async = testContext.async();
-    ExtractableResponse<Response> response = RestAssured.given()
-      .spec(spec)
-      .body(searchRequest)
-      .when()
-      .post("/source-storage/stream/marc-record-identifiers")
-      .then()
-      .extract();
-    JsonObject responseBody = new JsonObject(response.body().asString());
-    // then
-    assertEquals(HttpStatus.SC_OK, response.statusCode());
-    assertEquals(1, responseBody.getJsonArray("records").size());
-    assertEquals(1, responseBody.getInteger("totalCount").intValue());
-    async.complete();
-  }
-
-  @Test
   public void shouldReturnEmptyResponseOnSearchMarcRecordIdsWhenRecordWasSuppressed(TestContext testContext) {
     // given
     Async async = testContext.async();

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -1108,6 +1108,46 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
   }
 
   @Test
+  public void shouldReturnIdOnSearchMarcRecordIdsWhenLeaderDeleted(TestContext testContext) {
+    // given
+    postSnapshots(testContext, snapshot_2);
+    Response createParsed = RestAssured.given()
+      .spec(spec)
+      .body(marc_bib_record_2)
+      .when()
+      .post(SOURCE_STORAGE_RECORDS_PATH);
+    assertThat(createParsed.statusCode(), is(HttpStatus.SC_CREATED));
+    Record parsed = createParsed.body().as(Record.class);
+    Async async = testContext.async();
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .delete(SOURCE_STORAGE_RECORDS_PATH + "/" + parsed.getId())
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+    async.complete();
+    MarcRecordSearchRequest searchRequest = new MarcRecordSearchRequest();
+    searchRequest.setLeaderSearchExpression("p_05 = 'd'");
+    searchRequest.setFieldsSearchExpression("005.date to '20250401'");
+    searchRequest.setDeleted(true);
+    // when
+    async = testContext.async();
+    ExtractableResponse<Response> response = RestAssured.given()
+      .spec(spec)
+      .body(searchRequest)
+      .when()
+      .post("/source-storage/stream/marc-record-identifiers")
+      .then()
+      .extract();
+    JsonObject responseBody = new JsonObject(response.body().asString());
+    // then
+    assertEquals(HttpStatus.SC_OK, response.statusCode());
+    assertEquals(1, responseBody.getJsonArray("records").size());
+    assertEquals(1, responseBody.getInteger("totalCount").intValue());
+    async.complete();
+  }
+
+  @Test
   public void shouldReturnEmptyResponseOnSearchMarcRecordIdsWhenRecordWasSuppressed(TestContext testContext) {
     // given
     Async async = testContext.async();


### PR DESCRIPTION
## Purpose
Long-running query causing timeout on [POST] /source-storage/stream/marc-record-identifiers
## Approach
Refactored query: 
- Join marc_records_tracking on version also to get latest versions
- Remove HAVING clause
- Use joins instead of subquery
- Select count from cte
Query example:

> with "filtered_records" as (
  select
    "records_lb"."external_id"
  from
    "records_lb"
    join marc_indexers on "records_lb"."id" = marc_indexers.marc_id
    join "marc_records_tracking" on (
      "marc_records_tracking"."marc_id" = marc_indexers.marc_id
      and "marc_records_tracking"."version" = marc_indexers.version
    )
  where
    (
      (
        (
          "field_no" = '005'
          AND immutable_to_date(value) <= '20250512'
        )
      )
      and (leader_record_status = 'd')
      and "records_lb"."state" in ('ACTUAL', 'DELETED')
      and "records_lb"."record_type" = 'MARC_BIB'
      and "records_lb"."external_id" is not null
    )
  group by
    "records_lb"."external_id"
)
select
  "alias_79170529"."external_id",
  "alias_16380299".count
from
  (
    select
      "external_id"
    from
      filtered_records
  ) "alias_79170529"
  right outer join (
    select
      count(distinct "external_id")
    from
      filtered_records
  ) "alias_16380299" on true

#### Jira
https://folio-org.atlassian.net/browse/MODSOURCE-871
https://folio-org.atlassian.net/browse/MODSOURCE-878
