### PR TITLE
MODSOURCE-937 - Set groupInstanceId property during consumer wrapper creation

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jsqlparser</groupId>

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AbstractConsumerVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AbstractConsumerVerticle.java
@@ -11,6 +11,8 @@ import io.vertx.core.Promise;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.kafka.GlobalLoadSensor;
 import org.folio.kafka.KafkaConfig;
@@ -49,6 +51,7 @@ public abstract class AbstractConsumerVerticle<K,V> extends AbstractVerticle {
         .globalLoadSensor(new GlobalLoadSensor())
         .subscriptionDefinition(subscriptionDefinition)
         .processRecordErrorHandler(processRecordErrorHandler())
+        .groupInstanceId(getClass().getSimpleName() + "-" + UUID.randomUUID())
         .build());
     });
 


### PR DESCRIPTION
## Purpose
to configure "group.instance.id" parameter during consumer wrapper creation



## Learning
[MODSOURCE-937](https://issues.folio.org/browse/MODSOURCE-937)