### PR TITLE
MODSOURCE-745 - Subscribe to JobExecution cancellation and add cache

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -23,6 +23,7 @@ import org.folio.verticle.MarcIndexersVersionDeletionVerticle;
 import org.folio.verticle.SpringVerticleFactory;
 import org.folio.verticle.consumers.AuthorityDomainConsumersVerticle;
 import org.folio.verticle.consumers.AuthorityLinkChunkConsumersVerticle;
+import org.folio.verticle.consumers.CancelledJobExecutionConsumersVerticle;
 import org.folio.verticle.consumers.DataImportConsumersVerticle;
 import org.folio.verticle.consumers.ParsedRecordChunkConsumersVerticle;
 import org.folio.verticle.consumers.QuickMarcConsumersVerticle;
@@ -95,6 +96,7 @@ public class InitAPIImpl implements InitAPI {
     Promise<String> deployConsumer3 = Promise.promise();
     Promise<String> deployConsumer4 = Promise.promise();
     Promise<String> deployConsumer5 = Promise.promise();
+    Promise<String> deployConsumer6 = Promise.promise();
 
     deployVerticle(vertx, verticleFactory, AuthorityLinkChunkConsumersVerticle.class,
       OptionalInt.of(authorityLinkChunkConsumerInstancesNumber), deployConsumer1);
@@ -106,6 +108,8 @@ public class InitAPIImpl implements InitAPI {
       OptionalInt.of(parsedMarcChunkConsumerInstancesNumber), deployConsumer4);
     deployVerticle(vertx, verticleFactory, QuickMarcConsumersVerticle.class,
       OptionalInt.of(quickMarcConsumerInstancesNumber), deployConsumer5);
+    deployVerticle(vertx, verticleFactory, CancelledJobExecutionConsumersVerticle.class,
+      OptionalInt.of(1), deployConsumer6);
 
     return GenericCompositeFuture.all(List.of(
       deployConsumer1.future(),

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/caches/CancelledJobsIdsCache.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/caches/CancelledJobsIdsCache.java
@@ -1,0 +1,46 @@
+package org.folio.services.caches;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An in-memory cache that stores IDs of cancelled import jobs.
+ */
+@Component
+public class CancelledJobsIdsCache {
+
+  private final Cache<String, Boolean> cache;
+
+  public CancelledJobsIdsCache(
+    @Value("${srs.cancelled-job-cache.expiration.time.minutes:1440}") long cacheExpirationTimeMins) {
+    this.cache = Caffeine.newBuilder()
+      .expireAfterWrite(cacheExpirationTimeMins, TimeUnit.MINUTES)
+      .build();
+  }
+
+  /**
+   * Puts the specified {@code jobId} into the cache.
+   *
+   * @param jobId import job id to put into the cache
+   * @throws NullPointerException if the specified {@code jobId} is null
+   */
+  public void put(String jobId) {
+    cache.put(jobId, Boolean.TRUE);
+  }
+
+  /**
+   * Checks if the cache contains the specified {@code jobId}.
+   *
+   * @param jobId import job id to check
+   * @return {@code true} if the cache contains the {@code jobId}, {@code false} otherwise
+   * @throws NullPointerException if the specified {@code jobId} is null
+   */
+  public boolean contains(String jobId) {
+    return cache.asMap().containsKey(jobId);
+  }
+
+}

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AbstractConsumerVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/AbstractConsumerVerticle.java
@@ -56,7 +56,7 @@ public abstract class AbstractConsumerVerticle<K,V> extends AbstractVerticle {
     });
 
     List<Future<Void>> futures = new ArrayList<>();
-    consumers.forEach(consumer -> futures.add(consumer.start(recordHandler(), getConsumerName())));
+    consumers.forEach(consumer -> futures.add(consumer.start(recordHandler(), getModuleName())));
 
     GenericCompositeFuture.all(futures).onComplete(ar -> startPromise.complete());
   }
@@ -97,7 +97,7 @@ public abstract class AbstractConsumerVerticle<K,V> extends AbstractVerticle {
     return subscriptionDefinition;
   }
 
-  private String getConsumerName() {
+  protected String getModuleName() {
     return constructModuleName() + "_" + getClass().getSimpleName();
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/CancelledJobExecutionConsumersVerticle.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/verticle/consumers/CancelledJobExecutionConsumersVerticle.java
@@ -1,0 +1,95 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.jackson.DatabindCodec;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.headers.FolioKafkaHeaders;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.tools.utils.ModuleName;
+import org.folio.services.caches.CancelledJobsIdsCache;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.folio.DataImportEventTypes.DI_JOB_CANCELLED;
+import static org.folio.services.util.KafkaUtil.extractHeaderValue;
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+@Component
+@Scope(SCOPE_PROTOTYPE)
+public class CancelledJobExecutionConsumersVerticle extends AbstractConsumerVerticle<String, byte[]>
+  implements AsyncRecordHandler<String, byte[]> {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private final CancelledJobsIdsCache cancelledJobsIdsCache;
+  private final int loadLimit;
+
+  @Autowired
+  public CancelledJobExecutionConsumersVerticle(CancelledJobsIdsCache cancelledJobsIdsCache, KafkaConfig kafkaConfig,
+    @Value("${srs.kafka.CancelledJobExecutionConsumer.loadLimit:1000}") int loadLimit) {
+    super(kafkaConfig);
+    this.cancelledJobsIdsCache = cancelledJobsIdsCache;
+    this.loadLimit = loadLimit;
+  }
+
+  @Override
+  protected int loadLimit() {
+    return loadLimit;
+  }
+
+  @Override
+  protected AsyncRecordHandler<String, byte[]> recordHandler() {
+    return this;
+  }
+
+  @Override
+  protected List<String> eventTypes() {
+    return List.of(DI_JOB_CANCELLED.value());
+  }
+
+  @Override
+  public String getDeserializerClass() {
+    return ByteArrayDeserializer.class.getName();
+  }
+
+  /**
+   * Constructs a unique module name with pseudo-random suffix.
+   * This ensures that each instance of the module will have own consumer group
+   * and will consume all messages from the topic.
+   *
+   * @return unique module name string.
+   */
+  @Override
+  protected String getModuleName() {
+    return ModuleName.getModuleName() + "-" + java.util.UUID.randomUUID();
+  }
+
+  @Override
+  @SuppressWarnings("squid:S2629")
+  public Future<String> handle(KafkaConsumerRecord<String, byte[]> kafkaRecord) {
+    try {
+      String tenantId = extractHeaderValue(FolioKafkaHeaders.TENANT_ID, kafkaRecord.headers());
+      LOGGER.debug("handle:: Received cancelled job event, key: '{}', tenantId: '{}'", kafkaRecord.key(), tenantId);
+
+      String jobId = DatabindCodec.mapper().readValue(kafkaRecord.value(), Event.class).getEventPayload();
+      cancelledJobsIdsCache.put(jobId);
+      LOGGER.info("handle:: Processed cancelled job, jobId: '{}', tenantId: '{}', topic: '{}'",
+        jobId, tenantId, kafkaRecord.topic());
+      return Future.succeededFuture(kafkaRecord.key());
+    } catch (Exception e) {
+      LOGGER.warn("handle:: Failed to process cancelled job, key: '{}', from topic: '{}'",
+        kafkaRecord.key(), kafkaRecord.topic(), e);
+      return Future.failedFuture(e);
+    }
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/caches/CancelledJobsIdsCacheTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/caches/CancelledJobsIdsCacheTest.java
@@ -1,0 +1,44 @@
+package org.folio.services.caches;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class CancelledJobsIdsCacheTest {
+
+  private static final long CACHE_EXPIRATION_TIME_MINS = 5;
+
+  private CancelledJobsIdsCache cache;
+
+  @Before
+  public void setUp() {
+    cache = new CancelledJobsIdsCache(CACHE_EXPIRATION_TIME_MINS);
+  }
+
+  @Test
+  public void shouldIdAddToCache() {
+    String jobId = UUID.randomUUID().toString();
+    cache.put(jobId);
+    assertTrue(cache.contains(jobId));
+  }
+
+  @Test
+  public void shouldReturnFalseForNonExistentId() {
+    String jobId = UUID.randomUUID().toString();
+    assertFalse(cache.contains(jobId));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfJobIdIsNull() {
+    assertThrows(NullPointerException.class, () -> cache.contains(null));
+  }
+
+}

--- a/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/CancelledJobExecutionConsumersVerticleTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/verticle/consumers/CancelledJobExecutionConsumersVerticleTest.java
@@ -1,0 +1,173 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.folio.TestUtil;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.headers.FolioKafkaHeaders;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.services.caches.CancelledJobsIdsCache;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import static java.time.Duration.ofSeconds;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.folio.DataImportEventTypes.DI_JOB_CANCELLED;
+import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
+import static org.junit.Assert.assertTrue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@RunWith(VertxUnitRunner.class)
+public class CancelledJobExecutionConsumersVerticleTest {
+
+  private static final String TENANT_ID = "diku";
+  private static final String KAFKA_ENV_ID = "test-env";
+  private static final long CACHE_EXPIRATION_TIME_MINS = 5;
+
+  private static KafkaContainer kafkaContainer = TestUtil.getKafkaContainer();
+  private static Vertx vertx;
+  private static KafkaConfig kafkaConfig;
+
+  private CancelledJobsIdsCache cancelledJobsIdsCache;
+  private String verticleDeploymentId;
+
+  @BeforeClass
+  public static void beforeAll() {
+    vertx = Vertx.vertx();
+    kafkaContainer.start();
+    kafkaConfig = KafkaConfig.builder()
+      .kafkaHost(kafkaContainer.getHost())
+      .kafkaPort(String.valueOf(kafkaContainer.getFirstMappedPort()))
+      .envId(KAFKA_ENV_ID)
+      .build();
+  }
+
+  @AfterClass
+  public static void afterAll(TestContext context) {
+    vertx.close(context.asyncAssertSuccess(res -> kafkaContainer.stop()));
+  }
+
+  @Before
+  public void setUp(TestContext context) {
+    cancelledJobsIdsCache = new CancelledJobsIdsCache(CACHE_EXPIRATION_TIME_MINS);
+    deployVerticle(cancelledJobsIdsCache).onComplete(context.asyncAssertSuccess());
+  }
+
+  @After
+  public void tearDown(TestContext context) {
+    undeployVerticle().onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void shouldReadAndPutMultipleJobIdsToCache() throws ExecutionException, InterruptedException {
+    List<String> ids = generateJobIds(100);
+
+    sendJobIdsToKafka(ids);
+
+    await().atMost(ofSeconds(3))
+      .untilAsserted(() -> ids.forEach(id -> assertTrue(cancelledJobsIdsCache.contains(id))));
+  }
+
+  @Test
+  public void shouldReadAllEventsFromTopicIfVerticleWasRestarted(TestContext context)
+    throws ExecutionException, InterruptedException {
+
+    List<String> idsBatch1 = generateJobIds(100);
+    sendJobIdsToKafka(idsBatch1);
+    await().atMost(ofSeconds(3))
+      .untilAsserted(() -> idsBatch1.forEach(id -> assertTrue(cancelledJobsIdsCache.contains(id))));
+
+    // stop currently deployed verticle
+    Async async = context.async();
+    undeployVerticle().onComplete(context.asyncAssertSuccess(v -> async.complete()));
+
+    async.await(3000);
+    List<String> idsBatch2 = generateJobIds(200);
+    sendJobIdsToKafka(idsBatch2);
+
+    // redeploy the verticle
+    Async async2 = context.async();
+    cancelledJobsIdsCache = new CancelledJobsIdsCache(CACHE_EXPIRATION_TIME_MINS);
+    deployVerticle(cancelledJobsIdsCache)
+      .onComplete(context.asyncAssertSuccess(v -> async2.complete()));
+
+    async2.await(3000);
+    await().atMost(ofSeconds(3))
+      .untilAsserted(() -> idsBatch1.forEach(id -> assertTrue(cancelledJobsIdsCache.contains(id))));
+    await().atMost(ofSeconds(3))
+      .untilAsserted(() -> idsBatch2.forEach(id -> assertTrue(cancelledJobsIdsCache.contains(id))));
+  }
+
+  private Future<String> deployVerticle(CancelledJobsIdsCache cancelledJobsIdsCache) {
+    DeploymentOptions deploymentOptions = new DeploymentOptions()
+      .setThreadingModel(ThreadingModel.WORKER)
+      .setInstances(1);
+
+    return vertx.deployVerticle(
+      () -> new CancelledJobExecutionConsumersVerticle(cancelledJobsIdsCache, kafkaConfig, 1000),
+      deploymentOptions
+    ).onSuccess(deploymentId -> verticleDeploymentId = deploymentId);
+  }
+
+  private Future<Void> undeployVerticle() {
+    return vertx.undeploy(verticleDeploymentId);
+  }
+
+  private List<String> generateJobIds(int idsNumber) {
+    return Stream.iterate(0, i -> i < idsNumber, i -> ++i)
+      .map(i -> UUID.randomUUID().toString())
+      .toList();
+  }
+
+  private void sendJobIdsToKafka(List<String> ids) throws ExecutionException, InterruptedException {
+    for (String id : ids) {
+      Event event = new Event().withEventPayload(id);
+      sendEvent(DI_JOB_CANCELLED.value(), Json.encode(event));
+    }
+  }
+
+  private void sendEvent(String topic, String payload) throws ExecutionException, InterruptedException {
+    try (KafkaProducer<String, String> kafkaProducer = createKafkaProducer()) {
+      var topicName = formatToKafkaTopicName(topic);
+      var producerRecord = new ProducerRecord<>(topicName, "test-key", payload);
+      producerRecord.headers().add(FolioKafkaHeaders.TENANT_ID, TENANT_ID.getBytes());
+      kafkaProducer.send(producerRecord).get();
+    }
+  }
+
+  private KafkaProducer<String, String> createKafkaProducer() {
+    Properties producerProperties = new Properties();
+    producerProperties.setProperty(BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+    producerProperties.setProperty(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    producerProperties.setProperty(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    return new KafkaProducer<>(producerProperties);
+  }
+
+  private String formatToKafkaTopicName(String eventType) {
+    return KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_ID, getDefaultNameSpace(), TENANT_ID, eventType);
+  }
+
+}


### PR DESCRIPTION
## Purpose
to subscribe module to event about import job cancellation for skipping event processing for cancelled import jobs


## Approach
* create cache to store cancelled jobs id
* subscribe module to DI_JOB_CANCELLED event about import job cancellation and save received cancelled jobs ids to the cache. Consumer is created within a group to pick up topics created after add tests
* add tests


## Learning
[MODSOURCE-745](https://issues.folio.org/browse/MODSOURCE-745)