### PR TITLE
MODSOURCE-978 - Data Import page unusable due to infinite loading (intermittent problem)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODSOURCE-962](https://folio-org.atlassian.net/browse/MODSOURCE-962) MARC Modifications fail for Updates
 * [MODSOURCE-964](https://folio-org.atlassian.net/browse/MODSOURCE-964) 003 is being deleted when overlaying a MARC authority record with Data Import
 * [MODSOURCE-936](https://folio-org.atlassian.net/browse/MODSOURCE-936) Upgrade module to Vert.x 5.0
+* [MODSOURCE-978](https://folio-org.atlassian.net/browse/MODSOURCE-978) Data Import page unusable due to infinite loading
 
 ## 2025-03-13 5.10.0
 * [MODSOURMAN-1278](https://folio-org.atlassian.net/browse/MODSOURMAN-1278) Data import job stuck in progress with 99-100%

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -648,7 +648,7 @@ public class RecordDaoImpl implements RecordDao {
 
   @Override
   public Future<Optional<Record>> getRecordById(String id, String tenantId) {
-    return getQueryExecutor(tenantId).transaction(queryExecutor -> getRecordById(getQueryExecutor(tenantId), id));
+    return getQueryExecutor(tenantId).transaction(queryExecutor -> getRecordById(queryExecutor, id));
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j.version>2.25.3</log4j.version>
     <raml-module-builder.version>36.0.0-SNAPSHOT</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <vertx.version>5.0.5</vertx.version>
+    <vertx.version>5.0.8</vertx.version>
     <junit.version>5.10.2</junit.version>
     <rest-assured.version>5.5.1</rest-assured.version>
     <kafkaclients.version>3.9.2</kafkaclients.version>


### PR DESCRIPTION
## Purpose
to prevent transactions from hanging during  multiple RecordDaoImpl.getRecordById() method calls

## Approach
* correct RecordDaoImpl::getRecordById method implementation to use provided transactional executor/connection
* upgrade Vertx to >= v5.0.6 to pick up the fix to honor pool connection timeout during query execution directly on the Pool (e.g. when Pool::preparedQuery is used)


## Learning
[MODSOURCE-978](https://issues.folio.org/browse/MODSOURCE-978)