### PR TITLE
MODSOURMAN-1421: Populate deleted MARC Authority entity in event payload

### DIFF
--- a/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractDeleteEventHandler.java
+++ b/mod-source-record-storage-server/src/main/java/org/folio/services/handlers/actions/AbstractDeleteEventHandler.java
@@ -31,7 +31,9 @@ import static org.folio.services.util.EventHandlingUtil.toOkapiHeaders;
  * 1. Validates the event payload
  * 2. Retrieves a matched record from the context
  * 3. Updates the existing record with 'deleted' = true
- * 4. If successfully updated - removes a matched record form event payload,
+ * 4. If successfully updated - moves a matched record in the event payload from the
+ * 'MATCHED_' key to the 'DELETED_' one, so that later handlers do not mistake it for a
+ * record that still exists while data import logs can still report what was removed,
  * and puts external record id to event payload,
  * else completes exceptionally and loggs a cause
  */
@@ -81,7 +83,7 @@ public abstract class AbstractDeleteEventHandler implements EventHandler {
       })
       .onSuccess(ar -> {
         payload.setEventType(getNextEventType());
-        payload.getContext().remove(getRecordKey());
+        payload.getContext().put(getDeletedRecordKey(), payload.getContext().remove(getRecordKey()));
         payload.getContext().put(getExternalRecordIdKey(), getExternalRecordId(payloadRecord.getExternalIdsHolder()));
         future.complete(payload);
       })
@@ -100,6 +102,11 @@ public abstract class AbstractDeleteEventHandler implements EventHandler {
   /* Returns the string key under which a matched record put into event payload context */
   private String getRecordKey() {
     return "MATCHED_" + typeConnection.getMarcType();
+  }
+
+  /* Returns the string key under which the removed record is kept */
+  private String getDeletedRecordKey() {
+    return "DELETED_" + typeConnection.getMarcType();
   }
 
   /* Returns the string key under which an id of external record put into event payload context */

--- a/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityDeleteEventHandlerTest.java
+++ b/mod-source-record-storage-server/src/test/java/org/folio/services/MarcAuthorityDeleteEventHandlerTest.java
@@ -115,6 +115,9 @@ public class MarcAuthorityDeleteEventHandlerTest extends AbstractLBServiceTest {
           context.assertNull(throwable);
           context.assertEquals(DI_SRS_MARC_AUTHORITY_RECORD_DELETED.value(), eventPayload.getEventType());
           context.assertNull(eventPayload.getContext().get("MATCHED_MARC_AUTHORITY"));
+          var deletedRecordJson = eventPayload.getContext().get("DELETED_MARC_AUTHORITY");
+          context.assertNotNull(deletedRecordJson);
+          context.assertEquals(record.getMatchedId(), Json.decodeValue(deletedRecordJson, Record.class).getMatchedId());
           context.assertEquals(record.getExternalIdsHolder().getAuthorityId(), eventPayload.getContext().get("AUTHORITY_RECORD_ID"));
           recordService.getRecordById(record.getId(), TENANT_ID)
             .onComplete(optionalDeletedRecordAr -> {


### PR DESCRIPTION
### Purpose
Data Import logs should report the title of deleted record

### Approach
Move a matched record in the event payload from the 'MATCHED_' key to the 'DELETED_' one, so that later handlers do not mistake it for a record that still exists while data import logs can still report what was removed

### Related Issues
https://folio-org.atlassian.net/browse/MODSOURMAN-1421
