### PR TITLE
MODSOURMAN-1425: Fix - Timeout waiting for connection

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDao.java
@@ -340,6 +340,15 @@ public interface RecordDao {
   Future<Optional<SourceRecord>> getSourceRecordByCondition(Condition condition, String tenantId);
 
   /**
+   * Searches for {@link SourceRecord} by {@link Condition}
+   *
+   * @param queryExecutor  query execution
+   * @param condition query where condition
+   * @return return future with optional {@link SourceRecord}
+   */
+  Future<Optional<SourceRecord>> getSourceRecordByCondition(QueryExecutor queryExecutor, Condition condition);
+
+  /**
    * Searches for {@link SourceRecord} by external entity which was created from desired record by specific type.
    *
    * @param id             id
@@ -349,6 +358,17 @@ public interface RecordDao {
    * @return return future with optional {@link SourceRecord}
    */
   Future<Optional<SourceRecord>> getSourceRecordByExternalId(String id, IdType idType, RecordState state, String tenantId);
+
+  /**
+   * Searches for {@link SourceRecord} by external entity which was created from desired record by specific type.
+   *
+   * @param queryExecutor  query execution
+   * @param id             id
+   * @param idType external id type on which source record will be searched
+   * @param state external record state on which source record will be searched
+   * @return return future with optional {@link SourceRecord}
+   */
+  Future<Optional<SourceRecord>> getSourceRecordByExternalId(QueryExecutor queryExecutor, String id, IdType idType, RecordState state);
 
   /**
    * Deletes in transaction all records associated with specified snapshot and snapshot itself

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1163,22 +1163,30 @@ public class RecordDaoImpl implements RecordDao {
   }
 
   @Override
+  public Future<Optional<SourceRecord>> getSourceRecordByExternalId(QueryExecutor queryExecutor, String externalId, IdType idType, RecordState state) {
+    Condition condition = buildConditionBasedOnState(externalId, idType, state);
+    return getSourceRecordByCondition(queryExecutor, condition);
+  }
+
+  @Override
   public Future<Optional<SourceRecord>> getSourceRecordByCondition(Condition condition, String tenantId) {
     return getQueryExecutor(tenantId)
-      .transaction(queryExecutor -> RecordDaoUtil.findByCondition(queryExecutor, condition)
-        .compose(optionalRecord -> {
-          if (optionalRecord.isPresent()) {
-            return lookupAssociatedRecords(queryExecutor, optionalRecord.get(), false)
-              .map(RecordDaoUtil::toSourceRecord)
-              .map(sourceRecord -> {
-                if (Objects.nonNull(sourceRecord.getParsedRecord())) {
-                  return Optional.of(sourceRecord);
-                }
-                return Optional.empty();
-              });
-          }
+      .transaction(queryExecutor -> getSourceRecordByCondition(queryExecutor, condition));
+  }
+
+  @Override
+  public Future<Optional<SourceRecord>> getSourceRecordByCondition(QueryExecutor queryExecutor, Condition condition) {
+    return RecordDaoUtil.findByCondition(queryExecutor, condition)
+      .compose(optionalRecord -> {
+        if (optionalRecord.isEmpty()) {
           return Future.succeededFuture(Optional.empty());
-        }));
+        }
+        return lookupAssociatedRecords(queryExecutor, optionalRecord.get(), false)
+          .map(RecordDaoUtil::toSourceRecord)
+          .map(sourceRecord -> Objects.nonNull(sourceRecord.getParsedRecord())
+            ? Optional.of(sourceRecord)
+            : Optional.<SourceRecord>empty());
+      });
   }
 
   @Override

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/RecordServiceImpl.java
@@ -56,6 +56,7 @@ import org.folio.dao.util.ParsedRecordDaoUtil;
 import org.folio.dao.util.RecordDaoUtil;
 import org.folio.dao.util.RecordType;
 import org.folio.dao.util.SnapshotDaoUtil;
+import org.folio.dao.util.executor.QueryExecutor;
 import org.folio.dataimport.util.OkapiConnectionParams;
 import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.processing.value.ListValue;
@@ -154,7 +155,7 @@ public class RecordServiceImpl implements RecordService {
           }
           return Future.succeededFuture();
         })
-        .compose(v -> setMatchedIdForRecord(rec, tenantId))
+        .compose(v -> setMatchedIdForRecord(queryExecutor, rec))
         .compose(r -> {
           if (Objects.isNull(r.getGeneration())) {
             return recordDao.calculateGeneration(queryExecutor, r);
@@ -476,18 +477,24 @@ public class RecordServiceImpl implements RecordService {
   }
 
   private Future<Record> setMatchedIdForRecord(Record rec, String tenantId) {
-    String marcField999s = getFieldFromMarcRecord(rec, TAG_999, INDICATOR, INDICATOR, SUBFIELD_S);
-    if (marcField999s != null) {
-      // Set matched id from 999$s marc field
-      LOG.debug("setMatchedIdForRecord:: Set matchedId: {} from 999$s field for record with id: {}", marcField999s, rec.getId());
-      return Future.succeededFuture(rec.withMatchedId(marcField999s));
+    Optional<Record> fastResult = tryGetMatchedIdFrom999(rec);
+    if (fastResult.isPresent()) {
+      return Future.succeededFuture(fastResult.get());
+    }
+    return recordDao.executeInTransaction(queryExecutor -> setMatchedIdForRecord(queryExecutor, rec), tenantId);
+  }
+
+  private Future<Record> setMatchedIdForRecord(QueryExecutor queryExecutor, Record rec) {
+    Optional<Record> fastResult = tryGetMatchedIdFrom999(rec);
+    if (fastResult.isPresent()) {
+      return Future.succeededFuture(fastResult.get());
     }
     Promise<Record> promise = Promise.promise();
     String externalId = RecordDaoUtil.getExternalId(rec.getExternalIdsHolder(), rec.getRecordType());
     IdType idType = getExternalIdType(rec.getRecordType());
 
     if (externalId != null && idType != null && rec.getState() == Record.State.ACTUAL) {
-      setMatchedIdFromExistingSourceRecord(rec, tenantId, promise, externalId, idType);
+      setMatchedIdFromExistingSourceRecord(queryExecutor, rec, promise, externalId, idType);
     } else {
       // Set matched id same as record id
       promise.complete(rec.withMatchedId(rec.getId()));
@@ -500,8 +507,18 @@ public class RecordServiceImpl implements RecordService {
     });
   }
 
-  private void setMatchedIdFromExistingSourceRecord(Record rec, String tenantId, Promise<Record> promise, String externalId, IdType idType) {
-    recordDao.getSourceRecordByExternalId(externalId, idType, RecordState.ACTUAL, tenantId)
+  private static Optional<Record> tryGetMatchedIdFrom999(Record rec) {
+    String marcField999s = getFieldFromMarcRecord(rec, TAG_999, INDICATOR, INDICATOR, SUBFIELD_S);
+    if (marcField999s != null) {
+      // Set matched id from 999$s marc field
+      LOG.debug("setMatchedIdForRecord:: Set matchedId: {} from 999$s field for record with id: {}", marcField999s, rec.getId());
+      return Optional.of(rec.withMatchedId(marcField999s));
+    }
+    return Optional.empty();
+  }
+
+  private void setMatchedIdFromExistingSourceRecord(QueryExecutor queryExecutor, Record rec, Promise<Record> promise, String externalId, IdType idType) {
+    recordDao.getSourceRecordByExternalId(queryExecutor, externalId, idType, RecordState.ACTUAL)
       .onComplete(ar -> {
         if (ar.succeeded()) {
           Optional<SourceRecord> sourceRecord = ar.result();


### PR DESCRIPTION
## Purpose
Some MARC authority records are not created in each data import chunk when importing 10k records using an update + create job profile (about 30 records in each chunk are not created because of the following errors:
"io.vertx.core.impl.NoStackTraceThrowable: Timeout")

## Approach
The use of 2 connections in a single transaction was fixed (RecordDaoImpl.getSourceRecordByCondition - a new database connection was requested each time)

## Learning
[MODSOURMAN-1425](https://folio-org.atlassian.net/browse/MODSOURMAN-1425)
