### PR TITLE
MODSOURCE-919 - Ability to restrict record update action in member tenant to local record only

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.4.3</version>
+      <version>4.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/DataImportKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/DataImportKafkaHandler.java
@@ -31,6 +31,7 @@ import static org.apache.logging.log4j.Level.DEBUG;
 import static org.apache.logging.log4j.Level.ERROR;
 import static org.apache.logging.log4j.Level.INFO;
 import static org.folio.DataImportEventTypes.DI_ERROR;
+import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
 import static org.folio.services.util.KafkaUtil.extractHeaderValue;
 
 @Component
@@ -41,8 +42,8 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
   private static final String LOG_MESSAGE_TEMPLATE = "%s for jobExecutionId: '%s' and recordId: '%s' and chunkId: '%s' and userId: '%s'";
 
   public static final String PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
-  private static final String RECORD_ID_HEADER = "recordId";
-  private static final String CHUNK_ID_HEADER = "chunkId";
+  static final String RECORD_ID_HEADER = "recordId";
+  static final String CHUNK_ID_HEADER = "chunkId";
   static final String USER_ID_HEADER = "userId";
 
   private Vertx vertx;
@@ -100,6 +101,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
     String recordId = extractHeaderValue(RECORD_ID_HEADER, targetRecord.headers());
     String chunkId = extractHeaderValue(CHUNK_ID_HEADER, targetRecord.headers());
     String userId = extractHeaderValue(USER_ID_HEADER, targetRecord.headers());
+    String permissions = extractHeaderValue(PERMISSIONS, targetRecord.headers());
     try {
       Promise<String> promise = Promise.promise();
       Event event = DatabindCodec.mapper().readValue(targetRecord.value(), Event.class);
@@ -111,6 +113,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
       eventPayload.getContext().put(RECORD_ID_HEADER, recordId);
       eventPayload.getContext().put(CHUNK_ID_HEADER, chunkId);
       eventPayload.getContext().put(USER_ID_HEADER, userId);
+      eventPayload.getContext().put(PERMISSIONS, permissions);
 
       OkapiConnectionParams params = RestUtil.retrieveOkapiConnectionParams(eventPayload, vertx);
       String jobProfileSnapshotId = eventPayload.getContext().get(PROFILE_SNAPSHOT_ID_KEY);

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/DataImportKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/DataImportKafkaHandler.java
@@ -101,7 +101,6 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
     String recordId = extractHeaderValue(RECORD_ID_HEADER, targetRecord.headers());
     String chunkId = extractHeaderValue(CHUNK_ID_HEADER, targetRecord.headers());
     String userId = extractHeaderValue(USER_ID_HEADER, targetRecord.headers());
-    String permissions = extractHeaderValue(PERMISSIONS, targetRecord.headers());
     try {
       Promise<String> promise = Promise.promise();
       Event event = DatabindCodec.mapper().readValue(targetRecord.value(), Event.class);
@@ -113,7 +112,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
       eventPayload.getContext().put(RECORD_ID_HEADER, recordId);
       eventPayload.getContext().put(CHUNK_ID_HEADER, chunkId);
       eventPayload.getContext().put(USER_ID_HEADER, userId);
-      eventPayload.getContext().put(PERMISSIONS, permissions);
+      populateWithPermissionsHeader(eventPayload, targetRecord);
 
       OkapiConnectionParams params = RestUtil.retrieveOkapiConnectionParams(eventPayload, vertx);
       String jobProfileSnapshotId = eventPayload.getContext().get(PROFILE_SNAPSHOT_ID_KEY);
@@ -165,4 +164,13 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, byte[]
       LOGGER.log(level, formattedMessage);
     }
   }
+
+  private void populateWithPermissionsHeader(DataImportEventPayload eventPayload,
+                                             KafkaConsumerRecord<String, byte[]> kafkaRecord) {
+    String permissions = extractHeaderValue(PERMISSIONS, kafkaRecord.headers());
+    if (permissions != null) {
+      eventPayload.getContext().put(PERMISSIONS, permissions);
+    }
+  }
+
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -62,7 +62,7 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
     "Failed to handle event payload, cause event payload context does not contain required data to modify MARC record";
   private static final String MAPPING_PARAMETERS_NOT_FOUND_MSG = "MappingParameters snapshot was not found by jobExecutionId '%s'";
   public static final String USER_HAS_NO_PERMISSION_MSG = "User does not have permission to update MARC record on central tenant";
-  private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "data-import.central-record.item.put";
+  private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "consortia.data-import.central-record-update.execute";
   private static final String EMPTY_PERMISSIONS_VALUE = "[]";
 
   protected RecordService recordService;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -61,7 +61,7 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
   private static final String PAYLOAD_HAS_NO_DATA_MSG =
     "Failed to handle event payload, cause event payload context does not contain required data to modify MARC record";
   private static final String MAPPING_PARAMETERS_NOT_FOUND_MSG = "MappingParameters snapshot was not found by jobExecutionId '%s'";
-  private static final String USER_HAS_NO_PERMISSION_MSG = "User does not have permission to update MARC record on central tenant";
+  public static final String USER_HAS_NO_PERMISSION_MSG = "User does not have permission to update MARC record on central tenant";
   private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "data-import.central-record.item.put";
   private static final String EMPTY_PERMISSIONS_VALUE = "[]";
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcAuthorityUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcAuthorityUpdateModifyEventHandler.java
@@ -49,4 +49,9 @@ public class MarcAuthorityUpdateModifyEventHandler extends AbstractUpdateModifyE
   protected EntityType modifiedEntityType() {
     return MARC_AUTHORITY;
   }
+
+  @Override
+  protected EntityType getRelatedEntityType() {
+    return EntityType.AUTHORITY;
+  }
 }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
@@ -92,6 +92,11 @@ public class MarcBibUpdateModifyEventHandler extends AbstractUpdateModifyEventHa
   }
 
   @Override
+  protected EntityType getRelatedEntityType() {
+    return EntityType.INSTANCE;
+  }
+
+  @Override
   protected void submitSuccessfulEventType(DataImportEventPayload payload, CompletableFuture<DataImportEventPayload> future, MappingDetail.MarcMappingOption marcMappingOption) {
     payload.setEventType(getUpdateEventType());
     future.complete(payload);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcHoldingsUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcHoldingsUpdateModifyEventHandler.java
@@ -48,4 +48,9 @@ public class MarcHoldingsUpdateModifyEventHandler extends AbstractUpdateModifyEv
   protected EntityType modifiedEntityType() {
     return MARC_HOLDINGS;
   }
+
+  @Override
+  protected EntityType getRelatedEntityType() {
+    return EntityType.HOLDINGS;
+  }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/consumers/DataImportKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/consumers/DataImportKafkaHandlerTest.java
@@ -1,0 +1,212 @@
+package org.folio.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.folio.ActionProfile;
+import org.folio.DataImportEventPayload;
+import org.folio.JobProfile;
+import org.folio.TestUtil;
+import org.folio.dataimport.util.OkapiConnectionParams;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.processing.events.EventManager;
+import org.folio.processing.events.services.handler.EventHandler;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.services.caches.JobProfileSnapshotCache;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.folio.consumers.DataImportKafkaHandler.CHUNK_ID_HEADER;
+import static org.folio.consumers.DataImportKafkaHandler.PROFILE_SNAPSHOT_ID_KEY;
+import static org.folio.consumers.DataImportKafkaHandler.RECORD_ID_HEADER;
+import static org.folio.consumers.DataImportKafkaHandler.USER_ID_HEADER;
+import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
+import static org.folio.okapi.common.XOkapiHeaders.PERMISSIONS;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_COMPLETED;
+import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MATCHED;
+import static org.folio.rest.jaxrs.model.ProfileType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(VertxUnitRunner.class)
+public class DataImportKafkaHandlerTest {
+
+  private static final String TENANT_ID = "diku";
+  private static final String OKAPI_URL = "http://localhost";
+  private static final String KAFKA_ENV_ID = "test-env";
+  private static final int KAFKA_MAX_REQUEST_SIZE_VAL = 1048576;
+
+  private static Vertx vertx;
+  private static KafkaContainer kafkaContainer = TestUtil.getKafkaContainer();
+  private static KafkaConfig kafkaConfig;
+
+  @Mock
+  private JobProfileSnapshotCache profileSnapshotCacheMock;
+  @Mock
+  private EventHandler mockedEventHandler;
+  private DataImportKafkaHandler dataImportKafkaHandler;
+  private AutoCloseable mocksCloseable;
+
+  private final ProfileSnapshotWrapper jobProfileSnapshotWrapper = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withContentType(JOB_PROFILE)
+    .withContent(JsonObject.mapFrom(new JobProfile()
+        .withId(UUID.randomUUID().toString())).getMap())
+    .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(ACTION_PROFILE)
+      .withContent(JsonObject.mapFrom(new ActionProfile()
+        .withAction(ActionProfile.Action.UPDATE)
+        .withFolioRecord(ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC)).getMap())));
+
+  @BeforeClass
+  public static void setUpClass() {
+    vertx = Vertx.vertx();
+    kafkaContainer.start();
+    kafkaConfig = KafkaConfig.builder()
+      .kafkaHost(kafkaContainer.getHost())
+      .kafkaPort(String.valueOf(kafkaContainer.getFirstMappedPort()))
+      .envId(KAFKA_ENV_ID)
+      .maxRequestSize(KAFKA_MAX_REQUEST_SIZE_VAL)
+      .build();
+  }
+
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    vertx.close(context.asyncAssertSuccess(res -> kafkaContainer.stop()));
+  }
+
+  @Before
+  public void setUp() {
+    mocksCloseable = MockitoAnnotations.openMocks(this);
+    when(profileSnapshotCacheMock.get(anyString(), any(OkapiConnectionParams.class)))
+      .thenReturn(Future.succeededFuture(Optional.of(jobProfileSnapshotWrapper)));
+    when(mockedEventHandler.isEligible(any(DataImportEventPayload.class)))
+      .thenReturn(true);
+    doAnswer(invocation -> CompletableFuture.completedFuture(invocation.<DataImportEventPayload>getArgument(0)))
+      .when(mockedEventHandler).handle(any(DataImportEventPayload.class));
+    dataImportKafkaHandler = new DataImportKafkaHandler(vertx, profileSnapshotCacheMock, kafkaConfig);
+    EventManager.clearEventHandlers();
+    EventManager.registerEventHandler(mockedEventHandler);
+    EventManager.registerKafkaEventPublisher(kafkaConfig, vertx, 1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mocksCloseable.close();
+  }
+
+  @Test
+  public void shouldHandleKafkaRecordAndPopulatePayloadWithHeaders(TestContext context) {
+    // Given
+    String expectedPermissions = JsonArray.of("test-permission").encode();
+    String expectedUserId = UUID.randomUUID().toString();
+    String expectedRecordId = UUID.randomUUID().toString();
+    String expectedChunkId = UUID.randomUUID().toString();
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withEventType(DI_SRS_MARC_BIB_RECORD_MATCHED.value())
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withCurrentNode(jobProfileSnapshotWrapper.getChildSnapshotWrappers().getFirst())
+      .withTenant(TENANT_ID)
+      .withOkapiUrl(OKAPI_URL)
+      .withToken(EMPTY)
+      .withContext(new HashMap<>(Map.of(
+        PROFILE_SNAPSHOT_ID_KEY, jobProfileSnapshotWrapper.getId()
+      )));
+
+    Event event = new Event()
+      .withEventType(DI_SRS_MARC_BIB_RECORD_MATCHED.value())
+      .withId(UUID.randomUUID().toString())
+      .withEventPayload(Json.encode(eventPayload));
+
+    List<KafkaHeader> headers = List.of(
+      new KafkaHeaderImpl(PERMISSIONS, expectedPermissions),
+      new KafkaHeaderImpl(USER_ID_HEADER, expectedUserId),
+      new KafkaHeaderImpl(RECORD_ID_HEADER, expectedRecordId),
+      new KafkaHeaderImpl(CHUNK_ID_HEADER, expectedChunkId));
+
+    KafkaConsumerRecord<String, byte[]> kafkaRecord = mock(KafkaConsumerRecord.class);
+    when(kafkaRecord.headers()).thenReturn(headers);
+    when(kafkaRecord.value()).thenReturn(Json.encode(event).getBytes());
+
+    // When
+    Future<String> future = dataImportKafkaHandler.handle(kafkaRecord);
+
+    // Then
+    future.onComplete(context.asyncAssertSuccess(v -> {
+      ArgumentCaptor<DataImportEventPayload> payloadCaptor = ArgumentCaptor.forClass(DataImportEventPayload.class);
+      verify(mockedEventHandler).handle(payloadCaptor.capture());
+      DataImportEventPayload payload = payloadCaptor.getValue();
+      context.assertEquals(expectedPermissions, payload.getContext().get(PERMISSIONS));
+      context.assertEquals(expectedUserId, payload.getContext().get(USER_ID_HEADER));
+      context.assertEquals(expectedRecordId, payload.getContext().get(RECORD_ID_HEADER));
+      context.assertEquals(expectedChunkId, payload.getContext().get(CHUNK_ID_HEADER));
+      verifyEventPublished(DI_COMPLETED.value(), context);
+    }));
+  }
+
+  private void verifyEventPublished(String eventType, TestContext context) {
+    String topicToObserve = formatToKafkaTopicName(eventType);
+    List<ConsumerRecord<String, String>> observedEvents = observeKafkaEvents(topicToObserve);
+    context.assertEquals(1, observedEvents.size());
+  }
+
+  private String formatToKafkaTopicName(String eventType) {
+    return KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_ID, getDefaultNameSpace(), TENANT_ID, eventType);
+  }
+
+  private List<ConsumerRecord<String, String>> observeKafkaEvents(String topic) {
+    Properties consumerProperties = new Properties();
+    consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+    consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+    consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    ConsumerRecords<String, String> records;
+    try (KafkaConsumer<String, String> kafkaConsumer = new KafkaConsumer<>(consumerProperties)) {
+      kafkaConsumer.subscribe(List.of(topic));
+      records = kafkaConsumer.poll(Duration.ofSeconds(20));
+    }
+    return IteratorUtils.toList(records.iterator());
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/consumers/DataImportKafkaHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/consumers/DataImportKafkaHandlerTest.java
@@ -5,6 +5,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
@@ -137,6 +138,7 @@ public class DataImportKafkaHandlerTest {
   @Test
   public void shouldHandleKafkaRecordAndPopulatePayloadWithHeaders(TestContext context) {
     // Given
+    Async async = context.async();
     String expectedPermissions = JsonArray.of("test-permission").encode();
     String expectedUserId = UUID.randomUUID().toString();
     String expectedRecordId = UUID.randomUUID().toString();
@@ -180,8 +182,10 @@ public class DataImportKafkaHandlerTest {
       context.assertEquals(expectedUserId, payload.getContext().get(USER_ID_HEADER));
       context.assertEquals(expectedRecordId, payload.getContext().get(RECORD_ID_HEADER));
       context.assertEquals(expectedChunkId, payload.getContext().get(CHUNK_ID_HEADER));
-      verifyEventPublished(DI_COMPLETED.value(), context);
+      async.complete();
     }));
+    async.await();
+    verifyEventPublished(DI_COMPLETED.value(), context);
   }
 
   private void verifyEventPublished(String eventType, TestContext context) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -21,7 +21,6 @@ import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.services.handlers.actions.AbstractUpdateModifyEventHandler.USER_HAS_NO_PERMISSION_MSG;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -111,6 +110,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     new UrlPathPattern(new RegexPattern(INSTANCE_LINKS_URL + "/.*"), true);
   private static final String LINKING_RULES_URL = "/linking-rules/instance-authority";
   private static final String CENTRAL_TENANT_ID = "centralTenantId";
+  private static final String USER_HAS_NO_PERMISSION_MSG = "User does not have permission to update record/instance on central tenant";
   private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "consortia.data-import.central-record-update.execute";
   private static final String SECOND_PARSED_CONTENT =
     "{\"leader\":\"02326cam a2200301Ki 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -21,6 +21,7 @@ import static org.folio.rest.jaxrs.model.ProfileType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileType.MAPPING_PROFILE;
 import static org.folio.rest.jaxrs.model.Record.RecordType.MARC_BIB;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.services.handlers.actions.AbstractUpdateModifyEventHandler.USER_HAS_NO_PERMISSION_MSG;
 import static org.folio.services.util.AdditionalFieldsUtil.TAG_005;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -429,7 +430,8 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     CompletableFuture<DataImportEventPayload> future = modifyRecordEventHandler.handle(dataImportEventPayload);
 
     // then
-    Future.fromCompletionStage(future).onComplete(context.asyncAssertFailure());
+    Future.fromCompletionStage(future)
+      .onComplete(context.asyncAssertFailure(e -> context.assertEquals(USER_HAS_NO_PERMISSION_MSG, e.getMessage())));
   }
 
   @Test

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcBibUpdateModifyEventHandlerTest.java
@@ -111,7 +111,7 @@ public class MarcBibUpdateModifyEventHandlerTest extends AbstractLBServiceTest {
     new UrlPathPattern(new RegexPattern(INSTANCE_LINKS_URL + "/.*"), true);
   private static final String LINKING_RULES_URL = "/linking-rules/instance-authority";
   private static final String CENTRAL_TENANT_ID = "centralTenantId";
-  private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "data-import.central-record.item.put";
+  private static final String CENTRAL_RECORD_UPDATE_PERMISSION = "consortia.data-import.central-record-update.execute";
   private static final String SECOND_PARSED_CONTENT =
     "{\"leader\":\"02326cam a2200301Ki 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"ind1\":\"1\",\"ind2\":\" \",\"subfields\":[{\"a\":\"Chin, Staceyann Test,\"},{\"e\":\"author.\"},{\"0\":\"http://id.loc.gov/authorities/names/n2008052404\"},{\"9\":\"5a56ffa8-e274-40ca-8620-34a23b5b45dd\"}]}}]}";


### PR DESCRIPTION
## Purpose
to prohibit MARC record update on a central tenant if user does not have appropriate permissions/capabilities

## Approach
* check if user has "consortia.data-import.central-record-update.execute" permission allowing update of record on central tenant
* add tests


## Learning
[MODSOURCE-919](https://issues.folio.org/browse/MODSOURCE-919)