### PR TITLE
MODAUD-247: Update of Linked MARC bib field triggered by MARC authority update is not tracked by Audit log

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -741,7 +741,7 @@ public class RecordDaoImpl implements RecordDao {
             // Store old records for later event publishing
             // Debug: log all records before storing old records
             records.forEach(r -> LOG.debug("saveRecordsByExternalIds:: OLD record - ID: {}, matched_id: {}, generation: {}, state: {}, parsedRecord: {}",
-              r.getId(), r.getMatchedId(), r.getGeneration(), r.getState(), r.getParsedRecord() != null ? "present" : "null"));
+              r.getId(), r.getMatchedId(), r.getGeneration(), r.getState(), r.getParsedRecord() != null ? r.getParsedRecord().getFormattedContent() : "null"));
 
             oldRecordsHolder.addAll(records);
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1473,12 +1473,8 @@ public class RecordDaoImpl implements RecordDao {
       .compose(optionalRecord -> optionalRecord
         .map(existingRecord -> insertOrUpdateRecord(queryExecutor, oldRecord)
           .compose(r -> insertOrUpdateRecord(queryExecutor, newRecord))
-          .compose(updatedRecord -> {
-            // Publish event using the actual database state before update (existingRecord),
-            // not the parameter (oldRecord), to ensure correct old version is sent to audit
-            recordDomainEventPublisher.publishRecordUpdated(existingRecord, updatedRecord, okapiHeaders);
-            return Future.succeededFuture(updatedRecord);
-          }))
+          .onSuccess(updatedRecord ->
+            recordDomainEventPublisher.publishRecordUpdated(existingRecord, updatedRecord, okapiHeaders)))
         .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_TEMPLATE, oldRecord.getId())))));
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -732,32 +732,10 @@ public class RecordDaoImpl implements RecordDao {
             var records = queryResult.fetch(this::toRecord);
 
             LOG.debug("saveRecordsByExternalIds:: Fetched {} old records from DB", records.size());
-            if (!records.isEmpty()) {
-              records.forEach(r -> LOG.debug("  - Record ID: {}, matched_id: {}, generation: {}, state: {}",
-                r.getId(), r.getMatchedId(), r.getGeneration(), r.getState()));
-            }
-
             if (CollectionUtils.isEmpty(records)) {
               LOG.warn("saveRecordsByExternalIds:: No records returned from the fetch query");
               return new RecordsBatchResponse().withTotalRecords(0);
             }
-
-            // Store old records for later event publishing
-            // Debug: log all records before storing old records
-            records.forEach(r -> LOG.debug(
-              "saveRecordsByExternalIds:: OLD record - id: {}, snapshotId: {}, matchedId: {}, generation: {}, "
-                + "recordType: {}, state: {}, order: {}, deleted: {}, leaderRecordStatus: {}, "
-                + "externalIdsHolder: {}, additionalInfo: {}, metadata: {}, "
-                + "rawRecord: {}, parsedRecord.id: {}, parsedRecord.formattedContent: {}, parsedRecord.content: {}, "
-                + "errorRecord: {}",
-              r.getId(), r.getSnapshotId(), r.getMatchedId(), r.getGeneration(),
-              r.getRecordType(), r.getState(), r.getOrder(), r.getDeleted(), r.getLeaderRecordStatus(),
-              r.getExternalIdsHolder(), r.getAdditionalInfo(), r.getMetadata(),
-              r.getRawRecord() != null ? r.getRawRecord().getId() : "null",
-              r.getParsedRecord() != null ? r.getParsedRecord().getId() : "null",
-              r.getParsedRecord() != null ? r.getParsedRecord().getFormattedContent() : "null",
-              r.getParsedRecord() != null ? r.getParsedRecord().getContent() : "null",
-              r.getErrorRecord() != null ? r.getErrorRecord().getId() : "null"));
 
             // Deep-clone old records via Jackson tree conversion so that later mutations
             // by recordsModifier do not affect the snapshot used for UPDATE events.
@@ -765,19 +743,9 @@ public class RecordDaoImpl implements RecordDao {
             for (Record r : records) {
               oldRecordsHolder.add(OBJECT_MAPPER.convertValue(r, Record.class));
             }
-            LOG.debug("saveRecordsByExternalIds:: Stored {} old records in holder", oldRecordsHolder.size());
 
             var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());
             var modifiedRecords = recordsModifier.apply(existingRecordsCollection);
-
-            LOG.debug("saveRecordsByExternalIds:: Applied recordsModifier to records, modified count: {}", modifiedRecords.getTotalRecords());
-            modifiedRecords.getRecords().forEach(r -> {
-              LOG.debug("  - Modified Record ID: {}, matched_id: {}, generation: {}",
-                r.getId(), r.getMatchedId(), r.getGeneration());
-              if (r.getParsedRecord() != null && r.getParsedRecord().getContent() != null) {
-                LOG.debug("    ParsedRecord content updated");
-              }
-            });
 
             // validate snapshot
             var snapshotId = modifiedRecords.getRecords().getFirst().getSnapshotId();
@@ -801,12 +769,9 @@ public class RecordDaoImpl implements RecordDao {
             LOG.info("saveRecordsByExternalIds:: recordCollection: {}", modifiedRecords.getTotalRecords());
             persistDatabaseRecords(dsl, recordType, matchedIds, dbRecords, dbRawRecords, dbParsedRecords, dbErrorRecords);
 
-            LOG.debug("saveRecordsByExternalIds:: Persisted {} records to DB", dbRecords.size());
-
             // return result
             queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
             records = queryResult.fetch(this::toRecord);
-            LOG.debug("saveRecordsByExternalIds:: Re-fetched {} records from DB after persistence", records.size());
 
             return new RecordsBatchResponse()
               .withRecords(records)
@@ -823,36 +788,24 @@ public class RecordDaoImpl implements RecordDao {
       }
     ).map(response -> {
         LOG.debug("saveRecordsByExternalIds:: batch record save was successful");
-        // Use publishRecordUpdated instead of publishRecordCreated
-        // Pair old and new records for proper event publishing
+        // This method only serves UPDATE flows (see AuthorityLinkChunkKafkaHandler),
+        // so every saved record has a pre-modification snapshot in oldRecordsHolder
+        // and must be published as an UPDATE event.
         var newRecords = response.getRecords();
-        if (!newRecords.isEmpty() && !oldRecordsHolder.isEmpty()) {
-          LOG.debug("saveRecordsByExternalIds:: Publishing events for {} new records, {} old records in holder",
-            newRecords.size(), oldRecordsHolder.size());
-          // Create a map of old records by matched ID for pairing
+        if (!newRecords.isEmpty()) {
           Map<String, Record> oldRecordsMap = oldRecordsHolder.stream()
             .collect(Collectors.toMap(r -> r.getMatchedId() != null ? r.getMatchedId() : r.getId(),
                                       Function.identity(), (existing, replacement) -> existing));
           newRecords.forEach(newRecord -> {
             String key = newRecord.getMatchedId() != null ? newRecord.getMatchedId() : newRecord.getId();
             Record oldRecord = oldRecordsMap.get(key);
-            LOG.debug("saveRecordsByExternalIds:: Processing record pair - key: {}", key);
-            if (oldRecord != null) {
-              LOG.debug("saveRecordsByExternalIds:: Publishing UPDATE event for record: {}", key);
-              LOG.debug("    -> Publishing UPDATE event");
-              LOG.debug("       Old record - ID: {}, generation: {}, parsedRecord.content: {}",
-                oldRecord.getId(), oldRecord.getGeneration(), oldRecord.getParsedRecord() != null ? oldRecord.getParsedRecord().getContent() : "null");
-              LOG.debug("       New record - ID: {}, generation: {}, parsedRecord.content: {}",
-                newRecord.getId(), newRecord.getGeneration(), newRecord.getParsedRecord() != null ? newRecord.getParsedRecord().getContent() : "null");
-              recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
-            } else {
-              LOG.warn("saveRecordsByExternalIds:: Could not find old record for new record with key: {}", key);
-              LOG.debug("    -> Publishing CREATE event (old record not found)");
-              recordDomainEventPublisher.publishRecordCreated(newRecord, okapiHeaders);
+            if (oldRecord == null) {
+              LOG.warn("saveRecordsByExternalIds:: No pre-modification snapshot for new record with key: {}, skipping event publication", key);
+              return;
             }
+            recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
           });
         }
-        LOG.debug("saveRecordsByExternalIds:: Completed successfully with {} event(s) published", newRecords.size());
         return response;
       })
       .onFailure(e -> LOG.warn("saveRecordsByExternalIds:: Error during batch record save", e));

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -740,8 +740,20 @@ public class RecordDaoImpl implements RecordDao {
 
             // Store old records for later event publishing
             // Debug: log all records before storing old records
-            records.forEach(r -> LOG.debug("saveRecordsByExternalIds:: OLD record - ID: {}, matched_id: {}, generation: {}, state: {}, parsedRecord: {}",
-              r.getId(), r.getMatchedId(), r.getGeneration(), r.getState(), r.getParsedRecord() != null ? r.getParsedRecord().getFormattedContent() : "null"));
+            records.forEach(r -> LOG.debug(
+              "saveRecordsByExternalIds:: OLD record - id: {}, snapshotId: {}, matchedId: {}, generation: {}, "
+                + "recordType: {}, state: {}, order: {}, deleted: {}, leaderRecordStatus: {}, "
+                + "externalIdsHolder: {}, additionalInfo: {}, metadata: {}, "
+                + "rawRecord: {}, parsedRecord.id: {}, parsedRecord.formattedContent: {}, parsedRecord.content: {}, "
+                + "errorRecord: {}",
+              r.getId(), r.getSnapshotId(), r.getMatchedId(), r.getGeneration(),
+              r.getRecordType(), r.getState(), r.getOrder(), r.getDeleted(), r.getLeaderRecordStatus(),
+              r.getExternalIdsHolder(), r.getAdditionalInfo(), r.getMetadata(),
+              r.getRawRecord() != null ? r.getRawRecord().getId() : "null",
+              r.getParsedRecord() != null ? r.getParsedRecord().getId() : "null",
+              r.getParsedRecord() != null ? r.getParsedRecord().getFormattedContent() : "null",
+              r.getParsedRecord() != null ? r.getParsedRecord().getContent() : "null",
+              r.getErrorRecord() != null ? r.getErrorRecord().getId() : "null"));
 
             oldRecordsHolder.addAll(records);
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -739,6 +739,10 @@ public class RecordDaoImpl implements RecordDao {
             }
 
             // Store old records for later event publishing
+            // Debug: log all records before storing old records
+            records.forEach(r -> LOG.debug("saveRecordsByExternalIds:: OLD record - ID: {}, matched_id: {}, generation: {}, state: {}, parsedRecord: {}",
+              r.getId(), r.getMatchedId(), r.getGeneration(), r.getState(), r.getParsedRecord() != null ? "present" : "null"));
+
             oldRecordsHolder.addAll(records);
 
             LOG.debug("saveRecordsByExternalIds:: Stored {} old records in holder", oldRecordsHolder.size());
@@ -748,7 +752,7 @@ public class RecordDaoImpl implements RecordDao {
 
             LOG.debug("saveRecordsByExternalIds:: Applied recordsModifier to records, modified count: {}", modifiedRecords.getTotalRecords());
             modifiedRecords.getRecords().forEach(r -> {
-              LOG.debug("  - Modified Record ID: {}, matched_id: {}, generation: {}", 
+              LOG.debug("  - Modified Record ID: {}, matched_id: {}, generation: {}",
                 r.getId(), r.getMatchedId(), r.getGeneration());
               if (r.getParsedRecord() != null && r.getParsedRecord().getContent() != null) {
                 LOG.debug("    ParsedRecord content updated");

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -705,6 +705,7 @@ public class RecordDaoImpl implements RecordDao {
                                                                RecordType recordType,
                                                                RecordsModifierOperator recordsModifier,
                                                                Map<String, String> okapiHeaders) {
+    LOG.debug("saveRecordsByExternalIds:: Starting processing for external IDs: {}", externalIds);
     var condition = RecordDaoUtil.getExternalIdsCondition(externalIds,
         getExternalIdType(Record.RecordType.fromValue(recordType.name())))
       .and(RecordDaoUtil.filterRecordByDeleted(false));
@@ -726,6 +727,12 @@ public class RecordDaoImpl implements RecordDao {
             var queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
             var records = queryResult.fetch(this::toRecord);
 
+            LOG.debug("saveRecordsByExternalIds:: Fetched {} old records from DB", records.size());
+            if (!records.isEmpty()) {
+              records.forEach(r -> LOG.debug("  - Record ID: {}, matched_id: {}, generation: {}, state: {}",
+                r.getId(), r.getMatchedId(), r.getGeneration(), r.getState()));
+            }
+
             if (CollectionUtils.isEmpty(records)) {
               LOG.warn("saveRecordsByExternalIds:: No records returned from the fetch query");
               return new RecordsBatchResponse().withTotalRecords(0);
@@ -734,8 +741,19 @@ public class RecordDaoImpl implements RecordDao {
             // Store old records for later event publishing
             oldRecordsHolder.addAll(records);
 
+            LOG.debug("saveRecordsByExternalIds:: Stored {} old records in holder", oldRecordsHolder.size());
+
             var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());
             var modifiedRecords = recordsModifier.apply(existingRecordsCollection);
+
+            LOG.debug("saveRecordsByExternalIds:: Applied recordsModifier to records, modified count: {}", modifiedRecords.getTotalRecords());
+            modifiedRecords.getRecords().forEach(r -> {
+              LOG.debug("  - Modified Record ID: {}, matched_id: {}, generation: {}", 
+                r.getId(), r.getMatchedId(), r.getGeneration());
+              if (r.getParsedRecord() != null && r.getParsedRecord().getContent() != null) {
+                LOG.debug("    ParsedRecord content updated");
+              }
+            });
 
             // validate snapshot
             var snapshotId = modifiedRecords.getRecords().getFirst().getSnapshotId();
@@ -759,9 +777,13 @@ public class RecordDaoImpl implements RecordDao {
             LOG.info("saveRecordsByExternalIds:: recordCollection: {}", modifiedRecords.getTotalRecords());
             persistDatabaseRecords(dsl, recordType, matchedIds, dbRecords, dbRawRecords, dbParsedRecords, dbErrorRecords);
 
+            LOG.debug("saveRecordsByExternalIds:: Persisted {} records to DB", dbRecords.size());
+
             // return result
             queryResult = readRecords(dsl, condition, recordType, 0, externalIds.size(), false, emptyList());
             records = queryResult.fetch(this::toRecord);
+            LOG.debug("saveRecordsByExternalIds:: Re-fetched {} records from DB after persistence", records.size());
+
             return new RecordsBatchResponse()
               .withRecords(records)
               .withTotalRecords(records.size())
@@ -781,6 +803,8 @@ public class RecordDaoImpl implements RecordDao {
         // Pair old and new records for proper event publishing
         var newRecords = response.getRecords();
         if (!newRecords.isEmpty() && !oldRecordsHolder.isEmpty()) {
+          LOG.debug("saveRecordsByExternalIds:: Publishing events for {} new records, {} old records in holder",
+            newRecords.size(), oldRecordsHolder.size());
           // Create a map of old records by matched ID for pairing
           Map<String, Record> oldRecordsMap = oldRecordsHolder.stream()
             .collect(Collectors.toMap(r -> r.getMatchedId() != null ? r.getMatchedId() : r.getId(),
@@ -788,15 +812,21 @@ public class RecordDaoImpl implements RecordDao {
           newRecords.forEach(newRecord -> {
             String key = newRecord.getMatchedId() != null ? newRecord.getMatchedId() : newRecord.getId();
             Record oldRecord = oldRecordsMap.get(key);
+            LOG.debug("saveRecordsByExternalIds:: Processing record pair - key: {}", key);
             if (oldRecord != null) {
               LOG.debug("saveRecordsByExternalIds:: Publishing UPDATE event for record: {}", key);
+              LOG.debug("    -> Publishing UPDATE event");
+              LOG.debug("       Old record - ID: {}, generation: {}", oldRecord.getId(), oldRecord.getGeneration());
+              LOG.debug("       New record - ID: {}, generation: {}", newRecord.getId(), newRecord.getGeneration());
               recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
             } else {
               LOG.warn("saveRecordsByExternalIds:: Could not find old record for new record with key: {}", key);
+              LOG.debug("    -> Publishing CREATE event (old record not found)");
               recordDomainEventPublisher.publishRecordCreated(newRecord, okapiHeaders);
             }
           });
         }
+        LOG.debug("saveRecordsByExternalIds:: Completed successfully with {} event(s) published", newRecords.size());
         return response;
       })
       .onFailure(e -> LOG.warn("saveRecordsByExternalIds:: Error during batch record save", e));

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -832,8 +832,10 @@ public class RecordDaoImpl implements RecordDao {
             if (oldRecord != null) {
               LOG.debug("saveRecordsByExternalIds:: Publishing UPDATE event for record: {}", key);
               LOG.debug("    -> Publishing UPDATE event");
-              LOG.debug("       Old record - ID: {}, generation: {}", oldRecord.getId(), oldRecord.getGeneration());
-              LOG.debug("       New record - ID: {}, generation: {}", newRecord.getId(), newRecord.getGeneration());
+              LOG.debug("       Old record - ID: {}, generation: {}, parsedRecord.content: {}",
+                oldRecord.getId(), oldRecord.getGeneration(), oldRecord.getParsedRecord() != null ? oldRecord.getParsedRecord().getContent() : "null");
+              LOG.debug("       New record - ID: {}, generation: {}, parsedRecord.content: {}",
+                newRecord.getId(), newRecord.getGeneration(), newRecord.getParsedRecord() != null ? newRecord.getParsedRecord().getContent() : "null");
               recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
             } else {
               LOG.warn("saveRecordsByExternalIds:: Could not find old record for new record with key: {}", key);

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -715,6 +715,9 @@ public class RecordDaoImpl implements RecordDao {
       return Future.failedFuture("saveRecordsByExternalIds:: operation must be executed by a Vertx thread");
     }
 
+    // Store old records in a holder so we can access them later for publishing UPDATE events
+    List<Record> oldRecordsHolder = new ArrayList<>();
+
     return context.owner().executeBlocking(
       () -> {
         try (Connection connection = getConnection(tenantId)) {
@@ -727,6 +730,10 @@ public class RecordDaoImpl implements RecordDao {
               LOG.warn("saveRecordsByExternalIds:: No records returned from the fetch query");
               return new RecordsBatchResponse().withTotalRecords(0);
             }
+
+            // Store old records for later event publishing
+            oldRecordsHolder.addAll(records);
+
             var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());
             var modifiedRecords = recordsModifier.apply(existingRecordsCollection);
 
@@ -768,11 +775,28 @@ public class RecordDaoImpl implements RecordDao {
           throw e;
         }
       }
-    )
-      .map(response -> {
+    ).map(response -> {
         LOG.debug("saveRecordsByExternalIds:: batch record save was successful");
-        response.getRecords()
-          .forEach(r -> recordDomainEventPublisher.publishRecordCreated(r, okapiHeaders));
+        // Use publishRecordUpdated instead of publishRecordCreated
+        // Pair old and new records for proper event publishing
+        var newRecords = response.getRecords();
+        if (!newRecords.isEmpty() && !oldRecordsHolder.isEmpty()) {
+          // Create a map of old records by matched ID for pairing
+          Map<String, Record> oldRecordsMap = oldRecordsHolder.stream()
+            .collect(Collectors.toMap(r -> r.getMatchedId() != null ? r.getMatchedId() : r.getId(),
+                                      Function.identity(), (existing, replacement) -> existing));
+          newRecords.forEach(newRecord -> {
+            String key = newRecord.getMatchedId() != null ? newRecord.getMatchedId() : newRecord.getId();
+            Record oldRecord = oldRecordsMap.get(key);
+            if (oldRecord != null) {
+              LOG.debug("saveRecordsByExternalIds:: Publishing UPDATE event for record: {}", key);
+              recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
+            } else {
+              LOG.warn("saveRecordsByExternalIds:: Could not find old record for new record with key: {}", key);
+              recordDomainEventPublisher.publishRecordCreated(newRecord, okapiHeaders);
+            }
+          });
+        }
         return response;
       })
       .onFailure(e -> LOG.warn("saveRecordsByExternalIds:: Error during batch record save", e));

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1496,7 +1496,7 @@ public class RecordDaoImpl implements RecordDao {
         .map(existingRecord -> insertOrUpdateRecord(queryExecutor, oldRecord)
           .compose(r -> insertOrUpdateRecord(queryExecutor, newRecord))
           .onSuccess(updatedRecord ->
-            recordDomainEventPublisher.publishRecordUpdated(existingRecord, updatedRecord, okapiHeaders)))
+            recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders)))
         .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_TEMPLATE, oldRecord.getId())))));
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -41,6 +41,8 @@ import static org.jooq.impl.DSL.table;
 import static org.jooq.impl.DSL.trueCondition;
 import static org.jooq.impl.DSL.with;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.vertx.core.Context;
@@ -99,6 +101,7 @@ import org.folio.dao.util.RecordDaoUtil;
 import org.folio.dao.util.RecordType;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.dao.util.TenantUtil;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.kafka.exception.DuplicateEventException;
 import org.folio.processing.value.ListValue;
 import org.folio.processing.value.MissingValue;
@@ -166,6 +169,7 @@ import org.springframework.stereotype.Component;
 public class RecordDaoImpl implements RecordDao {
 
   private static final Logger LOG = LogManager.getLogger();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperTool.getMapper();
 
   private static final String CTE = "cte";
   private static final String FILTERED_RECORDS = "filtered_records";
@@ -755,8 +759,12 @@ public class RecordDaoImpl implements RecordDao {
               r.getParsedRecord() != null ? r.getParsedRecord().getContent() : "null",
               r.getErrorRecord() != null ? r.getErrorRecord().getId() : "null"));
 
-            oldRecordsHolder.addAll(records);
-
+            // Deep-clone old records via Jackson tree conversion so that later mutations
+            // by recordsModifier do not affect the snapshot used for UPDATE events.
+            // convertValue avoids the intermediate byte[] serialization used before.
+            for (Record r : records) {
+              oldRecordsHolder.add(OBJECT_MAPPER.convertValue(r, Record.class));
+            }
             LOG.debug("saveRecordsByExternalIds:: Stored {} old records in holder", oldRecordsHolder.size());
 
             var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -739,7 +739,6 @@ public class RecordDaoImpl implements RecordDao {
 
             // Deep-clone old records via Jackson tree conversion so that later mutations
             // by recordsModifier do not affect the snapshot used for UPDATE events.
-            // convertValue avoids the intermediate byte[] serialization used before.
             for (Record r : records) {
               oldRecordsHolder.add(OBJECT_MAPPER.convertValue(r, Record.class));
             }

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -720,8 +720,9 @@ public class RecordDaoImpl implements RecordDao {
       return Future.failedFuture("saveRecordsByExternalIds:: operation must be executed by a Vertx thread");
     }
 
-    // Store old records in a holder so we can access them later for publishing UPDATE events
-    List<Record> oldRecordsHolder = new ArrayList<>();
+    // Store pre-modification snapshots keyed by matchedId so we can pair them with new records
+    // for UPDATE event publication after the transaction commits.
+    Map<String, Record> oldRecordsByKey = new HashMap<>();
 
     return context.owner().executeBlocking(
       () -> {
@@ -738,9 +739,12 @@ public class RecordDaoImpl implements RecordDao {
             }
 
             // Deep-clone old records via Jackson tree conversion so that later mutations
-            // by recordsModifier do not affect the snapshot used for UPDATE events.
+            // by recordsModifier do not affect the snapshot used for UPDATE events, and
+            // index them by matchedId in the same pass for O(1) pairing below.
+            // putIfAbsent: on the theoretical duplicate matchedId, the first clone wins.
             for (Record r : records) {
-              oldRecordsHolder.add(OBJECT_MAPPER.convertValue(r, Record.class));
+              Record clone = OBJECT_MAPPER.convertValue(r, Record.class);
+              oldRecordsByKey.putIfAbsent(recordKey(clone), clone);
             }
 
             var existingRecordsCollection = new RecordCollection().withRecords(records).withTotalRecords(records.size());
@@ -788,23 +792,17 @@ public class RecordDaoImpl implements RecordDao {
     ).map(response -> {
         LOG.debug("saveRecordsByExternalIds:: batch record save was successful");
         // This method only serves UPDATE flows (see AuthorityLinkChunkKafkaHandler),
-        // so every saved record has a pre-modification snapshot in oldRecordsHolder
+        // so every saved record has a pre-modification snapshot in oldRecordsByKey
         // and must be published as an UPDATE event.
-        var newRecords = response.getRecords();
-        if (!newRecords.isEmpty()) {
-          Map<String, Record> oldRecordsMap = oldRecordsHolder.stream()
-            .collect(Collectors.toMap(r -> r.getMatchedId() != null ? r.getMatchedId() : r.getId(),
-                                      Function.identity(), (existing, replacement) -> existing));
-          newRecords.forEach(newRecord -> {
-            String key = newRecord.getMatchedId() != null ? newRecord.getMatchedId() : newRecord.getId();
-            Record oldRecord = oldRecordsMap.get(key);
-            if (oldRecord == null) {
-              LOG.warn("saveRecordsByExternalIds:: No pre-modification snapshot for new record with key: {}, skipping event publication", key);
-              return;
-            }
-            recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
-          });
-        }
+        response.getRecords().forEach(newRecord -> {
+          String key = recordKey(newRecord);
+          Record oldRecord = oldRecordsByKey.get(key);
+          if (oldRecord == null) {
+            LOG.warn("saveRecordsByExternalIds:: No pre-modification snapshot for new record with key: {}, skipping event publication", key);
+            return;
+          }
+          recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders);
+        });
         return response;
       })
       .onFailure(e -> LOG.warn("saveRecordsByExternalIds:: Error during batch record save", e));
@@ -1972,6 +1970,15 @@ public class RecordDaoImpl implements RecordDao {
       recordDto.setErrorRecord(errorRecord);
     }
     return recordDto;
+  }
+
+  /**
+   * Key used to pair pre-modification and post-modification versions of the same logical record.
+   * matchedId is stable across generations; id is a per-version identifier used as a fallback
+   * only for the rare case where matchedId is not populated.
+   */
+  private static String recordKey(Record record) {
+    return record.getMatchedId() != null ? record.getMatchedId() : record.getId();
   }
 
   private Record toRecord(org.jooq.Record dbRecord) {

--- a/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/dao/RecordDaoImpl.java
@@ -1495,8 +1495,12 @@ public class RecordDaoImpl implements RecordDao {
       .compose(optionalRecord -> optionalRecord
         .map(existingRecord -> insertOrUpdateRecord(queryExecutor, oldRecord)
           .compose(r -> insertOrUpdateRecord(queryExecutor, newRecord))
-          .onSuccess(updatedRecord ->
-            recordDomainEventPublisher.publishRecordUpdated(oldRecord, newRecord, okapiHeaders)))
+          .compose(updatedRecord -> {
+            // Publish event using the actual database state before update (existingRecord),
+            // not the parameter (oldRecord), to ensure correct old version is sent to audit
+            recordDomainEventPublisher.publishRecordUpdated(existingRecord, updatedRecord, okapiHeaders);
+            return Future.succeededFuture(updatedRecord);
+          }))
         .orElse(Future.failedFuture(new NotFoundException(format(RECORD_NOT_FOUND_TEMPLATE, oldRecord.getId())))));
   }
 

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
@@ -51,13 +51,16 @@ public class RecordDomainEventPublisher {
   }
 
   private void publishRecord(DomainEventPayload domainEventPayload, Map<String, String> okapiHeaders, SourceRecordDomainEventType eventType) {
+    LOG.debug("publishRecord:: Publishing {} event for record", eventType);
     if (!domainEventsEnabled || notValidForPublishing(domainEventPayload)) {
+      LOG.info("publishRecord:: Skipping publication - domainEventsEnabled: {}, isValid: {}", domainEventsEnabled, !notValidForPublishing(domainEventPayload));
       return;
     }
     try {
       Record aRecord = domainEventPayload.newRecord() != null ? domainEventPayload.newRecord() : domainEventPayload.oldRecord();
       var kafkaHeaders = getKafkaHeaders(okapiHeaders, aRecord.getRecordType());
       var key = aRecord.getId();
+      LOG.info("publishRecord:: Sending event to Kafka - recordId: {}, eventType: {}", key, eventType);
       kafkaSender.sendEventToKafka(okapiHeaders.get(OKAPI_TENANT_HEADER), Json.encode(domainEventPayload),
         eventType.name(), kafkaHeaders, key);
     } catch (Exception e) {
@@ -66,6 +69,9 @@ public class RecordDomainEventPublisher {
   }
 
   private boolean notValidForPublishing(DomainEventPayload domainEventPayload) {
+    LOG.debug("notValidForPublishing:: Checking - oldRecord: {}, newRecord: {}",
+      domainEventPayload.oldRecord() != null ? "NOT_NULL" : "NULL",
+      domainEventPayload.newRecord() != null ? "NOT_NULL" : "NULL");
     if (domainEventPayload.newRecord() == null && domainEventPayload.oldRecord() == null) {
       LOG.warn("Old and new records are null and won't be sent as domain event");
       return true;
@@ -78,19 +84,19 @@ public class RecordDomainEventPublisher {
 
   private static boolean notValidRecord(Record aRecord) {
     if (isNull(aRecord)) {
-      LOG.warn("Record is null and won't be sent as domain event");
+      LOG.warn("Record is null - REASON: aRecord is NULL");
       return true;
     }
     if (isNull(aRecord.getRecordType())) {
-      LOG.warn("Record [with id {}] contains no type information and won't be sent as domain event", aRecord.getId());
+      LOG.warn("Record [with id {}] contains no type information - REASON: getRecordType() returned null", aRecord.getId());
       return true;
     }
     if (isNull(aRecord.getParsedRecord())) {
-      LOG.warn("Record [with id {}] contains no parsed record and won't be sent as domain event", aRecord.getId());
+      LOG.warn("Record [with id {}] contains no parsed record - REASON: getParsedRecord() returned null", aRecord.getId());
       return true;
     }
     if (isNull(aRecord.getParsedRecord().getContent())) {
-      LOG.warn("Record [with id {}] contains no parsed record content and won't be sent as domain event",
+      LOG.warn("Record [with id {}] contains no parsed record content - REASON: getContent() returned null",
         aRecord.getId());
       return true;
     }

--- a/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/domainevent/RecordDomainEventPublisher.java
@@ -60,7 +60,7 @@ public class RecordDomainEventPublisher {
       Record aRecord = domainEventPayload.newRecord() != null ? domainEventPayload.newRecord() : domainEventPayload.oldRecord();
       var kafkaHeaders = getKafkaHeaders(okapiHeaders, aRecord.getRecordType());
       var key = aRecord.getId();
-      LOG.info("publishRecord:: Sending event to Kafka - recordId: {}, eventType: {}", key, eventType);
+      LOG.debug("publishRecord:: Sending event to Kafka - recordId: {}, eventType: {}", key, eventType);
       kafkaSender.sendEventToKafka(okapiHeaders.get(OKAPI_TENANT_HEADER), Json.encode(domainEventPayload),
         eventType.name(), kafkaHeaders, key);
     } catch (Exception e) {

--- a/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/dao/RecordDaoImplTest.java
@@ -4,13 +4,21 @@ import static org.folio.dao.RecordDaoImpl.INDEXERS_DELETION_LOCK_NAMESPACE_ID;
 import static org.folio.rest.jaxrs.model.Record.State.ACTUAL;
 import static org.folio.rest.jaxrs.model.Record.State.DELETED;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +29,7 @@ import org.folio.TestUtil;
 import org.folio.dao.util.AdvisoryLockUtil;
 import org.folio.dao.util.IdType;
 import org.folio.dao.util.MatchField;
+import org.folio.dao.util.RecordType;
 import org.folio.dao.util.SnapshotDaoUtil;
 import org.folio.processing.value.MissingValue;
 import org.folio.processing.value.StringValue;
@@ -28,19 +37,26 @@ import org.folio.rest.jaxrs.model.ExternalIdsHolder;
 import org.folio.rest.jaxrs.model.ParsedRecord;
 import org.folio.rest.jaxrs.model.RawRecord;
 import org.folio.rest.jaxrs.model.Record;
+import org.folio.rest.jaxrs.model.RecordsBatchResponse;
 import org.folio.rest.jaxrs.model.Snapshot;
 import org.folio.services.AbstractLBServiceTest;
 import org.folio.services.domainevent.RecordDomainEventPublisher;
+import org.folio.services.entities.RecordsModifierOperator;
 import org.folio.services.util.TypeConnection;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(VertxUnitRunner.class)
 public class RecordDaoImplTest extends AbstractLBServiceTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @Mock
   private RecordDomainEventPublisher recordDomainEventPublisher;
@@ -225,4 +241,128 @@ public class RecordDaoImplTest extends AbstractLBServiceTest {
     });
   }
 
+
+  @Test
+  public void shouldPublishRecordUpdatedWithPreModificationSnapshotWhenSavingByExternalIds(TestContext context) {
+    Async async = context.async();
+    // Build a self-contained fixture on a COMMITTED snapshot so that persistDatabaseRecords()
+    // will mark the previous version as OLD (its lookup filters by committed snapshots only)
+    // and the re-fetch inside the DAO returns strictly the freshly saved version.
+    Snapshot committedSnapshot = new Snapshot()
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withProcessingStartedDate(new Date())
+      .withStatus(Snapshot.Status.COMMITTED);
+    String seedRecordId = UUID.randomUUID().toString();
+    String seedExternalId = UUID.randomUUID().toString();
+    String originalContent = TestUtil.readFileFromPath(PARSED_MARC_RECORD_CONTENT_SAMPLE_PATH);
+    // Replace a controlled field value inside the MARC JSON so that the content stays
+    // structurally valid and formatRecord() does not fall back to an ErrorRecord.
+    String originalMarker = "20141107001016.0";
+    String modifiedMarker = "20990101000000.0";
+    context.assertTrue(originalContent.contains(originalMarker));
+    String modifiedContent = originalContent.replace(originalMarker, modifiedMarker);
+    Record seedRecord = new Record()
+      .withId(seedRecordId)
+      .withState(ACTUAL)
+      .withMatchedId(seedRecordId)
+      .withSnapshotId(committedSnapshot.getJobExecutionId())
+      .withGeneration(0)
+      .withRecordType(Record.RecordType.MARC_BIB)
+      .withRawRecord(new RawRecord().withId(seedRecordId).withContent(rawRecord.getContent()))
+      .withParsedRecord(new ParsedRecord().withId(seedRecordId).withContent(originalContent))
+      .withExternalIdsHolder(new ExternalIdsHolder().withInstanceId(seedExternalId));
+
+    Snapshot updateSnapshot = new Snapshot()
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withProcessingStartedDate(new Date())
+      .withStatus(Snapshot.Status.COMMITTED);
+    RecordsModifierOperator modifier = collection -> {
+      collection.getRecords().forEach(r -> {
+        String newRecordId = UUID.randomUUID().toString();
+        r.setId(newRecordId);
+        r.setSnapshotId(updateSnapshot.getJobExecutionId());
+        r.getRawRecord().setId(newRecordId);
+        r.getParsedRecord().setId(newRecordId);
+        r.getParsedRecord().setContent(modifiedContent);
+      });
+      return collection;
+    };
+
+    Future<RecordsBatchResponse> future = SnapshotDaoUtil
+      .save(postgresClientFactory.getQueryExecutor(TENANT_ID), committedSnapshot)
+      .compose(v -> recordDao.saveRecord(seedRecord, okapiHeaders))
+      .compose(v -> {
+        // Fixture setUp and the seed record create three records via saveRecord() which trigger
+        // publishRecordCreated(); reset the counters so the verifications below only observe
+        // the interactions caused by the method under test.
+        clearInvocations(recordDomainEventPublisher);
+        return SnapshotDaoUtil.save(postgresClientFactory.getQueryExecutor(TENANT_ID), updateSnapshot);
+      })
+      .compose(v -> recordDao.saveRecordsByExternalIds(List.of(seedExternalId), RecordType.MARC_BIB, modifier, okapiHeaders));
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(1, ar.result().getTotalRecords());
+
+      ArgumentCaptor<Record> oldCaptor = ArgumentCaptor.forClass(Record.class);
+      ArgumentCaptor<Record> newCaptor = ArgumentCaptor.forClass(Record.class);
+      verify(recordDomainEventPublisher, times(1))
+        .publishRecordUpdated(oldCaptor.capture(), newCaptor.capture(), eq(okapiHeaders));
+      verify(recordDomainEventPublisher, never()).publishRecordCreated(any(), any());
+
+      Record capturedOld = oldCaptor.getValue();
+      Record capturedNew = newCaptor.getValue();
+      // Deep-clone contract: the "old" record must carry the pre-modification content
+      // even though the modifier has already mutated the shared record instance in-place.
+      String oldContent = capturedOld.getParsedRecord().getContent().toString();
+      String newContent = capturedNew.getParsedRecord().getContent().toString();
+      context.assertTrue(oldContent.contains(originalMarker));
+      context.assertFalse(oldContent.contains(modifiedMarker));
+      context.assertTrue(newContent.contains(modifiedMarker));
+      context.assertFalse(newContent.contains(originalMarker));
+      context.assertEquals(seedRecordId, capturedOld.getId());
+      context.assertNotEquals(capturedOld.getId(), capturedNew.getId());
+      context.assertEquals(seedRecord.getMatchedId(), capturedOld.getMatchedId());
+      context.assertEquals(seedRecord.getMatchedId(), capturedNew.getMatchedId());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldReturnEmptyResponseAndNotPublishEventsWhenNoRecordsFoundByExternalIds(TestContext context) {
+    clearInvocations(recordDomainEventPublisher);
+    Async async = context.async();
+    String unknownExternalId = UUID.randomUUID().toString();
+    RecordsModifierOperator modifier = collection -> collection;
+
+    Future<RecordsBatchResponse> future = recordDao.saveRecordsByExternalIds(
+      List.of(unknownExternalId), RecordType.MARC_BIB, modifier, okapiHeaders);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(0, ar.result().getTotalRecords());
+      verify(recordDomainEventPublisher, never()).publishRecordUpdated(any(), any(), any());
+      verify(recordDomainEventPublisher, never()).publishRecordCreated(any(), any());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldSkipDeletedRecordsWhenSavingByExternalIds(TestContext context) {
+    clearInvocations(recordDomainEventPublisher);
+    Async async = context.async();
+    RecordsModifierOperator modifier = collection -> collection;
+
+    String deletedExternalId = deletedRecord.getExternalIdsHolder().getInstanceId();
+    Future<RecordsBatchResponse> future = recordDao.saveRecordsByExternalIds(
+      List.of(deletedExternalId), RecordType.MARC_BIB, modifier, okapiHeaders);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertEquals(0, ar.result().getTotalRecords());
+      verify(recordDomainEventPublisher, never()).publishRecordUpdated(any(), any(), any());
+      verify(recordDomainEventPublisher, never()).publishRecordCreated(any(), any());
+      async.complete();
+    });
+  }
 }


### PR DESCRIPTION
## Purpose
Update of Linked MARC bibliographic field triggered by MARC authority update is not tracked by Audit log.

## Approach
The message type for the audit has been changed from “CREATED” to “UPDATED”

## Learn
[MODAUD-247](https://folio-org.atlassian.net/browse/MODAUD-247)