### PR TITLE
MODSOURCE-989: Upgrade folio-kafka-wrapper to use Kafka 4.2

### DIFF
--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>5.0.0</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>4.0.0</version>
+      <version>4.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.jsqlparser</groupId>

--- a/mod-source-record-storage-server/pom.xml
+++ b/mod-source-record-storage-server/pom.xml
@@ -22,19 +22,19 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>toxiproxy</artifactId>
+      <artifactId>testcontainers-toxiproxy</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
@@ -221,7 +221,7 @@
   </dependencies>
 
   <properties>
-    <testcontainers.version>1.21.0</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <jooq.version>3.16.19</jooq.version>

--- a/mod-source-record-storage-server/src/test/java/org/folio/TestUtil.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/TestUtil.java
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 
 public final class TestUtil {
 
-  private static final DockerImageName KAFKA_CONTAINER_NAME = DockerImageName.parse("apache/kafka-native:3.8.0");
+  private static final DockerImageName KAFKA_CONTAINER_NAME = DockerImageName.parse("apache/kafka-native:4.2.0");
 
   @SuppressWarnings("resource")
   public static KafkaContainer getKafkaContainer() {

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
     <log4j.version>2.25.3</log4j.version>
     <raml-module-builder.version>36.0.0</raml-module-builder.version>
     <main.basedir>${project.basedir}</main.basedir>
-    <vertx.version>5.0.8</vertx.version>
+    <vertx.version>5.0.12</vertx.version>
     <junit.version>5.10.2</junit.version>
     <rest-assured.version>5.5.1</rest-assured.version>
-    <kafkaclients.version>3.9.2</kafkaclients.version>
+    <kafkaclients.version>4.2.0</kafkaclients.version>
     <spring.version>7.0.6</spring.version>
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <generate_routing_context>/source-storage/stream/records,/source-storage/stream/source-records,/source-storage/stream/marc-record-identifiers</generate_routing_context>


### PR DESCRIPTION
Upgrade vertx to 5.0.12