### PR TITLE
MODSOURCE-914: Update aspectj-maven-plugin to version 1.14.1 and add support for java 21

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -236,7 +236,7 @@
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jooq.version>3.16.19</jooq.version>
     <vertx-jooq.version>6.5.5</vertx-jooq.version>
-    <aspectj.version>1.9.19</aspectj.version>
+    <aspectj.version>1.9.21</aspectj.version>
     <postgres.version>42.7.2</postgres.version>
     <postgres.image>postgres:16-alpine</postgres.image>
     <lombok.version>1.18.38</lombok.version>
@@ -466,11 +466,11 @@
       <plugin>
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.13.1</version>
+        <version>1.14.1</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <release>17</release>
+          <release>21</release>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
           <forceAjcCompile>true</forceAjcCompile>


### PR DESCRIPTION
## Purpose
[ERROR] Failed to execute goal dev.aspectj:aspectj-maven-plugin:1.14.1:compile (default) on project mod-source-record-storage-server: AJC compiler errors

## Approach
bump aspectj-maven-plugin version to 1.14.1 and aspectj.version to 1.9.21

## Learning
[MODSOURCE-915](https://folio-org.atlassian.net/browse/MODSOURCE-915)
