### PR TITLE
MODSOURCE-804. Include FOLIO Identifiers in Kafka Messages

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
@@ -107,7 +107,7 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
     }
   }
 
-  private Future<String> sendBackRecordsBatchResponse(RecordsBatchResponse recordsBatchResponse, List<KafkaHeader> kafkaHeaders, String tenantId, int chunkNumber, String eventType, KafkaConsumerRecord<String, byte[]> commonRecord) {
+  protected Future<String> sendBackRecordsBatchResponse(RecordsBatchResponse recordsBatchResponse, List<KafkaHeader> kafkaHeaders, String tenantId, int chunkNumber, String eventType, KafkaConsumerRecord<String, byte[]> commonRecord) {
     Event event;
     event = new Event()
       .withId(UUID.randomUUID().toString())

--- a/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/consumers/ParsedRecordChunksKafkaHandler.java
@@ -148,7 +148,9 @@ public class ParsedRecordChunksKafkaHandler implements AsyncRecordHandler<String
       })
       .onFailure(err -> {
         Throwable cause = err.getCause();
-        LOGGER.warn("sendBackRecordsBatchResponse:: {} write error {}", producerName, cause);
+        String jobExecutionId = extractHeaderValue(JOB_EXECUTION_ID_HEADER, commonRecord.headers());
+        String chunkId = extractHeaderValue(CHUNK_ID_HEADER, commonRecord.headers());
+        LOGGER.warn("sendBackRecordsBatchResponse:: {} write error jobExecutionId={} chunkId={}", producerName, jobExecutionId, chunkId, cause);
         writePromise.fail(cause);
       });
     return writePromise.future();

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -502,7 +502,7 @@ public class RecordServiceImpl implements RecordService {
             promise.complete(record.withMatchedId(record.getId()));
           }
         } else {
-          LOG.warn("setMatchedIdFromExistingSourceRecord:: Error while retrieving source record");
+          LOG.warn("setMatchedIdFromExistingSourceRecord:: Error while retrieving source record recordId={}", record.getId());
           promise.fail(ar.cause());
         }
       });

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
@@ -7,6 +7,8 @@ import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
 import static org.folio.services.domainevent.SourceRecordDomainEventType.SOURCE_RECORD_CREATED;
 import static org.folio.services.domainevent.SourceRecordDomainEventType.SOURCE_RECORD_DELETED;
 import static org.folio.services.domainevent.SourceRecordDomainEventType.SOURCE_RECORD_UPDATED;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_REQUEST_HEADER;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_USER_HEADER;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -107,6 +109,12 @@ public class RecordDomainEventPublisher {
 
     Optional.ofNullable(okapiHeaders.get(OKAPI_TOKEN_HEADER))
       .ifPresent(token -> headers.add(KafkaHeader.header(OKAPI_TOKEN_HEADER, token)));
+
+    Optional.ofNullable(okapiHeaders.get(OKAPI_USER_HEADER))
+      .ifPresent(userId -> headers.add(KafkaHeader.header(OKAPI_USER_HEADER, userId)));
+
+    Optional.ofNullable(okapiHeaders.get(OKAPI_REQUEST_HEADER))
+        .ifPresent(requestId -> headers.add(KafkaHeader.header(OKAPI_REQUEST_HEADER, requestId)));
 
     Optional.ofNullable(recordType)
       .map(Record.RecordType::value)

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -19,8 +19,7 @@ import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlle
 import static org.folio.services.util.AdditionalFieldsUtil.isFieldsFillingNeeded;
 import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrId;
 import static org.folio.services.util.AdditionalFieldsUtil.updateLatestTransactionDate;
-import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
-import static org.folio.services.util.EventHandlingUtil.toOkapiHeaders;
+import static org.folio.services.util.EventHandlingUtil.*;
 import static org.folio.services.util.RestUtil.retrieveOkapiConnectionParams;
 
 import io.vertx.core.Future;
@@ -35,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,8 +161,18 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     );
 
     String recordId = eventPayload.getContext().get(RECORD_ID_HEADER);
-    if (recordId != null) {
+    if (StringUtils.isNotBlank(recordId)) {
       kafkaHeaders.add(KafkaHeader.header(RECORD_ID_HEADER, recordId));
+    }
+
+    String userId = eventPayload.getContext().get(USER_ID_HEADER);
+    if (StringUtils.isNotBlank(userId)) {
+      kafkaHeaders.add(KafkaHeader.header(USER_ID_HEADER, userId));
+    }
+
+    String requestId = eventPayload.getContext().get(OKAPI_REQUEST_HEADER);
+    if (StringUtils.isNotBlank(requestId)) {
+      kafkaHeaders.add(KafkaHeader.header(OKAPI_REQUEST_HEADER, requestId));
     }
     return kafkaHeaders;
   }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -118,12 +118,12 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
           future.complete(dataImportEventPayload);
         })
         .onFailure(throwable -> {
-          LOG.warn(FAIL_MSG, eventType, throwable);
+          LOG.warn(FAIL_MSG + " jobExecutionId={}", eventType, jobExecutionId, throwable);
           dataImportEventPayload.setEventType(getNextEventType(dataImportEventPayload));
           future.completeExceptionally(throwable);
         });
     } catch (Exception e) {
-      LOG.warn(FAIL_MSG, eventType, e);
+      LOG.warn(FAIL_MSG + " jobExecutionId={}", eventType, jobExecutionId, e);
       future.completeExceptionally(e);
     }
     return future;
@@ -211,7 +211,7 @@ public abstract class AbstractPostProcessingEventHandler implements EventHandler
     String userId = (String) dataImportEventPayload.getAdditionalProperties().get(USER_ID_HEADER);
 
     if (isEmpty(entityAsString) || isEmpty(recordAsString)) {
-      LOG.warn(EVENT_HAS_NO_DATA_MSG);
+      LOG.warn(EVENT_HAS_NO_DATA_MSG + " jobExecutionId={}", dataImportEventPayload.getJobExecutionId());
       recordPromise.fail(new EventProcessingException(EVENT_HAS_NO_DATA_MSG));
     } else {
       Record record = Json.decodeValue(recordAsString, Record.class);

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/AbstractPostProcessingEventHandler.java
@@ -19,7 +19,9 @@ import static org.folio.services.util.AdditionalFieldsUtil.getValueFromControlle
 import static org.folio.services.util.AdditionalFieldsUtil.isFieldsFillingNeeded;
 import static org.folio.services.util.AdditionalFieldsUtil.remove035WithActualHrId;
 import static org.folio.services.util.AdditionalFieldsUtil.updateLatestTransactionDate;
-import static org.folio.services.util.EventHandlingUtil.*;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_REQUEST_HEADER;
+import static org.folio.services.util.EventHandlingUtil.sendEventToKafka;
+import static org.folio.services.util.EventHandlingUtil.toOkapiHeaders;
 import static org.folio.services.util.RestUtil.retrieveOkapiConnectionParams;
 
 import io.vertx.core.Future;

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractDeleteEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractDeleteEventHandler.java
@@ -76,7 +76,7 @@ public abstract class AbstractDeleteEventHandler implements EventHandler {
           LOG.debug("handlePayload:: No records found, recordId: '{}'", payloadRecord.getMatchedId());
           return Future.succeededFuture();
         }
-        LOG.warn("handlePayload:: Error during record deletion", throwable);
+        LOG.warn("handlePayload:: Error during record deletion recordId={}", payloadRecord.getId(), throwable);
         return Future.failedFuture(throwable);
       })
       .onSuccess(ar -> {

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractUpdateModifyEventHandler.java
@@ -87,7 +87,7 @@ public abstract class AbstractUpdateModifyEventHandler implements EventHandler {
     try {
       var payloadContext = payload.getContext();
       if (isNull(payloadContext) || isBlank(payloadContext.get(modifiedEntityType().value()))) {
-        LOG.warn(PAYLOAD_HAS_NO_DATA_MSG);
+        LOG.warn(PAYLOAD_HAS_NO_DATA_MSG + " jobExecutionId={}", jobExecutionId);
         future.completeExceptionally(new EventProcessingException(PAYLOAD_HAS_NO_DATA_MSG));
         return future;
       }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/MarcBibUpdateModifyEventHandler.java
@@ -3,8 +3,6 @@ package org.folio.services.handlers.actions;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.dataimport.util.RestUtil.OKAPI_TENANT_HEADER;
-import static org.folio.dataimport.util.RestUtil.OKAPI_TOKEN_HEADER;
-import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_MODIFIED_READY_FOR_POST_PROCESSING;
 import static org.folio.rest.jaxrs.model.DataImportEventTypes.DI_SRS_MARC_BIB_RECORD_UPDATED;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
@@ -17,6 +15,7 @@ import io.vertx.core.Vertx;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,11 +124,7 @@ public class MarcBibUpdateModifyEventHandler extends AbstractUpdateModifyEventHa
     var okapiParams = getOkapiParams(dataImportEventPayload);
     var centralTenantId = dataImportEventPayload.getContext().get(CENTRAL_TENANT_ID);
     if (centralTenantId != null) {
-      okapiParams = new OkapiConnectionParams(Map.of(
-        OKAPI_URL_HEADER, okapiParams.getOkapiUrl(),
-        OKAPI_TENANT_HEADER, centralTenantId,
-        OKAPI_TOKEN_HEADER, okapiParams.getToken()
-      ), vertx);
+      okapiParams = overrideOkapiParamsWithTenant(okapiParams, centralTenantId);
     }
 
     OkapiConnectionParams finalOkapiParams = okapiParams;
@@ -137,6 +132,13 @@ public class MarcBibUpdateModifyEventHandler extends AbstractUpdateModifyEventHa
       .compose(linkingRuleDtos -> loadInstanceLink(matchedRecord, instanceId, finalOkapiParams)
         .compose(links -> modifyMarcBibRecord(dataImportEventPayload, mappingProfile, mappingParameters, links, linkingRuleDtos.orElse(Collections.emptyList())))
         .compose(links -> updateInstanceLinks(instanceId, links, finalOkapiParams)));
+  }
+
+  private OkapiConnectionParams overrideOkapiParamsWithTenant(OkapiConnectionParams okapiParams, String tenantId) {
+    Map<String, String> newHeaders = new HashMap<>();
+    okapiParams.getHeaders().forEach(entry -> newHeaders.put(entry.getKey(), entry.getValue()));
+    newHeaders.put(OKAPI_TENANT_HEADER, tenantId);
+    return new OkapiConnectionParams(newHeaders, vertx);
   }
 
   private Future<Optional<InstanceLinkDtoCollection>> loadInstanceLink(Record oldRecord, String instanceId,

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/EventHandlingUtil.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
@@ -35,6 +37,8 @@ public final class EventHandlingUtil {
   private static final Logger LOGGER = LogManager.getLogger();
   private static final String RECORD_ID_HEADER = "recordId";
   private static final String CHUNK_ID_HEADER = "chunkId";
+  public static final String OKAPI_REQUEST_HEADER = "x-okapi-request-id";
+  public static final String OKAPI_USER_HEADER = "x-okapi-user-id";
 
 
   private EventHandlingUtil() { }
@@ -126,6 +130,14 @@ public final class EventHandlingUtil {
     okapiHeaders.put(OKAPI_URL_HEADER, eventPayload.getOkapiUrl());
     okapiHeaders.put(OKAPI_TENANT_HEADER, eventPayload.getTenant());
     okapiHeaders.put(OKAPI_TOKEN_HEADER, eventPayload.getToken());
+    String userId = eventPayload.getContext().get(OKAPI_USER_HEADER);
+    if (StringUtils.isNotBlank(userId)) {
+      okapiHeaders.put(OKAPI_USER_HEADER, userId);
+    }
+    String requestId = eventPayload.getContext().get(OKAPI_REQUEST_HEADER);
+    if (StringUtils.isNotBlank(requestId)) {
+      okapiHeaders.put(OKAPI_REQUEST_HEADER, requestId);
+    }
     return okapiHeaders;
   }
 
@@ -138,6 +150,14 @@ public final class EventHandlingUtil {
     okapiHeaders.put(OKAPI_URL_HEADER, extractHeaderValue(OKAPI_URL_HEADER, kafkaHeaders));
     okapiHeaders.put(OKAPI_TENANT_HEADER, nonNull(eventTenantId) ? eventTenantId : extractHeaderValue(OKAPI_TENANT_HEADER, kafkaHeaders));
     okapiHeaders.put(OKAPI_TOKEN_HEADER, extractHeaderValue(OKAPI_TOKEN_HEADER, kafkaHeaders));
+    String userId = extractHeaderValue(OKAPI_USER_HEADER, kafkaHeaders);
+    if (StringUtils.isNotBlank(userId)) {
+      okapiHeaders.put(OKAPI_USER_HEADER, userId);
+    }
+    String requestId = extractHeaderValue(OKAPI_REQUEST_HEADER, kafkaHeaders);
+    if (StringUtils.isNotBlank(requestId)) {
+      okapiHeaders.put(OKAPI_REQUEST_HEADER, requestId);
+    }
     return okapiHeaders;
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/util/RestUtil.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/util/RestUtil.java
@@ -1,14 +1,18 @@
 package org.folio.services.util;
 
 import io.vertx.core.Vertx;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
 import org.folio.dataimport.util.OkapiConnectionParams;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.folio.dataimport.util.RestUtil.OKAPI_TENANT_HEADER;
 import static org.folio.dataimport.util.RestUtil.OKAPI_TOKEN_HEADER;
 import static org.folio.dataimport.util.RestUtil.OKAPI_URL_HEADER;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_REQUEST_HEADER;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_USER_HEADER;
 
 public final class RestUtil {
 
@@ -16,10 +20,20 @@ public final class RestUtil {
   }
 
   public static OkapiConnectionParams retrieveOkapiConnectionParams(DataImportEventPayload eventPayload, Vertx vertx) {
-    return OkapiConnectionParams.createSystemUserConnectionParams(Map.of(
+    Map<String, String> okapiHeaders = new HashMap<>(Map.of(
       OKAPI_URL_HEADER, eventPayload.getOkapiUrl(),
       OKAPI_TENANT_HEADER, eventPayload.getTenant(),
       OKAPI_TOKEN_HEADER, eventPayload.getToken()
-    ), vertx);
+    ));
+
+    String userId = eventPayload.getContext().get(OKAPI_USER_HEADER);
+    if (StringUtils.isNotBlank(userId)) {
+      okapiHeaders.put(OKAPI_USER_HEADER, userId);
+    }
+    String requestId = eventPayload.getContext().get(OKAPI_REQUEST_HEADER);
+    if (StringUtils.isNotBlank(requestId)) {
+      okapiHeaders.put(OKAPI_REQUEST_HEADER, requestId);
+    }
+    return OkapiConnectionParams.createSystemUserConnectionParams(okapiHeaders, vertx);
   }
 }

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/util/EventHandlingUtilTest.java
@@ -1,15 +1,37 @@
 package org.folio.services.util;
 
-
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.folio.DataImportEventPayload;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.KafkaTopicNameHelper;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.folio.services.domainevent.RecordDomainEventPublisher.RECORD_DOMAIN_EVENT_TOPIC;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_REQUEST_HEADER;
+import static org.folio.services.util.EventHandlingUtil.OKAPI_USER_HEADER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class EventHandlingUtilTest {
 
   private static final String ENV = "env";
   private static final String EVENT = "event";
   private static final String TENANT = "tenant";
+  private static final String OKAPI_URL = "http://localhost:9130";
+  private static final String TOKEN = "test-token";
+  private static final String USER_ID = "user-123";
+  private static final String REQUEST_ID = "request-456";
 
   @Test
   public void shouldCreateSubscriptionPattern() {
@@ -17,5 +39,252 @@ public class EventHandlingUtilTest {
     var actual = EventHandlingUtil.createSubscriptionPattern(ENV, EVENT);
 
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void shouldConstructModuleName() {
+    // When
+    String moduleName = EventHandlingUtil.constructModuleName();
+
+    // Then
+    assertNotNull(moduleName);
+    assertFalse(moduleName.isEmpty());
+  }
+
+  @Test
+  public void shouldCreateTopicNameForDomainEvent() {
+    // Given
+    String eventType = "SOURCE_RECORD_CREATED";
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    String topicName = EventHandlingUtil.createTopicName(eventType, TENANT, kafkaConfig);
+
+    // Then
+    String expected = KafkaTopicNameHelper.formatTopicName(ENV, TENANT, RECORD_DOMAIN_EVENT_TOPIC);
+    assertEquals(expected, topicName);
+  }
+
+  @Test
+  public void shouldCreateTopicNameForSourceRecordUpdatedDomainEvent() {
+    // Given
+    String eventType = "SOURCE_RECORD_UPDATED";
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    String topicName = EventHandlingUtil.createTopicName(eventType, TENANT, kafkaConfig);
+
+    // Then
+    String expected = KafkaTopicNameHelper.formatTopicName(ENV, TENANT, RECORD_DOMAIN_EVENT_TOPIC);
+    assertEquals(expected, topicName);
+  }
+
+  @Test
+  public void shouldCreateTopicNameForSourceRecordDeletedDomainEvent() {
+    // Given
+    String eventType = "SOURCE_RECORD_DELETED";
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    String topicName = EventHandlingUtil.createTopicName(eventType, TENANT, kafkaConfig);
+
+    // Then
+    String expected = KafkaTopicNameHelper.formatTopicName(ENV, TENANT, RECORD_DOMAIN_EVENT_TOPIC);
+    assertEquals(expected, topicName);
+  }
+
+  @Test
+  public void shouldCreateTopicNameForRegularEvent() {
+    // Given
+    String eventType = "DI_COMPLETED";
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    String topicName = EventHandlingUtil.createTopicName(eventType, TENANT, kafkaConfig);
+
+    // Then
+    String expected = KafkaTopicNameHelper.formatTopicName(ENV, KafkaTopicNameHelper.getDefaultNameSpace(),
+      TENANT, eventType);
+    assertEquals(expected, topicName);
+  }
+
+  @Test
+  public void shouldConvertDataImportEventPayloadToOkapiHeaders() {
+    // Given
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withOkapiUrl(OKAPI_URL)
+      .withTenant(TENANT)
+      .withToken(TOKEN)
+      .withContext(new HashMap<>());
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(eventPayload);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(TENANT, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertNull(headers.get(OKAPI_USER_HEADER));
+    assertNull(headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldConvertDataImportEventPayloadToOkapiHeadersWithUserIdAndRequestId() {
+    // Given
+    HashMap<String, String> context = new HashMap<>();
+    context.put(OKAPI_USER_HEADER, USER_ID);
+    context.put(OKAPI_REQUEST_HEADER, REQUEST_ID);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload()
+      .withOkapiUrl(OKAPI_URL)
+      .withTenant(TENANT)
+      .withToken(TOKEN)
+      .withContext(context);
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(eventPayload);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(TENANT, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertEquals(USER_ID, headers.get(OKAPI_USER_HEADER));
+    assertEquals(REQUEST_ID, headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldConvertKafkaHeadersToOkapiHeaders() {
+    // Given
+    List<KafkaHeader> kafkaHeaders = createKafkaHeaders();
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(kafkaHeaders);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(TENANT, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertEquals(USER_ID, headers.get(OKAPI_USER_HEADER));
+    assertEquals(REQUEST_ID, headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldConvertKafkaHeadersToOkapiHeadersWithoutOptionalHeaders() {
+    // Given
+    List<KafkaHeader> kafkaHeaders = List.of(
+      KafkaHeader.header(OKAPI_URL_HEADER, OKAPI_URL),
+      KafkaHeader.header(OKAPI_TENANT_HEADER, TENANT),
+      KafkaHeader.header(OKAPI_TOKEN_HEADER, TOKEN)
+    );
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(kafkaHeaders);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(TENANT, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertNull(headers.get(OKAPI_USER_HEADER));
+    assertNull(headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldConvertKafkaHeadersToOkapiHeadersWithTenantOverride() {
+    // Given
+    String overrideTenant = "override-tenant";
+    List<KafkaHeader> kafkaHeaders = createKafkaHeaders();
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(kafkaHeaders, overrideTenant);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(overrideTenant, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertEquals(USER_ID, headers.get(OKAPI_USER_HEADER));
+    assertEquals(REQUEST_ID, headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldConvertKafkaHeadersToOkapiHeadersWithNullTenantOverride() {
+    // Given
+    List<KafkaHeader> kafkaHeaders = createKafkaHeaders();
+
+    // When
+    Map<String, String> headers = EventHandlingUtil.toOkapiHeaders(kafkaHeaders, null);
+
+    // Then
+    assertEquals(OKAPI_URL, headers.get(OKAPI_URL_HEADER));
+    assertEquals(TENANT, headers.get(OKAPI_TENANT_HEADER));
+    assertEquals(TOKEN, headers.get(OKAPI_TOKEN_HEADER));
+    assertEquals(USER_ID, headers.get(OKAPI_USER_HEADER));
+    assertEquals(REQUEST_ID, headers.get(OKAPI_REQUEST_HEADER));
+  }
+
+  @Test
+  public void shouldCreateProducerRecordWithAllFields() {
+    // Given
+    String eventPayload = "{\"test\":\"data\"}";
+    String eventType = "TEST_EVENT";
+    String key = "test-key";
+    List<KafkaHeader> kafkaHeaders = createKafkaHeaders();
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    var producerRecord = EventHandlingUtil.createProducerRecord(
+      eventPayload, eventType, key, TENANT, kafkaHeaders, kafkaConfig);
+
+    // Then
+    assertNotNull(producerRecord);
+    assertEquals(key, producerRecord.key());
+    assertNotNull(producerRecord.value());
+    assertNotNull(producerRecord.topic());
+
+    // Verify the event value contains expected data (serialized as JSON string)
+    String value = producerRecord.value();
+    assertTrue(value.contains(eventType));
+    assertTrue(value.contains(TENANT));
+    assertTrue(value.contains("\"eventTTL\":1"));
+  }
+
+  @Test
+  public void shouldCreateProducerRecordWithDomainEventType() {
+    // Given
+    String eventPayload = "{\"recordId\":\"123\"}";
+    String eventType = "SOURCE_RECORD_CREATED";
+    String key = "record-123";
+    List<KafkaHeader> kafkaHeaders = new ArrayList<>();
+    KafkaConfig kafkaConfig = KafkaConfig.builder()
+      .envId(ENV)
+      .build();
+
+    // When
+    var producerRecord = EventHandlingUtil.createProducerRecord(
+      eventPayload, eventType, key, TENANT, kafkaHeaders, kafkaConfig);
+
+    // Then
+    assertNotNull(producerRecord);
+    String expectedTopic = KafkaTopicNameHelper.formatTopicName(ENV, TENANT, RECORD_DOMAIN_EVENT_TOPIC);
+    assertEquals(expectedTopic, producerRecord.topic());
+  }
+
+  private List<KafkaHeader> createKafkaHeaders() {
+    return List.of(
+      KafkaHeader.header(OKAPI_URL_HEADER, OKAPI_URL),
+      KafkaHeader.header(OKAPI_TENANT_HEADER, TENANT),
+      KafkaHeader.header(OKAPI_TOKEN_HEADER, TOKEN),
+      KafkaHeader.header(OKAPI_USER_HEADER, USER_ID),
+      KafkaHeader.header(OKAPI_REQUEST_HEADER, REQUEST_ID)
+    );
   }
 }


### PR DESCRIPTION
## Purpose
Include FOLIO Identifiers in Kafka Messages
https://folio-org.atlassian.net/browse/MODSOURCE-804

Include Job Execution Identifiers In Logs
https://folio-org.atlassian.net/browse/MODSOURCE-805

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
