### PR TITLE
MODSOURCE-917 - Rename permission for suppress from discovery endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -134,7 +134,7 @@
           ],
           "pathPattern": "/source-storage/records/{id}/suppress-from-discovery",
           "permissionsRequired": [
-            "source-storage.records.update"
+            "source-storage.records.suppress-discovery.item.put"
           ]
         },
         {
@@ -399,9 +399,10 @@
       "replaces": ["source-storage.records.get"]
     },
     {
-      "permissionName": "source-storage.records.update",
-      "displayName": "Source Storage - update record",
-      "description": "Update Record's fields"
+      "permissionName": "source-storage.records.suppress-discovery.item.put",
+      "displayName": "Source Storage - update record's suppress from discovery field",
+      "description": "Update record's suppress from discovery field",
+      "replaces": ["source-storage.records.update"]
     },
     {
       "permissionName": "source-storage.records.delete",


### PR DESCRIPTION
## Purpose
to ensure work of the endpoint that manages record suppression from discovery in Eureka-based environment when it's called by user directly


## Approach
* rename the enpoint permission for proper capability creation


## Learning
[MODSOURCE-917](https://issues.folio.org/browse/MODSOURCE-917)