### PR TITLE
MODSOURCE-914: Update marc4j for 2.9.6 version

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -466,7 +466,7 @@
       <plugin>
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.13.1</version>
+        <version>1.14.1</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>org.marc4j</groupId>
       <artifactId>marc4j</artifactId>
-      <version>2.9.2</version>
+      <version>2.9.6</version>
     </dependency>
     <dependency>
       <groupId>io.xlate</groupId>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -236,7 +236,7 @@
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jooq.version>3.16.19</jooq.version>
     <vertx-jooq.version>6.5.5</vertx-jooq.version>
-    <aspectj.version>1.9.19</aspectj.version>
+    <aspectj.version>1.9.21</aspectj.version>
     <postgres.version>42.7.2</postgres.version>
     <postgres.image>postgres:16-alpine</postgres.image>
     <lombok.version>1.18.38</lombok.version>
@@ -470,7 +470,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <release>17</release>
+          <release>21</release>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
           <forceAjcCompile>true</forceAjcCompile>

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -145,7 +145,8 @@ public final class AdditionalFieldsUtil {
     boolean result = false;
     try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
       if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
-        var sourceParsedRecordString = record.getParsedRecord().getContent().toString();
+        //var sourceParsedRecordString = record.getParsedRecord().getContent().toString();
+        var sourceParsedRecordString = new JsonObject(Json.encode(record.getParsedRecord().getContent())).encode();
         MarcWriter streamWriter = new MarcStreamWriter(new ByteArrayOutputStream());
         MarcJsonWriter jsonWriter = new MarcJsonWriter(os);
         MarcFactory factory = MarcFactory.newInstance();
@@ -734,7 +735,7 @@ public final class AdditionalFieldsUtil {
    * Checks whether field 005 needs to be updated or this field is protected.
    *
    * @param record            record to check
-   * @param mappingParameters
+   * @param mappingParameters mapping parameters
    * @return true for case when field 005 have to updated
    */
   private static boolean isField005NeedToUpdate(Record record, MappingParameters mappingParameters) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -145,8 +145,11 @@ public final class AdditionalFieldsUtil {
     boolean result = false;
     try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
       if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
-        //var sourceParsedRecordString = record.getParsedRecord().getContent().toString();
-        var sourceParsedRecordString = new JsonObject(Json.encode(record.getParsedRecord().getContent())).encode();
+
+        String sourceParsedRecordString = record.getParsedRecord().getContent() instanceof String
+          ? (String) record.getParsedRecord().getContent()
+          : Json.encode(record.getParsedRecord().getContent());
+
         MarcWriter streamWriter = new MarcStreamWriter(new ByteArrayOutputStream());
         MarcJsonWriter jsonWriter = new MarcJsonWriter(os);
         MarcFactory factory = MarcFactory.newInstance();

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/AdditionalFieldsUtil.java
@@ -146,8 +146,8 @@ public final class AdditionalFieldsUtil {
     try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
       if (record != null && record.getParsedRecord() != null && record.getParsedRecord().getContent() != null) {
 
-        String sourceParsedRecordString = record.getParsedRecord().getContent() instanceof String
-          ? (String) record.getParsedRecord().getContent()
+        String sourceParsedRecordString = record.getParsedRecord().getContent() instanceof String contentStr
+          ? contentStr
           : Json.encode(record.getParsedRecord().getContent());
 
         MarcWriter streamWriter = new MarcStreamWriter(new ByteArrayOutputStream());

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.text.RandomStringGenerator;
 import org.apache.http.HttpStatus;
 import org.folio.dao.util.ParsedRecordDaoUtil;

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordApiTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.io.IOException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,7 +22,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.commons.text.RandomStringGenerator;
 import org.apache.http.HttpStatus;
 import org.folio.dao.util.ParsedRecordDaoUtil;
 import org.junit.Assert;
@@ -56,13 +54,7 @@ public class RecordApiTest extends AbstractRestVerticleTest {
   private static final String SEVENTH_UUID = UUID.randomUUID().toString();
   private static final String EIGHTH_UUID = UUID.randomUUID().toString();
 
-  private static final SecureRandom secureRandom = new SecureRandom();
-  private static final RandomStringGenerator generator = new RandomStringGenerator.Builder()
-    .withinRange('0', 'z')
-            .filteredBy(Character::isLetterOrDigit)
-            .usingRandom(secureRandom::nextInt)
-            .build();
-  private static final String FIRST_HRID = generator.generate(9);
+  private static final String FIRST_HRID = "hrid00010";
   private static final String GENERATION = "generation";
 
   private static RawRecord rawMarcRecord;

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.TestUtil;
 import org.folio.dao.PostgresClientFactory;
@@ -36,6 +35,8 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class RecordsGenerationTest extends AbstractRestVerticleTest {
 
+  private final static String HR_ID01 = "hrid00001";
+  private final static String HR_ID02 = "hrid00002";
   private static RawRecord rawRecord;
   private static ParsedRecord marcRecord;
 
@@ -100,7 +101,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
         .withMatchedId(matchedId)
         .withExternalIdsHolder(new ExternalIdsHolder()
           .withInstanceId(UUID.randomUUID().toString())
-          .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+          .withInstanceHrid("hrid00001"));
 
       Record created = RestAssured.given()
         .spec(spec)
@@ -157,7 +158,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withGeneration(5)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid(HR_ID01));
 
     Record created = RestAssured.given()
       .spec(spec)
@@ -199,7 +200,8 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
 
     ExternalIdsHolder externalIdsHolder = new ExternalIdsHolder()
       .withInstanceId(UUID.randomUUID().toString())
-      .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9));
+      .withInstanceHrid(HR_ID01);
+
     Record record1 = new Record()
       .withId(matchedId)
       .withSnapshotId(snapshot_1.getJobExecutionId())
@@ -289,7 +291,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withMatchedId(matchedId)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid(HR_ID01));
 
     RestAssured.given()
       .spec(spec)
@@ -309,7 +311,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withMatchedId(matchedId)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid(HR_ID02));
 
     RestAssured.given()
       .spec(spec)
@@ -389,7 +391,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
     ParsedRecord parsedRecord = new ParsedRecord().withId(srsId)
       .withContent(new JsonObject().put("leader", "01542ccm a2200361   4500")
         .put("fields", new JsonArray()
-          .add(new JsonObject().put("001", RandomStringUtils.randomAlphanumeric(9)))
+          .add(new JsonObject().put("001", HR_ID01))
           .add(new JsonObject().put("999", new JsonObject()
           .put("subfields",
             new JsonArray().add(new JsonObject().put("s", srsId)))
@@ -405,7 +407,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withMatchedId(srsId)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid(HR_ID02));
 
     RestAssured.given()
       .spec(spec)
@@ -456,7 +458,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
     ParsedRecord parsedRecord = new ParsedRecord().withId(srsId)
       .withContent(new JsonObject().put("leader", "01542ccm a2200361   4500")
         .put("fields", new JsonArray()
-          .add(new JsonObject().put("001", RandomStringUtils.randomAlphanumeric(9)))
+          .add(new JsonObject().put("001", HR_ID01))
           .add(new JsonObject().put("999", new JsonObject()
             .put("ind1", "f")
             .put("ind2", "f")
@@ -473,7 +475,7 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
       .withMatchedId(matchedId)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(instanceId)
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid(HR_ID02));
 
     RestAssured.given()
       .spec(spec)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsGenerationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -459,7 +458,11 @@ public class RecordsGenerationTest extends AbstractRestVerticleTest {
         .put("fields", new JsonArray()
           .add(new JsonObject().put("001", RandomStringUtils.randomAlphanumeric(9)))
           .add(new JsonObject().put("999", new JsonObject()
-          .put("subfields", new JsonArray().add(new JsonObject().put("s", srsId)).add(new JsonObject().put("i", instanceId)))))));
+            .put("ind1", "f")
+            .put("ind2", "f")
+          .put("subfields", new JsonArray()
+            .add(new JsonObject().put("s", srsId))
+            .add(new JsonObject().put("i", instanceId)))))));
 
     Record newRecord = new Record()
       .withId(srsId)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/RecordsMatchingApiTest.java
@@ -5,7 +5,6 @@ import io.restassured.response.Response;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.TestUtil;
 import org.folio.dao.PostgresClientFactory;
@@ -60,6 +59,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
   private static final String FIELD_007 = "12569";
   private static final String FIELD_035 = "12345";
   private static final int SPLIT_INDEX = 2;
+  private static final String HR_ID = "hrId12345";
 
   private static String rawRecordContent;
   private static String parsedRecordContent;
@@ -275,7 +275,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(new RawRecord().withId(recordId).withContent(rawRecordContent))
       .withParsedRecord(new ParsedRecord().withId(recordId).withContent(parsedRecordContent))
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(HR_ID));
 
     postRecords(context, record);
 
@@ -656,7 +656,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
         .withRecordType(MARC_BIB)
         .withRawRecord(new RawRecord().withId(recordId).withContent(rawRecordContent))
         .withParsedRecord(new ParsedRecord().withId(recordId).withContent(parsedRecordContent))
-        .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(HR_ID));
 
       postRecords(context, record);
     }
@@ -851,7 +851,7 @@ public class RecordsMatchingApiTest extends AbstractRestVerticleTest {
         .withRecordType(MARC_BIB)
         .withRawRecord(new RawRecord().withId(recordId).withContent(rawRecordContent))
         .withParsedRecord(new ParsedRecord().withId(recordId).withContent(parsedRecordContent))
-        .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(HR_ID));
 
       postRecords(context, record);
     }

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SnapshotApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SnapshotApiTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -297,7 +296,7 @@ public class SnapshotApiTest extends AbstractRestVerticleTest {
 
     String recordId = UUID.randomUUID().toString();
     var marcRecordWith001 = new ParsedRecord()
-      .withContent(new JsonObject().put("fields", new JsonArray().add(new JsonObject().put("001", RandomStringUtils.randomAlphanumeric(9)))).encode());
+      .withContent(new JsonObject().put("fields", new JsonArray().add(new JsonObject().put("001", "id000100"))).encode());
     Record record = new Record()
       .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(rawRecord)
@@ -309,7 +308,7 @@ public class SnapshotApiTest extends AbstractRestVerticleTest {
       record.withId(id).withMatchedId(id)
         .withExternalIdsHolder(new ExternalIdsHolder()
           .withInstanceId(UUID.randomUUID().toString())
-          .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+          .withInstanceHrid("hrid00100"));
       RestAssured.given()
         .spec(spec)
         .body(record)

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceRecordApiTest.java
@@ -26,7 +26,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,9 +58,9 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
   private static final String SEVENTH_UUID = UUID.randomUUID().toString();
   private static final String EIGHTH_UUID = UUID.randomUUID().toString();
   private static final String NINTH_UUID = UUID.randomUUID().toString();
-  private static final String FIRST_HRID = RandomStringUtils.randomAlphanumeric(9);
-  private static final String SECOND_HRID = RandomStringUtils.randomAlphanumeric(9);
-  private static final String THIRD_HRID = RandomStringUtils.randomAlphanumeric(9);
+  private static final String FIRST_HRID = "hridFirst";
+  private static final String SECOND_HRID = "hridSecond";
+  private static final String THIRD_HRID = "hridThird";
 
   private static final RawRecord rawRecord;
   private static final ParsedRecord marcRecord;
@@ -465,7 +464,6 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body().as(Record.class);
 
     String instanceId = UUID.randomUUID().toString();
-    String hrId = RandomStringUtils.randomAlphanumeric(9);
 
     Record record = new Record().withId(THIRD_UUID)
       .withSnapshotId(snapshot_2.getJobExecutionId())
@@ -475,7 +473,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(THIRD_UUID)
       .withOrder(11)
       .withState(Record.State.ACTUAL)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid(hrId));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid("hrid12345"));
 
     RestAssured.given()
       .spec(spec)
@@ -535,7 +533,6 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body().as(Record.class);
 
     String instanceId = UUID.randomUUID().toString();
-    String hrId = RandomStringUtils.randomAlphanumeric(9);
 
     Record record = new Record().withId(THIRD_UUID)
       .withSnapshotId(snapshot_2.getJobExecutionId())
@@ -545,7 +542,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(THIRD_UUID)
       .withOrder(11)
       .withState(Record.State.ACTUAL)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid(hrId));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid("hrid12345"));
 
     RestAssured.given()
       .spec(spec)
@@ -859,7 +856,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body("sourceRecords*.deleted", everyItem(is(false)))
       .extract().response().body().as(SourceRecordCollection.class).getSourceRecords();
 
-    testContext.assertEquals(0, sourceRecordList.get(0).getOrder());
+    testContext.assertEquals(0, sourceRecordList.getFirst().getOrder());
     async.complete();
   }
 
@@ -963,7 +960,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
 
     String firstSrsId = UUID.randomUUID().toString();
     String firstInstanceId = UUID.randomUUID().toString();
-    String firstHrId = RandomStringUtils.randomAlphanumeric(9);
+    String firstHrId = "hridFirst";
 
     ParsedRecord parsedRecord = new ParsedRecord().withId(firstSrsId)
       .withContent(new JsonObject().put("leader", "01542dcm a2200361   4500")
@@ -989,7 +986,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
 
     String secondSrsId = UUID.randomUUID().toString();
     String secondInstanceId = UUID.randomUUID().toString();
-    String secondHrId = RandomStringUtils.randomAlphanumeric(9);
+    String secondHrId = "hridSecond";
 
     Record deleted_record_2 = new Record()
       .withId(secondSrsId)
@@ -1402,7 +1399,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
     assertThat(getResponse.statusCode(), is(HttpStatus.SC_OK));
     SourceRecordCollection sourceRecordCollection = getResponse.body().as(SourceRecordCollection.class);
     assertThat(sourceRecordCollection.getSourceRecords().size(), is(1));
-    SourceRecord sourceRecord = sourceRecordCollection.getSourceRecords().get(0);
+    SourceRecord sourceRecord = sourceRecordCollection.getSourceRecords().getFirst();
     assertThat(sourceRecord.getRecordId(), is(createdRecord.getId()));
     // NOTE: raw record is no longer returned with source records for effeciency
     // assertThat(sourceRecord.getRawRecord().getContent(), is(rawRecord.getContent()));
@@ -1589,7 +1586,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body().as(Record.class);
 
     String externalId = UUID.randomUUID().toString();
-    String externalHrId = RandomStringUtils.randomAlphanumeric(9);
+    String externalHrId = "hridExternal";
 
     Record recordWithOldState = new Record().withId(FOURTH_UUID)
       .withSnapshotId(snapshot.getJobExecutionId())
@@ -1828,7 +1825,6 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body().as(Record.class);
 
     String instanceId = UUID.randomUUID().toString();
-    String hrId = RandomStringUtils.randomAlphanumeric(9);
 
     Record record = new Record().withId(THIRD_UUID)
       .withSnapshotId(snapshot.getJobExecutionId())
@@ -1838,7 +1834,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .withMatchedId(THIRD_UUID)
       .withOrder(11)
       .withState(Record.State.ACTUAL);
-    setExternalIds(record, recordType, instanceId, hrId);
+    setExternalIds(record, recordType, instanceId, "hridExternal");
 
     RestAssured.given()
       .spec(spec)
@@ -1967,7 +1963,7 @@ public class SourceRecordApiTest extends AbstractRestVerticleTest {
       .body("sourceRecords*.deleted", everyItem(is(false)))
       .extract().response().body().as(SourceRecordCollection.class).getSourceRecords();
 
-    testContext.assertEquals(0, sourceRecordList.get(0).getOrder());
+    testContext.assertEquals(0, sourceRecordList.getFirst().getOrder());
     async.complete();
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageBatchApiTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.TestMocks;
 import org.folio.TestUtil;
@@ -73,7 +72,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
   private static final String FIFTH_UUID = UUID.randomUUID().toString();
   private static final String VALID_HRID = "12345";
   private static final String MARC_RECORD_HRID = "393893";
-  private static final String HRID = RandomStringUtils.randomAlphanumeric(9);
+  private static final String HRID = "hrid00020";
 
   private static RawRecord rawRecord;
   private static ParsedRecord marcRecord;
@@ -906,7 +905,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_CREATED)
       .extract().response().body().as(RecordsBatchResponse.class);
 
-    Record createdRecord = createdRecordCollection.getRecords().get(0);
+    Record createdRecord = createdRecordCollection.getRecords().getFirst();
     assertThat(createdRecord.getId(), notNullValue());
     assertThat(createdRecord.getSnapshotId(), is(record_2.getSnapshotId()));
     assertThat(createdRecord.getRecordType(), is(record_2.getRecordType()));
@@ -1044,7 +1043,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .extract().response().body().as(ParsedRecordsBatchResponse.class);
 
-    ParsedRecord updatedParsedRecord = updatedParsedRecordCollection.getParsedRecords().get(0);
+    ParsedRecord updatedParsedRecord = updatedParsedRecordCollection.getParsedRecords().getFirst();
     assertThat(updatedParsedRecord.getId(), notNullValue());
 
     assertThat(JsonObject.mapFrom(updatedParsedRecord).encode(), containsString("\"leader\":\"01542ccm a2200361   4500\""));
@@ -1141,7 +1140,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .extract().response().body().as(ParsedRecordsBatchResponse.class);
 
-    ParsedRecord updatedParsedRecord = updatedParsedRecordCollection.getParsedRecords().get(0);
+    ParsedRecord updatedParsedRecord = updatedParsedRecordCollection.getParsedRecords().getFirst();
     assertThat(updatedParsedRecord.getId(), notNullValue());
 
     assertThat(JsonObject.mapFrom(updatedParsedRecord).encode(), containsString("\"leader\":\"01542ccm a2200361   4500\""));
@@ -1308,9 +1307,7 @@ public class SourceStorageBatchApiTest extends AbstractRestVerticleTest {
   @Test
   public void shouldReturnIdsWhenQueryParamListNotExceedMaxSize(TestContext testContext) {
     String [] ids = new String[32767];
-    for (int i = 0; i < ids.length; i++) {
-      ids[i]= "invalidId";
-    }
+    Arrays.fill(ids, "invalidId");
     searchMarcBibIdsByMatcher(testContext, Arrays.asList(ids), contains("invalidId"));
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/rest/impl/SourceStorageStreamApiTest.java
@@ -12,7 +12,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.folio.TestUtil;
 import org.folio.dao.PostgresClientFactory;
@@ -64,7 +63,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
   private static final String SIXTH_UUID = UUID.randomUUID().toString();
   private static final String SEVENTH_UUID = UUID.randomUUID().toString();
   private static final String EIGHTH_UUID = UUID.randomUUID().toString();
-  private static final String FIRST_HRID = RandomStringUtils.randomAlphanumeric(9);
+  private static final String FIRST_HRID = "id1234567";
 
   private static RawRecord rawRecord;
   private static ParsedRecord marcRecord;
@@ -210,7 +209,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(0, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -248,7 +247,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(4, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -295,7 +294,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(2, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
       .subscribe();
   }
 
@@ -337,7 +336,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         testContext.assertEquals(false, actual.get(1).getAdditionalInfo().getSuppressDiscovery());
         testContext.assertEquals(false, actual.get(1).getAdditionalInfo().getSuppressDiscovery());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -380,10 +379,10 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .map(r -> Json.decodeValue(r, Record.class))
       .doFinally(() -> {
         testContext.assertEquals(1, actual.size());
-        testContext.assertEquals(marc_holdings_record_1.getSnapshotId(), actual.get(0).getSnapshotId());
-        testContext.assertEquals(false, actual.get(0).getAdditionalInfo().getSuppressDiscovery());
+        testContext.assertEquals(marc_holdings_record_1.getSnapshotId(), actual.getFirst().getSnapshotId());
+        testContext.assertEquals(false, actual.getFirst().getAdditionalInfo().getSuppressDiscovery());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
       .subscribe();
   }
 
@@ -421,7 +420,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(2, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -523,7 +522,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         testContext.assertEquals(secondHrid, actual.get(0).getExternalIdsHolder().getInstanceHrid());
         testContext.assertEquals(secondHrid, actual.get(1).getExternalIdsHolder().getInstanceHrid());
         finalAsync.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -556,9 +555,9 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .map(r -> Json.decodeValue(r, SourceRecord.class))
       .doFinally(() -> {
         testContext.assertEquals(1, actual.size());
-        testContext.assertTrue(Objects.nonNull(actual.get(0).getParsedRecord()));
+        testContext.assertTrue(Objects.nonNull(actual.getFirst().getParsedRecord()));
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -590,7 +589,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(0, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -615,7 +614,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(0, actual.size());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -656,7 +655,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
       .doFinally(() -> {
         testContext.assertEquals(0, actual.size());
         finalAsync.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -746,7 +745,7 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         testContext.assertTrue(actual.get(1).getMetadata().getCreatedDate().after(actual.get(2).getMetadata().getCreatedDate()));
         testContext.assertTrue(actual.get(2).getMetadata().getCreatedDate().after(actual.get(3).getMetadata().getCreatedDate()));
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -774,10 +773,10 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
         testContext.assertTrue(Objects.nonNull(actual.get(1).getParsedRecord()));
         testContext.assertEquals(false, actual.get(0).getDeleted());
         testContext.assertEquals(false, actual.get(1).getDeleted());
-        testContext.assertEquals(11, actual.get(0).getOrder().intValue());
-        testContext.assertEquals(101, actual.get(1).getOrder().intValue());
+        testContext.assertEquals(11, actual.get(0).getOrder());
+        testContext.assertEquals(101, actual.get(1).getOrder());
         async.complete();
-      }).collect(() -> actual, (a, r) -> a.add(r))
+      }).collect(() -> actual, List::add)
         .subscribe();
   }
 
@@ -876,9 +875,9 @@ public class SourceStorageStreamApiTest extends AbstractRestVerticleTest {
           .doFinally(() -> {
             testContext.assertEquals(0, actual.size());
             finalAsync.complete();
-          }).collect(() -> actual, (a, r) -> a.add(r))
+          }).collect(() -> actual, List::add)
             .subscribe();
-      }).collect(() -> sourceRecordList, (a, r) -> a.add(r))
+      }).collect(() -> sourceRecordList, List::add)
         .subscribe();
   }
 

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityUpdateModifyEventHandlerTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.JobProfile;
@@ -186,7 +185,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       .withParsedRecord(parsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid("hrid00123"));
 
     ReactiveClassicGenericQueryExecutor queryExecutor = postgresClientFactory.getQueryExecutor(TENANT_ID);
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
@@ -217,7 +216,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(mappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -231,7 +230,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -259,7 +258,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -276,7 +275,7 @@ public class MarcAuthorityUpdateModifyEventHandlerTest extends AbstractLBService
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     boolean isEligible = modifyRecordEventHandler.isEligible(dataImportEventPayload);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.ActionProfile;
 import org.folio.DataImportEventPayload;
 import org.folio.InstanceLinkDtoCollection;
@@ -275,7 +274,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid("hrid00001"))
       .withMetadata(new Metadata());
 
     Record record_2 = new Record()
@@ -286,7 +285,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid("hrid00002"))
       .withMetadata(new Metadata());
 
     ReactiveClassicGenericQueryExecutor queryExecutorLocalTenant = postgresClientFactory.getQueryExecutor(TENANT_ID);
@@ -342,7 +341,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContext.put("CENTRAL_TENANT_ID", CENTRAL_TENANT_ID);
 
     mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(mappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -356,7 +355,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst())
       .withAdditionalProperty(USER_ID_HEADER, userId);
 
     // when
@@ -410,7 +409,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(mappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -424,7 +423,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -465,7 +464,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     updateMappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(updateMappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -479,7 +478,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -519,7 +518,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     updateMappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(updateMappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -533,7 +532,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -561,7 +560,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -607,7 +606,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     boolean isEligible = modifyRecordEventHandler.isEligible(dataImportEventPayload);
@@ -710,7 +709,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(secondRawRecord)
       .withParsedRecord(secondParsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid("hridSecond"))
       .withMetadata(new Metadata());
 
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
@@ -736,7 +735,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
               .withIndicator2("*")
               .withSubfields(
                 List.of(new MarcSubfield().withSubfield("e"), new MarcSubfield().withSubfield("0"))))));
-        profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+        profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
           .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
             .withProfileId(updateMappingProfile.getId())
             .withContentType(MAPPING_PROFILE)
@@ -750,7 +749,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
           .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
           .withContext(payloadContext)
           .withProfileSnapshot(profileSnapshotWrapper)
-          .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+          .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
         modifyRecordEventHandler.handle(dataImportEventPayload)
           .whenComplete((eventPayload, throwable) -> {
             context.assertNotNull(throwable);
@@ -787,7 +786,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     payloadContextDuplicateRecord.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(mappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -801,7 +800,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContextOriginalRecord)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     DataImportEventPayload dataImportEventPayloadDuplicateRecord = new DataImportEventPayload()
       .withTenant(TENANT_ID)
@@ -811,7 +810,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContextDuplicateRecord)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future1 = modifyRecordEventHandler.handle(dataImportEventPayloadOriginalRecord);
@@ -888,7 +887,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .withRecordType(MARC_BIB)
       .withRawRecord(secondRawRecord)
       .withParsedRecord(secondParsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid("hridSecond"))
       .withMetadata(new Metadata());
 
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
@@ -899,7 +898,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
       .onSuccess(result -> {
         Record incomingRecord = new Record().withId(secondRecord.getId())
           .withParsedRecord(new ParsedRecord().withContent(incomingParsedContent))
-          .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+          .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(instanceId).withInstanceHrid("hridIncomong"));
         secondRecord.getParsedRecord().setContent(Json.encode(secondRecord.getParsedRecord().getContent()));
         HashMap<String, String> payloadContext = new HashMap<>();
         payloadContext.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(incomingRecord));
@@ -907,7 +906,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
 
         updateMappingProfile.getMappingDetails().withMarcMappingOption(UPDATE)
           .withMarcMappingDetails(emptyList());
-        profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+        profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
           .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
             .withProfileId(updateMappingProfile.getId())
             .withContentType(MAPPING_PROFILE)
@@ -922,7 +921,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
             .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
             .withContext(payloadContext)
             .withProfileSnapshot(profileSnapshotWrapper)
-            .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+            .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
         modifyRecordEventHandler.handle(dataImportEventPayload)
           .whenComplete((eventPayload, throwable) -> {
             var actualRecord = Json.decodeValue(dataImportEventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()), Record.class);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcHoldingsUpdateModifyEventHandlerTest.java
@@ -70,7 +70,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 @RunWith(VertxUnitRunner.class)
 public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
@@ -184,7 +183,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       .withRecordType(MARC_BIB)
       .withRawRecord(rawRecord)
       .withParsedRecord(parsedRecord)
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid("hrid00001"));
 
     ReactiveClassicGenericQueryExecutor queryExecutor = postgresClientFactory.getQueryExecutor(TENANT_ID);
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
@@ -215,7 +214,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
     payloadContext.put(MATCHED_MARC_BIB_KEY, Json.encode(record));
 
     mappingProfile.getMappingDetails().withMarcMappingOption(UPDATE);
-    profileSnapshotWrapper.getChildSnapshotWrappers().get(0)
+    profileSnapshotWrapper.getChildSnapshotWrappers().getFirst()
       .withChildSnapshotWrappers(Collections.singletonList(new ProfileSnapshotWrapper()
         .withProfileId(mappingProfile.getId())
         .withContentType(MAPPING_PROFILE)
@@ -229,7 +228,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(payloadContext)
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -257,7 +256,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
@@ -274,7 +273,7 @@ public class MarcHoldingsUpdateModifyEventHandlerTest extends AbstractLBServiceT
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withContext(new HashMap<>())
       .withProfileSnapshot(profileSnapshotWrapper)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     boolean isEligible = modifyRecordEventHandler.isEligible(dataImportEventPayload);

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/QuickMarcKafkaHandlerTest.java
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.TestUtil;
 import org.folio.dao.RecordDao;
 import org.folio.dao.RecordDaoImpl;
@@ -95,7 +94,7 @@ public class QuickMarcKafkaHandlerTest extends AbstractLBServiceTest {
       .withParsedRecord(parsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid("hrid00001"));
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
     SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)
       .compose(savedSnapshot -> recordService.saveRecord(record, okapiHeaders))

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/MarcIndexersVersionDeletionVerticleTest.java
@@ -15,7 +15,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.TestMocks;
 import org.folio.dao.RecordDao;
 import org.folio.dao.RecordDaoImpl;
@@ -74,7 +73,7 @@ public class MarcIndexersVersionDeletionVerticleTest extends AbstractLBServiceTe
       .withRecordType(Record.RecordType.MARC_BIB)
       .withRawRecord(TestMocks.getRecord(0).getRawRecord().withId(recordId))
       .withParsedRecord(TestMocks.getRecord(0).getParsedRecord().withId(recordId))
-      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(UUID.randomUUID().toString()).withInstanceHrid("hrid00001"));
 
     var okapiHeaders = Map.of(OKAPI_TENANT_HEADER, TENANT_ID);
     SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), snapshot)

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/DataImportConsumersVerticleTest.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.ActionProfile;
 import org.folio.JobProfile;
 import org.folio.MappingProfile;
@@ -152,7 +151,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .withParsedRecord(parsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid("hrid00001"));
 
     incorrectRecord = new Record()
       .withId(incorrectRecordId)
@@ -164,7 +163,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .withParsedRecord(incorrectParsedRecord)
       .withExternalIdsHolder(new ExternalIdsHolder()
         .withInstanceId(UUID.randomUUID().toString())
-        .withInstanceHrid(RandomStringUtils.randomAlphanumeric(9)));
+        .withInstanceHrid("incorrectHrid"));
 
     ReactiveClassicGenericQueryExecutor queryExecutor = postgresClientFactory.getQueryExecutor(TENANT_ID);
     RecordDaoImpl recordDao = new RecordDaoImpl(postgresClientFactory, recordDomainEventPublisher);
@@ -226,7 +225,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withJobExecutionId(snapshotForRecordUpdate.getJobExecutionId())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst())
       .withOkapiUrl(mockServer.baseUrl())
       .withTenant(TENANT_ID)
       .withToken(TOKEN)
@@ -302,7 +301,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
     DataImportEventPayload eventPayload = new DataImportEventPayload()
       .withEventType(DI_SRS_MARC_BIB_RECORD_CREATED.value())
       .withJobExecutionId(snapshotForRecordUpdate.getJobExecutionId())
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0))
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst())
       .withOkapiUrl(mockServer.baseUrl())
       .withTenant(TENANT_ID)
       .withToken(TOKEN)
@@ -359,7 +358,7 @@ public class DataImportConsumersVerticleTest extends AbstractLBServiceTest {
       .withTenant(TENANT_ID)
       .withToken(TOKEN)
       .withJobExecutionId(snapshotId)
-      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
+      .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().getFirst());
 
     // when
     send(DI_MARC_FOR_DELETE_RECEIVED, eventPayload);


### PR DESCRIPTION
## Purpose
Version 2.9.6 deserializes NULL values in JSON to “\u0000”.

## Approach
Fix tests: a few cases do not initialize the mandatory fields.

## Learning
[MODSOURCE-914](https://folio-org.atlassian.net/browse/MODSOURCE-914)
